### PR TITLE
fix(ui/renderer.lua): disable colorcolumn by default

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -703,6 +703,9 @@ create_window = function(state)
       filetype = "neo-tree",
       undolevels = -1,
     },
+    win_options = {
+        colorcolumn = "",
+    }
   }
 
   local win


### PR DESCRIPTION
Disable `colorcolumn` by default. Closes #390.