### PR TITLE
fix: don't close last window

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -88,7 +88,10 @@ M.close = function(state)
           end
           vim.api.nvim_win_set_buf(state.winid, new_buf)
         else
-          vim.api.nvim_win_close(state.winid, true)
+          local win_list = vim.api.nvim_tabpage_list_wins(0)
+          if #win_list > 1 then
+            vim.api.nvim_win_close(state.winid, true)
+          end
         end
       end
     end


### PR DESCRIPTION
when neotree is the only window; `NeoTreeShowToggle` tries to close last window resulting in following error:
```
E5108: Error executing lua .../packer/start/neo-tree.nvim/lua/neo-tree/ui/renderer.lua:92: Vim:E444: Cannot close last window
stack traceback:
        [C]: in function 'nvim_win_close'
        .../packer/start/neo-tree.nvim/lua/neo-tree/ui/renderer.lua:92: in function 'close'
        ...im/site/pack/packer/start/neo-tree.nvim/lua/neo-tree.lua:226: in function 'show'
        [string ":lua"]:1: in main chunk
```