### PR TITLE
Use correct method to check nvim version is >= 0.7

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -100,7 +100,7 @@ M.buffer_enter_event = function()
     ]])
 
     local winhighlight = 'Normal:NeoTreeNormal,NormalNC:NeoTreeNormalNC,SignColumn:NeoTreeSignColumn,CursorLine:NeoTreeCursorLine,FloatBorder:NeoTreeFloatBorder,StatusLine:NeoTreeStatusLine,StatusLineNC:NeoTreeStatusLineNC,VertSplit:NeoTreeVertSplit,EndOfBuffer:NeoTreeEndOfBuffer'
-    if vim.version().major >= 7 then
+    if vim.version().minor >= 7 then
       vim.cmd("setlocal winhighlight=" .. winhighlight .. ',WinSeparator:NeoTreeWinSeparator')
     else
       vim.cmd("setlocal winhighlight=" .. winhighlight)


### PR DESCRIPTION
A recent change added a check that the nvim version is >= 0.7 to use the WinSeparator highlight. The code for the check was
`if vim.version().major >= 7`, but it should use `minor` instead of `major` since '7' is the minor version.