### PR TITLE
feat: disable signcolumn by default

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -705,6 +705,7 @@ create_window = function(state)
     },
     win_options = {
         colorcolumn = "",
+        signcolumn = "no",
     }
   }
 

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -703,9 +703,9 @@ create_window = function(state)
       undolevels = -1,
     },
     win_options = {
-        colorcolumn = "",
-        signcolumn = "no",
-    }
+      colorcolumn = "",
+      signcolumn = "no",
+    },
   }
 
   local win


### PR DESCRIPTION
Hi! I think it would be better if `signcolumn` was disabled by default.

<details>
<summary>Before</summary>

<img width="616" alt="before" src="https://user-images.githubusercontent.com/57654917/178157614-7569a816-91d8-4cda-a609-e5829c80ba7e.png">
</details>

<details>
<summary>After</summary>

<img width="606" alt="after" src="https://user-images.githubusercontent.com/57654917/178157617-7b487b2d-1dd6-4ff4-a25f-e2ffe56d7d5f.png">
</details>