### PR TITLE
feat: accept negative padding for `default_component_configs.indent.padding`

### DIFF
--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -356,6 +356,7 @@ M.indent = function(config, node, state)
     table.insert(indent, { text = string.rep(" ", padding) })
   end
 
+  local padding_remaining = padding
   for i = 1, level do
     local char = ""
     local spaces_count = indent_size
@@ -377,6 +378,10 @@ M.indent = function(config, node, state)
       end
     end
 
+    if padding_remaining < 0 then
+      padding_remaining = padding_remaining + spaces_count
+      spaces_count = padding_remaining
+    end
     table.insert(indent, { text = char .. string.rep(" ", spaces_count), highlight = highlight })
   end
 


### PR DESCRIPTION
With the following config, the outcome still has an extra padding on the left by default as you can see on line `lua/neo-tree` in the picture.

I would like to delete this extra space by setting `default_component_configs.indent.padding` to a negative value to work around this feature.

```lua
require("neo-tree").setup({
  hide_root_node = true,
  default_component_configs = {
    indent = {
      padding = 0,
      -- padding = -2, -- This will work with this PR
    },
  },
})
```

### Current Behavior
(The white line is the edge of the shell window)

- `default_component_configs.indent.padding = 0`
![image](https://user-images.githubusercontent.com/41065736/178661162-4171a130-5279-4547-be2c-a6cece30a5da.png)

- `default_component_configs.indent.padding = -2`
![image](https://user-images.githubusercontent.com/41065736/178661914-42c837e0-c092-4645-8bc4-261ee635f60d.png)

### Expected Behavior
- `default_component_configs.indent.padding = -2`
![image](https://user-images.githubusercontent.com/41065736/178662210-dc623470-2a89-47cd-9eba-dc2ded932140.png)

Again, thanks for the awesome plugin,
@pysan3 