### PR TITLE
Fix boolean expression bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,14 +203,20 @@ use {
                 show_path = "none" -- "none", "relative", "absolute"
               }
             },
-            ["A"] = "add_directory", -- also accepts the config.show_path option.
+            ["A"] = "add_directory", -- also accepts the optional config.show_path option like "add".
             ["d"] = "delete",
             ["r"] = "rename",
             ["y"] = "copy_to_clipboard",
             ["x"] = "cut_to_clipboard",
             ["p"] = "paste_from_clipboard",
-            ["c"] = "copy", -- takes text input for destination, also accepts the config.show_path option
-            ["m"] = "move", -- takes text input for destination, also accepts the config.show_path option
+            ["c"] = "copy", -- takes text input for destination, also accepts the optional config.show_path option like "add":
+            -- ["c"] = {
+            --  "copy",
+            --  config = {
+            --    show_path = "none" -- "none", "relative", "absolute"
+            --  }
+            --}
+            ["m"] = "move", -- takes text input for destination, also accepts the optional config.show_path option like "add".
             ["q"] = "close_window",
             ["R"] = "refresh",
             ["?"] = "show_help",

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -235,6 +235,14 @@ x    = cut_to_clipboard:     Mark file to be cut (moved).
 
 p    = paste_from_clipboard: Copy/move each marked file to the selected folder.
 
+c    = copy:                 Copy the selected file or directory.
+                             Also accepts the optional `config.show_path` option
+                             like the add file action.
+
+m    = move:                 Move the selected file or directory.
+                             Also accepts the optional `config.show_path` option
+                             like the add file action.
+
 
 VIEW CHANGES                                            *neo-tree-view-changes*
 H = toggle_hidden: Toggle whether hidden (filtered items) are shown or not.

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -33,7 +33,7 @@ local function get_using_root_directory(state)
     using_root_directory = ""
   elseif show_path == "relative" then
     using_root_directory = state.path
-  elseif show_path ~= nil or show_path ~= "none" then
+  elseif show_path ~= nil and show_path ~= "none" then
     log.warn("A neo-tree mapping was setup with a config.show_path option with invalid value: \""..show_path.."\", falling back to its default: nil/\"none\"")
   end
   return using_root_directory


### PR DESCRIPTION
1. This PR fixes the issue I introduced wrt the show_path option I mentioned in my previous PR: https://github.com/nvim-neo-tree/neo-tree.nvim/pull/367#issuecomment-1146204360

2. Also tried to improve documentation a little bit, as per comment on the previous PR.

3. And when writing this documentation I realized that my previous change, from plenary Path.copy() to vim.loop.fs_copyfile(), removed the ability to copy a directory (recursively), so I reverted that change back to using Path.copy(), and also did some digging into why it silently failed with my usecase described in the previous PR (copying a file to a non-existing dir):
- The way the Path.copy() error was checked was incomplete, if the call to copy() succeeds, then the result a (potentially nested) table of Path instances as keys with as value the success result for that individual file. Not checking this caused the copy action to not fail even when it did not work for my usecase. I looked at the unittests for Path.copy() and based some extra error checking on how they check the result, so the error introduced by my usecase is now also caught. This explains the silent part.
- Now for the failed part: I found an 'issue' (an unhandled usecase) in plenary Path:copy(): when a source file (and not a directory) is copied, the destination parent dirs are _not_ created (they are when the source is a dir). As a workaround I added the `create_all_parents()` before the call to Path.copy() so the parent dirs are created anyway. So this means that the usecase of copying a file to a non-existing dir now works. (This should probably be reported to Plenary (maybe next weekend :) ))