### PR TITLE
fix: dialogs outside ui when tree pos is right

### DIFF
--- a/lua/neo-tree/ui/popups.lua
+++ b/lua/neo-tree/ui/popups.lua
@@ -20,11 +20,10 @@ M.popup_options = function(title, min_width, override_options)
   local popup_border_style = nt.config.popup_border_style
   local popup_border_text = NuiText(" " .. title .. " ", highlights.FLOAT_TITLE)
   local col = 0
-  local offset = (vim.api.nvim_win_get_width(0) - width) - 2
-  local is_right_window = vim.api.nvim_win_get_position(0)[2] + vim.api.nvim_win_get_width(0)
-      == vim.o.columns
-  if is_right_window and offset < 0 then
-    col = offset
+  -- fix popup position when using multigrid
+  local popup_last_col = vim.api.nvim_win_get_position(0)[2] + width + 2
+  if popup_last_col >= vim.o.columns then
+    col = vim.o.columns - popup_last_col
   end
   local popup_options = {
     relative = "cursor",

--- a/lua/neo-tree/ui/popups.lua
+++ b/lua/neo-tree/ui/popups.lua
@@ -20,9 +20,8 @@ M.popup_options = function(title, min_width, override_options)
   local popup_border_style = nt.config.popup_border_style
   local popup_border_text = NuiText(" " .. title .. " ", highlights.FLOAT_TITLE)
   local col = 0
-  local tree_pos = vim.api.nvim_buf_get_var(0, "neo_tree_position")
   local offset = (vim.api.nvim_win_get_width(0) - width) - 2
-  if tree_pos == "right" and offset < 0 then
+  if vim.api.nvim_win_get_number(0) ~= 1 and offset < 0 then
     col = offset
   end
   local popup_options = {

--- a/lua/neo-tree/ui/popups.lua
+++ b/lua/neo-tree/ui/popups.lua
@@ -21,7 +21,9 @@ M.popup_options = function(title, min_width, override_options)
   local popup_border_text = NuiText(" " .. title .. " ", highlights.FLOAT_TITLE)
   local col = 0
   local offset = (vim.api.nvim_win_get_width(0) - width) - 2
-  if vim.api.nvim_win_get_number(0) ~= 1 and offset < 0 then
+  local is_right_window = vim.api.nvim_win_get_position(0)[2] + vim.api.nvim_win_get_width(0)
+      == vim.o.columns
+  if is_right_window and offset < 0 then
     col = offset
   end
   local popup_options = {

--- a/lua/neo-tree/ui/popups.lua
+++ b/lua/neo-tree/ui/popups.lua
@@ -19,11 +19,17 @@ M.popup_options = function(title, min_width, override_options)
   local nt = require("neo-tree")
   local popup_border_style = nt.config.popup_border_style
   local popup_border_text = NuiText(" " .. title .. " ", highlights.FLOAT_TITLE)
+  local col = 0
+  local tree_pos = vim.api.nvim_buf_get_var(0, "neo_tree_position")
+  local offset = (vim.api.nvim_win_get_width(0) - width) - 2
+  if tree_pos == "right" and offset < 0 then
+    col = offset
+  end
   local popup_options = {
     relative = "cursor",
     position = {
       row = 1,
-      col = 0,
+      col = col,
     },
     size = width,
     border = {


### PR DESCRIPTION
Fixes No. 2 of #439 

There are always chances for improvement. When you see one here, I would love if you let me know.