### PR TITLE
Feat: add option to show none/relative/absolute for move and copy (and fix copy to new directory)

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -238,8 +238,8 @@ local config = {
       ["y"] = "copy_to_clipboard",
       ["x"] = "cut_to_clipboard",
       ["p"] = "paste_from_clipboard",
-      ["c"] = "copy", -- takes text input for destination
-      ["m"] = "move", -- takes text input for destination
+      ["c"] = "copy", -- takes text input for destination, also accepts the config.show_path option
+      ["m"] = "move", -- takes text input for destination, also accepts the config.show_path option
       ["q"] = "close_window",
       ["?"] = "show_help",
     },

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -225,9 +225,9 @@ local function get_using_root_directory(state, node)
   -- default to showing only the basename of the path
   local using_root_directory = in_directory
   if state.config.show_path == "absolute" then
-      using_root_directory = ""
+    using_root_directory = ""
   elseif state.config.show_path == "relative" then
-      using_root_directory = state.path
+    using_root_directory = state.path
   end
   return using_root_directory
 end

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -218,15 +218,30 @@ M.paste_from_clipboard = function(state, callback)
   end
 end
 
+---The root_directory is used to decide what part of the filename to show the
+-- user when asking for a new filename to e.g. copy or move to.
+local function get_using_root_directory(state, node)
+  local in_directory, _ = utils.split_path(node:get_id())
+  -- default to showing only the basename of the path
+  local using_root_directory = in_directory
+  if state.config.show_path == "absolute" then
+      using_root_directory = ""
+  elseif state.config.show_path == "relative" then
+      using_root_directory = state.path
+  end
+  return using_root_directory
+end
+
 ---Copies a node to a new location, using typed input.
 ---@param state table The state of the source
 ---@param callback function The callback to call when the command is done. Called with the parent node as the argument.
 M.copy = function(state, callback)
   local node = state.tree:get_node()
+  local using_root_directory = get_using_root_directory(state, node)
   if node.type == "message" then
     return
   end
-  fs_actions.copy_node(node.path, nil, callback)
+  fs_actions.copy_node(node.path, nil, callback, using_root_directory)
 end
 
 ---Moves a node to a new location, using typed input.
@@ -234,10 +249,11 @@ end
 ---@param callback function The callback to call when the command is done. Called with the parent node as the argument.
 M.move = function(state, callback)
   local node = state.tree:get_node()
+  local using_root_directory = get_using_root_directory(state, node)
   if node.type == "message" then
     return
   end
-  fs_actions.move_node(node.path, nil, callback)
+  fs_actions.move_node(node.path, nil, callback, using_root_directory)
 end
 
 M.delete = function(state, callback)

--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -12,7 +12,6 @@ local utils = require("neo-tree.utils")
 local inputs = require("neo-tree.ui.inputs")
 local events = require("neo-tree.events")
 local log = require("neo-tree.log")
-local Path = require("plenary.path")
 
 local M = {}
 
@@ -152,23 +151,19 @@ end
 M.copy_node = function(source, _destination, callback, using_root_directory)
   local _, name = utils.split_path(source)
   get_unused_name(_destination or source, using_root_directory, function(destination)
-    local path = Path:new(source)
-    local success, result = pcall(path.copy, path, {
-      destination = destination,
-      recursive = true,
-      parents = true,
-    })
-
-    if not success then
-      log.error("Could not copy the files from", source, "to", destination, ":", result)
-      return
-    end
+    create_all_parents(destination)
+    loop.fs_copyfile(source, destination, function(err)
+      if err then
+        log.error("Could not copy the files from", source, "to", destination, ":", err)
+        return
+      end
       vim.schedule(function()
         events.fire_event(events.FILE_ADDED, destination)
         if callback then
           callback(source, destination)
         end
       end)
+    end)
   end, 'Copy "' .. name .. '" to:')
 end
 

--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -95,17 +95,22 @@ local function create_all_parents(path)
 end
 
 -- Gets a non-existing filename from the user and executes the callback with it.
-local function get_unused_name(destination, using_root_directory, name_chosen_callback, first_message)
+local function get_unused_name(
+  destination,
+  using_root_directory,
+  name_chosen_callback,
+  first_message
+)
   if loop.fs_stat(destination) then
     local parent_path, name
     if not using_root_directory then
-        parent_path, name = utils.split_path(destination)
+      parent_path, name = utils.split_path(destination)
     elseif #using_root_directory > 0 then
-        parent_path = destination:sub(1, #using_root_directory)
-        name = destination:sub(#using_root_directory + 2)
+      parent_path = destination:sub(1, #using_root_directory)
+      name = destination:sub(#using_root_directory + 2)
     else
-        parent_path = nil
-        name = destination
+      parent_path = nil
+      name = destination
     end
 
     local message = first_message or name .. " already exists. Please enter a new name: "
@@ -122,7 +127,14 @@ end
 
 -- Move Node
 M.move_node = function(source, destination, callback, using_root_directory)
-  log.trace("Moving node: ", source, " to ", destination, ", using root directory: ", using_root_directory)
+  log.trace(
+    "Moving node: ",
+    source,
+    " to ",
+    destination,
+    ", using root directory: ",
+    using_root_directory
+  )
   local _, name = utils.split_path(source)
   get_unused_name(destination or source, using_root_directory, function(dest)
     create_all_parents(dest)


### PR DESCRIPTION
Hi,

This feature is related to https://github.com/nvim-neo-tree/neo-tree.nvim/issues/114

I added similar to `fs_actions.create_node()` (add node) the option to show "none", "relative" or "absolute" path when moving or copying a node/file. I tried to implement it in a similar way to the add feature, using similar naming conventions.

My motivation for adding this option/feature:
I regularly have to move a file from one subtree to another, which sometimes doesn't exist yet. And showing the path to edit can really help a lot, e.g. I want to move
`/path/dir1/aaa/bbb/ccc/file.cpp`
to 
`/path/dir2/aaa/bbb/ccc/file.cpp`
This feature allows for editing only 1 dir name, any other method to accomplish this task is more work atm, I think.

Fix issue with copy:
Also while doing this, I noticed that the copy didn't work when trying to copy to a non-existing directory. It doesn't give an error message but the file wasn't actually copied. 
e.g. to reproduce the issue:
nvim /tmp/test.txt
:Neotree reveal
copy the node with `c` and enter e.g. `dir/test.txt`
-> no error and `/tmp/dir/test.txt` is not created or copied to.
Plenary's path.copy() was used for this feature, I haven't further investigated into plenary what is up with that. I saw that the move uses vim.loop.fs_rename, so I changed the copy implementation with vim.loop.fs_copyfile in a similar manner, which does seem to work now. Removing this usage means I could remove the require of plenary in that file, as it was only used for that path.copy

Maybe these should be 2 separate pull requests, one for the feature one for the fix? Or anything else..

Note: I use this with `use_popups_for_input = false` which works absolutely great, but if floating windows are used, their size doesn't depend on the content but on the title (afaik), the title is still just the basename and not the full path (maybe this would be better.. though in the non-popup the input line could get very long as it also prints the title there). Anyway when the floating window is small, and the path long, it seems not ideal.