### PR TITLE
feat: support git base

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ What to show. Can be one of:
 |--------|-------------|
 | filesystem | Show a file browser. DEFAULT |
 | buffers    | Show a list of currently open buffers. |
-| git_status | Show the ouput of `git status` in a tree layout. |
+| git_status | Show the output of `git status` in a tree layout. |
 
 #### `position`
 Where to show it, can be one of:
@@ -311,6 +311,22 @@ current file. For example:
 :Neotree /home/user/relative/path
 :Neotree dir=/home/user/relative/path
 :Neotree position=current dir=relative/path
+```
+
+#### `git_base`
+The base that is used to calculate the git status for each dir/file.
+By default it uses `HEAD`, so it shows all changes that are not yet committed.
+You can for example work on a feature branch, and set it to `main`. It will
+show all changes that happened on the feature branch and main since you 
+branched off.
+
+Any git ref, commit, tag, or sha will work.
+
+```
+:Neotree main
+:Neotree v1.0
+:Neotree git_base=8fe34be
+:Neotree git_base=HEAD
 ```
 
 #### `reveal`
@@ -367,7 +383,7 @@ that would open a directory will open neo-tree in the specified window.
 
 Neo-tree is built on the idea of supporting various sources. Sources are
 basically interface implementations whose job it is to provide a list of
-hierachical items to be rendered, along with commands that are appropriate to
+hierarchical items to be rendered, along with commands that are appropriate to
 those items.
 
 ### filesystem
@@ -401,10 +417,17 @@ filesystem is open in a sidebar:
 
 ![Neo-tree git_status](https://github.com/nvim-neo-tree/resources/raw/main/images/Neo-tree-git_status.png)
 
+You can specify a different git base here as well. But be aware that it is not
+possible to unstage / revert a file that is already committed.
+
+```
+:Neotree float git_status git_base=main
+```
+
 
 ## Configuration and Customization
 
-This is designed to be flexible. The way that is acheived is by making
+This is designed to be flexible. The way that is achieved is by making
 everything a function, or a string that identifies a built-in function. All of the
 built-in functions can be replaced with your own implementation, or you can 
 add new ones.

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -95,6 +95,15 @@ don't need the full dir=/path. You may use any value that can be passed to the
 'expand' function, such as `%:p:h:h` to specify two directories up from the
 current file.
 
+git_base~
+The base that is used to calculate the git status for each dir/file.
+By default it uses `HEAD`, so it shows all changes that are not yet committed.
+You can for example work on a feature branch, and set it to `main`. It will
+show all changes that happened on the feature branch and main since you 
+branched off.
+
+Any git ref, commit, tag, or sha will work.
+
 reveal~
 This is a boolean flag. Adding this will make Neotree automatically find and 
 focus the current file when it opens.

--- a/lua/neo-tree/sources/buffers/init.lua
+++ b/lua/neo-tree/sources/buffers/init.lua
@@ -80,7 +80,7 @@ M.setup = function(config, global_config)
       handler = function(state)
         local this_state = get_state()
         if state == this_state then
-          state.git_status_lookup = git.status()
+          state.git_status_lookup = git.status(state.git_base)
         end
       end,
     })

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -13,7 +13,7 @@
 local highlights = require("neo-tree.ui.highlights")
 local utils = require("neo-tree.utils")
 local file_nesting = require("neo-tree.sources.common.file-nesting")
-local container    = require("neo-tree.sources.common.container")
+local container = require("neo-tree.sources.common.container")
 local log = require("neo-tree.log")
 
 local M = {}
@@ -123,12 +123,12 @@ M.git_status = function(config, node, state)
   local symbols = config.symbols or {}
   local change_symbol
   local change_highlt = highlights.FILE_NAME
-  local status_symbol = symbols.unstaged
-  local status_highlt = highlights.GIT_CONFLICT
+  local status_symbol = symbols.staged
+  local status_highlt = highlights.GIT_ADDED
 
-  if git_status:sub(2, 2) == " " then
-    status_symbol = symbols.staged
-    status_highlt = highlights.GIT_ADDED
+  if git_status:sub(1, 1) == " " then
+    status_symbol = symbols.unstaged
+    status_highlt = highlights.GIT_CONFLICT
   end
 
   if git_status:match("?$") then

--- a/lua/neo-tree/sources/git_status/lib/items.lua
+++ b/lua/neo-tree/sources/git_status/lib/items.lua
@@ -1,7 +1,6 @@
 local vim = vim
 local renderer = require("neo-tree.ui.renderer")
 local file_items = require("neo-tree.sources.common.file-items")
-local popups = require("neo-tree.ui.popups")
 local log = require("neo-tree.log")
 local git = require("neo-tree.git")
 
@@ -14,7 +13,7 @@ M.get_git_status = function(state)
     return
   end
   state.loading = true
-  local status_lookup, project_root = git.status(true)
+  local status_lookup, project_root = git.status(state.git_base, true)
   state.path = project_root or state.path or vim.fn.getcwd()
   local context = file_items.create_context(state)
   -- Create root folder

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -41,6 +41,7 @@ local function create_state(tabnr, sd, winid)
   state.position = {
     is = { restorable = false },
   }
+  state.git_base = "HEAD"
   return state
 end
 


### PR DESCRIPTION
I'd like to add support for changing the git base.
With the current implementation it just defaults to `HEAD`, but there are cases where it would be nice to see the diff against other bases as well.
For example, when you review a pull request, or you are working on a feature branch and want to compare it against the main branch.

The implementation is not super complex, instead of using `git status . --porcelain=v1`, you use `git -C . diff --name-status HEAD --` where `HEAD` can be any commit/branch.
You get the same information, but the formatting of the output is a little bit different.

This is just a hacky PoC, so you can try with setting `vim.g.git_base` to different values. I wanted to ask if you are okay with this, before I make a proper PR.

Also `vim.g.git_base` needs to be handled correctly.