### PR TITLE
Add NeoTreeWinSepartor hl

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -863,7 +863,7 @@ NeoTreeSignColumn         |hl-SignColumn| override in Neo-tree window.
 NeoTreeStatusLine         |hl-StatusLine| override in Neo-tree window.
 NeoTreeStatusLineNC       |hl-StatusLineNC| override in Neo-tree window.
 NeoTreeVertSplit          |hl-VertSplit| override in Neo-tree window.
-NeoTreeWinSeparator       |hl-WinSeparator override in Neo-tree window.
+NeoTreeWinSeparator       |hl-WinSeparator| override in Neo-tree window.
 NeoTreeEndOfBuffer        |hl-EndOfBuffer| override in Neo-tree window.
 NeoTreeRootName           The name of the root node.
 NeoTreeSymbolicLinkTarget Symbolic link target.

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -863,6 +863,7 @@ NeoTreeSignColumn         |hl-SignColumn| override in Neo-tree window.
 NeoTreeStatusLine         |hl-StatusLine| override in Neo-tree window.
 NeoTreeStatusLineNC       |hl-StatusLineNC| override in Neo-tree window.
 NeoTreeVertSplit          |hl-VertSplit| override in Neo-tree window.
+NeoTreeWinSeparator       |hl-WinSeparator override in Neo-tree window.
 NeoTreeEndOfBuffer        |hl-EndOfBuffer| override in Neo-tree window.
 NeoTreeRootName           The name of the root node.
 NeoTreeSymbolicLinkTarget Symbolic link target.

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -74,7 +74,7 @@ M.buffer_enter_event = function()
     vim.cmd([[
     setlocal cursorline
     setlocal nowrap
-    setlocal winhighlight=Normal:NeoTreeNormal,NormalNC:NeoTreeNormalNC,SignColumn:NeoTreeSignColumn,CursorLine:NeoTreeCursorLine,FloatBorder:NeoTreeFloatBorder,StatusLine:NeoTreeStatusLine,StatusLineNC:NeoTreeStatusLineNC,VertSplit:NeoTreeVertSplit,EndOfBuffer:NeoTreeEndOfBuffer
+    setlocal winhighlight=Normal:NeoTreeNormal,NormalNC:NeoTreeNormalNC,SignColumn:NeoTreeSignColumn,CursorLine:NeoTreeCursorLine,FloatBorder:NeoTreeFloatBorder,StatusLine:NeoTreeStatusLine,StatusLineNC:NeoTreeStatusLineNC,VertSplit:NeoTreeVertSplit,WinSeparator:NeoTreeWinSeparator,EndOfBuffer:NeoTreeEndOfBuffer
     setlocal nolist nospell nonumber norelativenumber
     ]])
     events.fire_event(events.NEO_TREE_BUFFER_ENTER)
@@ -297,7 +297,7 @@ local function merge_global_components_config(components, config)
   return merged_components
 end
 
-local merge_renderers = function (default_config, source_default_config, user_config)
+local merge_renderers = function(default_config, source_default_config, user_config)
   -- This can't be a deep copy/merge. If a renderer is specified in the target it completely
   -- replaces the base renderer.
 

--- a/lua/neo-tree/ui/highlights.lua
+++ b/lua/neo-tree/ui/highlights.lua
@@ -34,6 +34,7 @@ M.SIGNCOLUMN = "NeoTreeSignColumn"
 M.STATUS_LINE = "NeoTreeStatusLine"
 M.STATUS_LINE_NC = "NeoTreeStatusLineNC"
 M.VERTSPLIT = "NeoTreeVertSplit"
+M.WINSEPARATOR = "NeoTreeWinSeparator"
 M.END_OF_BUFFER = "NeoTreeEndOfBuffer"
 M.ROOT_NAME = "NeoTreeRootName"
 M.SYMBOLIC_LINK_TARGET = "NeoTreeSymbolicLinkTarget"
@@ -205,6 +206,7 @@ M.setup = function()
   create_highlight_group(M.STATUS_LINE_NC, { "StatusLineNC" })
 
   create_highlight_group(M.VERTSPLIT, { "VertSplit" })
+  create_highlight_group(M.WINSEPARATOR, { "WinSeparator" })
 
   create_highlight_group(M.END_OF_BUFFER, { "EndOfBuffer" })
 


### PR DESCRIPTION
Fix https://github.com/nvim-neo-tree/neo-tree.nvim/issues/328

This PR only adds the `NeoTreeWinSeparator` so that pre 0.7 users can continue using their setup.
In the future, `NeoTreeVertSplit` could be considered for removal? And the local `winhighlight` option would override both `WinSeparator` and `VertSplit` with `NeoTreeWinSeparator`, thus allowing pre 0.7 and post 0.7 users to work