### PR TITLE
Fixed problems with shellslash

### DIFF
--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -707,7 +707,10 @@ M.is_expandable = function(node)
 end
 
 M.windowize_path = function(path)
-  return path:gsub("/", "\\")
+  if not vim.o.shellslash then
+    return path:gsub("/", "\\")
+  end
+  return path
 end
 
 M.wrap = function(func, ...)

--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -511,7 +511,13 @@ end
 ---The file system path separator for the current platform.
 M.path_separator = "/"
 M.is_windows = vim.fn.has("win32") == 1 or vim.fn.has("win32unix") == 1
-M.use_shellslash = vim.o.shellslash
+
+local shellslash_exists, _ = pcall(function() local _ = vim.o.shellslash end)
+M.use_shellslash = false
+if shellslash_exists then
+    M.use_shellslash = vim.o.shellslash
+end
+
 if M.is_windows == true and not M.use_shellslash then
   M.path_separator = "\\"
 end

--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -511,7 +511,7 @@ end
 ---The file system path separator for the current platform.
 M.path_separator = "/"
 M.is_windows = vim.fn.has("win32") == 1 or vim.fn.has("win32unix") == 1
-if M.is_windows == true then
+if M.is_windows == true and not vim.o.shellslash then
   M.path_separator = "\\"
 end
 

--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -512,7 +512,7 @@ end
 M.path_separator = "/"
 M.is_windows = vim.fn.has("win32") == 1 or vim.fn.has("win32unix") == 1
 
-local shellslash_exists, _ = pcall(function() local _ = vim.o.shellslash end)
+local shellslash_exists = vim.fn.exists("+shellslash") ~= 0
 M.use_shellslash = false
 if shellslash_exists then
     M.use_shellslash = vim.o.shellslash

--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -511,7 +511,8 @@ end
 ---The file system path separator for the current platform.
 M.path_separator = "/"
 M.is_windows = vim.fn.has("win32") == 1 or vim.fn.has("win32unix") == 1
-if M.is_windows == true and not vim.o.shellslash then
+M.use_shellslash = vim.o.shellslash
+if M.is_windows == true and not M.use_shellslash then
   M.path_separator = "\\"
 end
 
@@ -707,7 +708,7 @@ M.is_expandable = function(node)
 end
 
 M.windowize_path = function(path)
-  if not vim.o.shellslash then
+  if not M.use_shellslash then
     return path:gsub("/", "\\")
   end
   return path


### PR DESCRIPTION
These changes should fix most of the issue about using shellslash on windows. However, maybe it's better to wait for [this PR on plenary](https://github.com/nvim-lua/plenary.nvim/pull/371) to be merged before accepting this. Without the changes on plenary, many things will just not work anyway.