### PR TITLE
fix: missing signcolumn highlight group

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -758,6 +758,7 @@ NeoTreeIndentMarker       The style of indentation markers (guides). By default,
 NeoTreeExpander           Used for collapsed/expanded icons.
 NeoTreeNormal             |hl-Normal| override in Neo-tree window.
 NeoTreeNormalNC           |hi-NormalNC| override in Neo-tree window.
+NeoTreeSignColumn         |hl-SignColumn| override in Neo-tree window.
 NeoTreeStatusLine         |hl-StatusLine| override in Neo-tree window.
 NeoTreeStatusLineNC       |hl-StatusLineNC| override in Neo-tree window.
 NeoTreeVertSplit          |hl-VertSplit| override in Neo-tree window.

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -731,7 +731,7 @@ these yourself before the plugin loads, it will not be touched. If they do not
 exist, they will be created.
 
 NeoTreeBufferNumber       The buffer number shown in the buffers source.
-NeoTreeCursorLine         |hi-CursorLine| override in Neo-tree window.
+NeoTreeCursorLine         |hl-CursorLine| override in Neo-tree window.
 NeoTreeDimText            Greyed out text used in various places.
 NeoTreeDirectoryIcon      Directory icon.
 NeoTreeDirectoryName      Directory name.
@@ -757,7 +757,7 @@ NeoTreeIndentMarker       The style of indentation markers (guides). By default,
                           the "Normal" highlight is used.
 NeoTreeExpander           Used for collapsed/expanded icons.
 NeoTreeNormal             |hl-Normal| override in Neo-tree window.
-NeoTreeNormalNC           |hi-NormalNC| override in Neo-tree window.
+NeoTreeNormalNC           |hl-NormalNC| override in Neo-tree window.
 NeoTreeSignColumn         |hl-SignColumn| override in Neo-tree window.
 NeoTreeStatusLine         |hl-StatusLine| override in Neo-tree window.
 NeoTreeStatusLineNC       |hl-StatusLineNC| override in Neo-tree window.

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -49,7 +49,11 @@ local define_events = function()
     return args
   end)
 
-  events.define_autocmd_event(events.VIM_BUFFER_CHANGED, { "BufWritePost", "BufFilePost", "BufModifiedSet" }, 200)
+  events.define_autocmd_event(
+    events.VIM_BUFFER_CHANGED,
+    { "BufWritePost", "BufFilePost", "BufModifiedSet" },
+    200
+  )
   events.define_autocmd_event(events.VIM_BUFFER_MODIFIED_SET, { "BufModifiedSet" }, 0)
   events.define_autocmd_event(events.VIM_BUFFER_ADDED, { "BufAdd" }, 200)
   events.define_autocmd_event(events.VIM_BUFFER_DELETED, { "BufDelete" }, 200)
@@ -69,7 +73,7 @@ M.buffer_enter_event = function()
     vim.cmd([[
     setlocal cursorline
     setlocal nowrap
-    setlocal winhighlight=Normal:NeoTreeNormal,NormalNC:NeoTreeNormalNC,CursorLine:NeoTreeCursorLine,FloatBorder:NeoTreeFloatBorder,StatusLine:NeoTreeStatusLine,StatusLineNC:NeoTreeStatusLineNC,VertSplit:NeoTreeVertSplit,EndOfBuffer:NeoTreeEndOfBuffer
+    setlocal winhighlight=Normal:NeoTreeNormal,NormalNC:NeoTreeNormalNC,SignColumn:NeoTreeSignColumn,CursorLine:NeoTreeCursorLine,FloatBorder:NeoTreeFloatBorder,StatusLine:NeoTreeStatusLine,StatusLineNC:NeoTreeStatusLineNC,VertSplit:NeoTreeVertSplit,EndOfBuffer:NeoTreeEndOfBuffer
     setlocal nolist nospell nonumber norelativenumber
     ]])
     events.fire_event(events.NEO_TREE_BUFFER_ENTER)

--- a/lua/neo-tree/ui/highlights.lua
+++ b/lua/neo-tree/ui/highlights.lua
@@ -29,6 +29,7 @@ M.INDENT_MARKER = "NeoTreeIndentMarker"
 M.MODIFIED = "NeoTreeModified"
 M.NORMAL = "NeoTreeNormal"
 M.NORMALNC = "NeoTreeNormalNC"
+M.SIGNCOLUMN = "NeoTreeSignColumn"
 M.STATUS_LINE = "NeoTreeStatusLine"
 M.STATUS_LINE_NC = "NeoTreeStatusLineNC"
 M.VERTSPLIT = "NeoTreeVertSplit"
@@ -104,7 +105,7 @@ local function create_highlight_group(hl_group_name, link_to_if_exists, backgrou
 end
 
 local faded_highlight_group_cache = {}
-M.get_faded_highlight_group = function (hl_group_name, fade_percentage)
+M.get_faded_highlight_group = function(hl_group_name, fade_percentage)
   if type(hl_group_name) ~= "string" then
     error("hl_group_name must be a string")
   end
@@ -177,7 +178,12 @@ M.get_faded_highlight_group = function (hl_group_name, fade_percentage)
   local green = (f_green * fade_percentage) + (b_green * (1 - fade_percentage))
   local blue = (f_blue * fade_percentage) + (b_blue * (1 - fade_percentage))
 
-  local new_foreground = string.format("%s%s%s", dec_to_hex(red, 2), dec_to_hex(green, 2), dec_to_hex(blue, 2))
+  local new_foreground = string.format(
+    "%s%s%s",
+    dec_to_hex(red, 2),
+    dec_to_hex(green, 2),
+    dec_to_hex(blue, 2)
+  )
 
   create_highlight_group(key, {}, hl_group.background, new_foreground, gui)
   faded_highlight_group_cache[key] = key
@@ -187,6 +193,8 @@ end
 M.setup = function()
   local normal_hl = create_highlight_group(M.NORMAL, { "Normal" })
   local normalnc_hl = create_highlight_group(M.NORMALNC, { "NormalNC", M.NORMAL })
+
+  create_highlight_group(M.SIGNCOLUMN, { "SignColumn", M.NORMAL })
 
   create_highlight_group(M.STATUS_LINE, { "StatusLine" })
   create_highlight_group(M.STATUS_LINE_NC, { "StatusLineNC" })
@@ -237,6 +245,5 @@ M.setup = function()
   create_highlight_group(M.GIT_RENAMED, { M.GIT_MODIFIED }, nil, nil)
   create_highlight_group(M.GIT_UNTRACKED, {}, nil, conflict.foreground, "italic")
 end
-
 
 return M


### PR DESCRIPTION
Hi! recently I found one missing part while customizing the theme of the neo-tree.

![neotree](https://user-images.githubusercontent.com/32578710/163210876-55fd4971-ffc7-48f3-8c68-9aff89c140e7.png)

Like the picture above, The background color of the neo-tree can be changed using `NeoTreeNormal`. And this overrides `Normal`.
However, because there were no highlight groups defined in the neo-tree for `SignColumn`, `NeoTreeNormal` was unable to create a consistent theme.