### PR TITLE
fix: skip git warnings

### DIFF
--- a/lua/neo-tree/git/status.lua
+++ b/lua/neo-tree/git/status.lua
@@ -61,6 +61,9 @@ local parse_git_status_line = function(context, line)
   local exclude_directories = context.exclude_directories
 
   local line_parts = vim.split(line, "	")
+  if #line_parts < 2 then
+    return
+  end
   local status = line_parts[1]
   local relative_path = line_parts[2]
 


### PR DESCRIPTION
I can't use `:Neotree git_status`
![image](https://user-images.githubusercontent.com/70210066/163729693-7246910e-860a-469a-bcf8-d8830acf2e09.png)
The print is the `line_parts` variable