### PR TITLE
docs(README): fix incorrect window picker tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ use {
       {
         -- only needed if you want to use the commands with "_with_window_picker" suffix
         's1n7ax/nvim-window-picker',
-        tag = "1.*",
+        tag = "v1.*",
         config = function()
           require'window-picker'.setup({
             autoselect_one = true,


### PR DESCRIPTION
The tag in the window picker plugin is prefixed with `v` if you don't have it, packer won't install the correct tags