### PR TITLE
fix: fixes #97, normalize path when checking subpath

### DIFF
--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -258,7 +258,7 @@ M.reveal_current_file = function(source_name)
   if cwd == nil then
     cwd = vim.fn.getcwd()
   end
-  if string.sub(path, 1, string.len(cwd)) ~= cwd then
+  if not utils.is_subpath(cwd, path) then
     cwd, _ = utils.split_path(path)
     inputs.confirm("File not in cwd. Change cwd to " .. cwd .. "?", function(response)
       if response == true then

--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -274,6 +274,27 @@ if M.is_windows == true then
   M.path_separator = "\\"
 end
 
+---Normalize a path, to avoid errors when comparing paths.
+---@param path string The path to be normalize.
+---@return string string The normalized path.
+M.normalize_path = function(path)
+  if M.is_windows then
+    -- normalize the drive letter to uppercase
+    path = path:sub(1, 1):upper() .. path:sub(2)
+  end
+  return path
+end
+
+---Check if a path is a subpath of another.
+--@param base string The base path.
+--@param path string The path to check is a subpath.
+--@return boolean boolean True if it is a subpath, false otherwise.
+M.is_subpath = function(base, path)
+  base = M.normalize_path(base)
+  path = M.normalize_path(path)
+  return string.sub(path, 1, string.len(base)) == base
+end
+
 ---Split string into a table of strings using a separator.
 ---@param inputString string The string to split.
 ---@param sep string The separator to use.


### PR DESCRIPTION
Fixes #97.

Add `normalize_path` and `is_subpath` to utils.lua, and use then when checking if file is in the cwd. Currently `normalize_path` only uppercase the drive letter in Windows.