### PR TITLE
fix: remove extra space on right related to #408

### DIFF
--- a/lua/neo-tree/sources/common/container.lua
+++ b/lua/neo-tree/sources/common/container.lua
@@ -187,7 +187,7 @@ local merge_content = function(context)
   -- * Repeat until all layers have been merged.
   -- * Join the left and right tables together and return.
   --
-  local remaining_width = context.container_width - 2 -- I don't know why I need to subtract 2
+  local remaining_width = context.container_width
   local left, right = {}, {}
   local left_width, right_width = 0, 0
 


### PR DESCRIPTION
As you can see in #408 , by disabling `signcolumn`, the width of the window changes.

I noticed a gap between icons and the edge on the right side. (See screenshots in https://github.com/nvim-neo-tree/neo-tree.nvim/pull/408#issuecomment-1179905051 )

I think this can be fixed by changing this line.

Best,
@pysan3 