### PR TITLE
fix: handle reveal_force_cwd correctly when cwd doesn't need to change

### DIFF
--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -175,12 +175,10 @@ handle_reveal = function(args, state)
   if cwd == nil then
     cwd = manager.get_cwd(state)
   end
-  if args.reveal_force_cwd then
-    if not utils.is_subpath(cwd, path) then
-      args.dir, _ = utils.split_path(path)
-      do_show_or_focus(args, state, true)
-      return
-    end
+  if args.reveal_force_cwd and not utils.is_subpath(cwd, path) then
+    args.dir, _ = utils.split_path(path)
+    do_show_or_focus(args, state, true)
+    return
   elseif not utils.is_subpath(cwd, path) then
     -- force was not specified, so we need to ask the user
     cwd, _ = utils.split_path(path)

--- a/tests/helpers/util.lua
+++ b/tests/helpers/util.lua
@@ -1,7 +1,12 @@
 local utils = {}
 
 local Path = require("plenary.path")
-local testdir = Path:new(vim.env.TMPDIR or "/tmp", "neo-tree-testing"):absolute()
+-- Resolve for two reasons.
+-- 1. Follow any symlinks which make comparing paths fail. (on macOS, TMPDIR can be under /var which is symlinked to
+--    /private/var)
+-- 2. Remove any double separators (on macOS TMPDIR can end in a trailing / which absolute doesn't remove, this should
+--    be coverted by https://github.com/nvim-lua/plenary.nvim/issues/330).
+local testdir = vim.fn.resolve(Path:new(vim.env.TMPDIR or "/tmp", "neo-tree-testing"):absolute())
 
 local function rm_test_dir()
   if vim.fn.isdirectory(testdir) == 1 then

--- a/tests/neo-tree/command/command_current_spec.lua
+++ b/tests/neo-tree/command/command_current_spec.lua
@@ -1,3 +1,4 @@
+local Path = require('plenary.path')
 local util = require("tests.helpers.util")
 local verify = require("tests.helpers.verify")
 local config = require("neo-tree").config
@@ -50,11 +51,17 @@ describe("Command", function()
       verify.buf_name_is(testfile)
     end)
 
-    it("`:Neotree current reveal_force_cwd reveal_file=xyz` should reveal file current window", function()
+    it("`:Neotree current reveal_force_cwd reveal_file=xyz` should reveal file current window if cwd is not a parent of file", function()
       vim.cmd("cd ~")
-      vim.cmd("tcd ~")
-      vim.cmd("lcd ~")
       local testfile = fs.lookup["deepfile2"].abspath
+      local cmd = "Neotree current reveal_force_cwd reveal_file=" .. testfile
+      run_in_current_command(cmd, testfile)
+    end)
+
+    it("`:Neotree current reveal_force_cwd reveal_file=xyz` should reveal file current window if cwd is a parent of file", function()
+      local testfile = fs.lookup["deepfile2"].abspath
+      local testfile_dir = Path:new(testfile):parent().filename
+      vim.cmd(string.format("cd %s", testfile_dir))
       local cmd = "Neotree current reveal_force_cwd reveal_file=" .. testfile
       run_in_current_command(cmd, testfile)
     end)


### PR DESCRIPTION
This PR fixes a bug where the tree will not open if `reveal_force_cwd` is given but the cwd doesn't need to change. i.e. the cwd is already a parent of the file being revealed. As you can see from the changes, the bug was just caused by an if branch being taken and then not doing anything.

I've added a unit test for this case and also tested manually.