### PR TITLE
feat(tests): Add baseline testing using Plenary's Busted hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: test
+test:
+	nvim --headless --noplugin -u tests/mininit.lua -c "PlenaryBustedDirectory tests/neo-tree/ { minimal_init = 'tests/mininit.lua' }"
+
+.PHONY: format
+format:
+	stylua ./lua ./tests

--- a/tests/helpers/util.lua
+++ b/tests/helpers/util.lua
@@ -1,0 +1,75 @@
+local utils = {}
+
+local Path = require("plenary.path")
+local testdir = Path:new(vim.env.TMPDIR or "/tmp", "neo-tree-testing"):absolute()
+
+local function rm_test_dir()
+  if vim.fn.isdirectory(testdir) == 1 then
+    vim.fn.delete(testdir, "rf")
+  end
+end
+
+utils.setup_test_fs = function()
+  rm_test_dir()
+
+  -- Need a list-style map here to ensure that things happen in the correct order.
+  --
+  -- When/if editing this, be cautious as (for now) other tests might be accessing
+  -- files from within this array by index
+  local fs = {
+    basedir = testdir,
+    content = {
+      {
+        name = "foo",
+        type = "dir",
+        content = {
+          { name = "foofile1.txt", type = "file" },
+          { name = "foofile2.txt", type = "file" },
+        },
+      },
+      { name = "bar", type = "dir" },
+      { name = "topfile1.txt", type = "file" },
+    },
+  }
+  local function makefs(content, basedir)
+    for _, info in ipairs(content) do
+      if info.type == "dir" then
+        info.abspath = Path:new(basedir, info.name):absolute()
+        vim.fn.mkdir(info.abspath, "p")
+        if info.content then
+          makefs(info.content, info.abspath)
+        end
+      elseif info.type == "file" then
+        info.abspath = Path:new(basedir, info.name):absolute()
+        vim.fn.writefile({}, info.abspath)
+      end
+    end
+  end
+  makefs(fs.content, testdir)
+  vim.cmd("tcd " .. testdir)
+  return fs
+end
+
+utils.teardown_test_fs = function()
+  rm_test_dir()
+end
+
+utils.clear_test_state = function()
+  -- TODO: Clear internal state?
+  vim.cmd("top new | wincmd o")
+  local keepbufnr = vim.api.nvim_get_current_buf()
+  for _, bufnr in ipairs(vim.api.nvim_list_bufs()) do
+    if bufnr ~= keepbufnr then
+      vim.api.nvim_buf_delete(bufnr, { force = true })
+    end
+  end
+  assert(#vim.api.nvim_tabpage_list_wins(0) == 1, "Failed to properly clear tab")
+  assert(#vim.api.nvim_list_bufs() == 1, "Failed to properly clear buffers")
+end
+
+utils.editfile = function(testfile)
+  vim.cmd("e " .. testfile)
+  assert.are.same(vim.fn.fnamemodify(vim.api.nvim_buf_get_name(0), ":p"), vim.fn.fnamemodify(testfile, ":p"))
+end
+
+return utils

--- a/tests/helpers/verify.lua
+++ b/tests/helpers/verify.lua
@@ -1,0 +1,49 @@
+local verify = {}
+
+verify.eventually = function(timeout, assertfunc, failmsg, ...)
+  local success, args = false, { ... }
+  vim.wait(timeout or 1000, function()
+    success = assertfunc(unpack(args))
+    return success
+  end)
+  assert(success, failmsg)
+end
+
+verify.after = function(timeout, assertfunc, failmsg)
+  vim.wait(timeout, function()
+    return false
+  end)
+  assert(assertfunc(), failmsg)
+end
+
+verify.bufnr_is_not = function(start_bufnr, timeout)
+  verify.eventually(timeout or 500, function()
+    return start_bufnr ~= vim.api.nvim_get_current_buf()
+  end, string.format("Current buffer is '%s' when expected to not be", start_bufnr))
+end
+
+verify.tree_focused = function(timeout)
+  verify.eventually(timeout or 1000, function()
+    return vim.api.nvim_buf_get_option(0, "filetype") == "neo-tree"
+  end, "Current buffer is not a 'neo-tree' filetype")
+end
+
+verify.tree_node_is = function(expected_node_id, timeout)
+  verify.eventually(timeout or 500, function()
+    local state = require("neo-tree.sources.manager").get_state("filesystem")
+    local node = state.tree:get_node()
+    if not node then
+      return false
+    end
+    local node_id = node:get_id()
+    if node_id ~= expected_node_id then
+      return false
+    end
+    if state.position.node_id ~= expected_node_id then
+      return false
+    end
+    return true
+  end, string.format("Tree node '%s' not focused", expected_node_id))
+end
+
+return verify

--- a/tests/mininit.lua
+++ b/tests/mininit.lua
@@ -1,0 +1,24 @@
+-- Need the absolute path as when doing the testing we will issue things like `tcd` to change directory
+-- to where our temporary filesystem lives
+vim.opt.rtp = {
+  vim.fn.fnamemodify(vim.trim(vim.fn.system("git rev-parse --show-toplevel")), ":p"),
+  vim.env.VIMRUNTIME,
+}
+
+vim.cmd([[
+  packadd plenary.nvim
+  packadd nui.nvim
+]])
+
+require("neo-tree").setup()
+
+vim.opt.swapfile = false
+
+vim.cmd([[
+  runtime plugin/neo-tree.vim
+]])
+
+-- For debugging
+P = function(...)
+  print(unpack(vim.tbl_map(vim.inspect, { ... })))
+end


### PR DESCRIPTION
@cseickel I split this out from the work I am doing on other branches as it seems to be in a relatively good state, and it would be beneficial to have sooner rather than later.

As an overview of what is here:

- Top level `Makefile` so you can just simply `make test` and run them as you please (also `make format` to run  `stylua`)
- Utility function(s) to setup/teardown a "test filesystem" to do whatever you want in
- Verification functions that help with the fact that a lot of the functions in `neo-tree` are async, so by default if we do something like `vim.cmd("NeoTreeFocus")` and then try to verify stuff, the verification is almost always going to fail as it happens too soon.

To show what this ends up looking like:

```lua
local util = require("tests.helpers.util")
local verify = require("tests.helpers.verify")

describe("Filesystem source command", function()
  local fs = util.setup_test_fs()

  after_each(function()
    util.clear_test_state()
  end)

  it("should reveal the current file in the tree", function()
    local testfile = fs.content[3].abspath
    util.editfile(testfile)

    local start_bufnr = vim.api.nvim_get_current_buf()

    vim.cmd("NeoTree filesystem action=reveal")
    verify.bufnr_is_not(start_bufnr)
    verify.tree_focused()
    verify.tree_node_is(testfile)
  end)

  it("should toggle the reveal-state of the tree", function()
    local testfile = fs.content[3].abspath
    util.editfile(testfile)

    local start_bufnr = vim.api.nvim_get_current_buf()

    vim.cmd("NeoTree filesystem action=reveal toggle=true")
    verify.bufnr_is_not(start_bufnr)
    verify.tree_focused()
    verify.tree_node_is(testfile)

    -- Wait long enough such that the tree _should have_ closed, then assert it is not focused anymore
    vim.cmd("NeoTree filesystem action=reveal toggle=true")
    verify.after(250, function()
      return #vim.api.nvim_tabpage_list_wins(0) == 1 and start_bufnr == vim.api.nvim_get_current_buf()
    end, "Failed to toggle the tree to a closed state with 'action=reveal'")
  end)
  
  util.teardown_test_fs()
end)
```

A few things to note:

- One thing right now is that the teardown stuff will only make sure that all buffers are wiped, but I am not sure that really is enough "cleanup" to ensure state from one test does not effect another. For example, the `state.position` metadata is not wiped. It is pretty easy to just wipe that from existence (the entire `state` object) however I'm not entirely sure what else might need to happen along with that. E.g. bad callbacks, leftover autocommands, etc. so wanted to get your opinion first before going to deep on that. It might be best to just expose a method for testing that "resets" all state (rather than wiping it completely) that any new functionality would need to abide by (meaning providing a way to be reset).
- There is no way to modify the current user configuration, as we only load `neo-tree` once in the `mininit.lua`, we could likely want a way to modify the configuration between different tests. Not sure how much of an effort this is at the moment.
- There are no actual examples of the tests here (other than the one above), so if you want I can push up my _super WIP_ examples that use them from #61 I am more than happy to. That branch also has some more unit-style tests as well, while the example above is more functional.
- I have zero clue about _Github_ actions, but you can definitely setup an action to ensure tests pass for merge requests.

This would be the first step towards #77 
