### PR TITLE
feat: support variable `last_indent_marker` width

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ This is open for debate, but here is the current style choices being observed:
 - BUT we don't currently have any OOP parts and I don't think we want any
 
 I prefer `local name = function()` over `local function name()`, just to be
-consistant with the `M.name = function()` exports.
+consistent with the `M.name = function()` exports.
 
 ### StyLua
 
@@ -51,7 +51,7 @@ current strategy is to maintain:
   in comments
 - The README contains "back of the box" high level overview of features. It is
   meant for people trying to decide if they want to install this plugin or not.
-  It should include refrences to the help file for more information: 
+  It should include references to the help file for more information: 
   `:h neo-tree-setup`
 - The vim help file [doc/neo-tree.txt](doc/neo-tree.txt) is the definitive
   reference and should contain all information needed to configure and use the

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -324,6 +324,7 @@ M.indent = function(config, node, state)
           highlight = expander_highlight
         elseif node.is_last_child then
           char = last_indent_marker
+          spaces_count = spaces_count - (vim.api.nvim_strwidth(last_indent_marker) - 1)
         end
       end
     end


### PR DESCRIPTION
With this, `last_indent_marker` can be more than one display cell wide. The difference is subtracted from the indent level.

```lua
indent = {
    indent_size = 4,
    last_indent_marker = "└──",
},
```
![Screen Capture_select-area_20220328174218](https://user-images.githubusercontent.com/12900252/160367047-0839a44f-0785-49a1-9860-962983993d2c.png)

(I also fixed some typos, I can make a different PR for this if you want)