### PR TITLE
feat(ui): use own namespace id

### DIFF
--- a/lua/neo-tree/ui/highlights.lua
+++ b/lua/neo-tree/ui/highlights.lua
@@ -3,6 +3,9 @@ local utils = require("neo-tree.utils")
 local vim = vim
 local M = {}
 
+---@type integer
+M.ns_id = vim.api.nvim_create_namespace("neo-tree.nvim")
+
 M.BUFFER_NUMBER = "NeoTreeBufferNumber"
 M.CURSOR_LINE = "NeoTreeCursorLine"
 M.DIM_TEXT = "NeoTreeDimText"

--- a/lua/neo-tree/ui/popups.lua
+++ b/lua/neo-tree/ui/popups.lua
@@ -20,6 +20,7 @@ M.popup_options = function(title, min_width, override_options)
   local popup_border_style = nt.config.popup_border_style
   local popup_border_text = NuiText(" " .. title .. " ", highlights.FLOAT_TITLE)
   local popup_options = {
+    ns_id = highlights.ns_id,
     relative = "cursor",
     position = {
       row = 1,

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -597,6 +597,7 @@ end
 
 create_tree = function(state)
   state.tree = NuiTree({
+    ns_id = highlights.ns_id,
     winid = state.winid,
     get_node_id = function(node)
       return node.id
@@ -695,6 +696,7 @@ create_window = function(state)
 
   local bufname = string.format("neo-tree %s [%s]", state.name, state.id)
   local win_options = {
+    ns_id = highlights.ns_id,
     size = utils.resolve_config_option(state, "window.width", "40"),
     position = state.current_position,
     relative = "editor",


### PR DESCRIPTION
If namespace id is not provided `nui.nvim` uses it's fallback namespace that is shared for other plugins using `nui.nvim`. It's better to use own namespace id.

Also, it is needed for testing.