### PR TITLE
feat(commands): Make `"_with_window_picker"` commands also invoke event_handlers

### DIFF
--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -431,11 +431,22 @@ local use_window_picker = function(state, path, cmd)
     )
     return
   end
+  local events = require("neo-tree.events")
+  local event_result = events.fire_event(events.FILE_OPEN_REQUESTED, {
+    state = state,
+    path = path,
+    open_cmd = cmd,
+  }) or {}
+  if event_result.handled then
+    events.fire_event(events.FILE_OPENED, path)
+    return
+  end
   local picked_window_id = picker.pick_window()
   if picked_window_id then
     vim.api.nvim_set_current_win(picked_window_id)
     vim.cmd(cmd .. ' ' .. vim.fn.fnameescape(path))
   end
+  events.fire_event(events.FILE_OPENED, path)
 end
 
 ---Marks potential windows with letters and will open the give node in the picked window.


### PR DESCRIPTION
Currently, the following commands do not invoke the `file_opened` / `file_open_requested` event_handlers.

- `open_with_window_picker`
- `split_with_window_picker`
- `vsplit_with_window_picker`

I would like them to trigger the same event_handlers as their corresponding builtin commands: `open`, `split`, `vsplit`.

If this is not a feature you are supporting, could you consider defining a different command name that mimics this feature? Like, `open_with_window_picker_and_event_handler` perhaps?

Love to hear your thoughts, thanks
pysan3