### PR TITLE
fix(files): set tree root correctly when revealing in split

### DIFF
--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -409,7 +409,7 @@ M.reveal_in_split = function(source_name, callback)
     cwd = M.get_cwd(state)
   end
   if cwd and not utils.is_subpath(cwd, path_to_reveal) then
-    state.path = utils.split_path(path_to_reveal)[1]
+    state.path, _ = utils.split_path(path_to_reveal)
   end
   M.navigate(state, state.path, path_to_reveal, callback)
 end


### PR DESCRIPTION
When using `:NeoTreeRevealInSplit`, the tree's root never changes from the working directory. This PR fixes that. I would have thought that `utils.split_path(path_to_reveal)[1]` would get the first out of the two things returned by `split_path` (like when you return tuples in Python), but it's actually indexing the first string returned instead (which returns `nil`).