### PR TITLE
Change `git commit` quotes context

### DIFF
--- a/lua/neo-tree/sources/git_status/commands.lua
+++ b/lua/neo-tree/sources/git_status/commands.lua
@@ -46,7 +46,7 @@ M.git_commit = function(state, and_push)
 
   inputs.input("Commit message: ", "", function(msg)
     msg = msg:gsub('"', "'")
-    local cmd = 'git commit -m "' .. msg .. '"'
+    local cmd = 'git commit -m \'' .. msg .. '\''
     local title = "git commit"
     if and_push then
       cmd = cmd .. " && git push"


### PR DESCRIPTION
By using single quotes, commit messages can contain special characters like ` (backtick) without being interpreted.

For example, providing [this is a \`test\`] without brackets results now in [this is a ] instead of [this is a `test`].