### PR TITLE
feat: enable opening at top and bottom positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,8 @@ Where to show it, can be one of:
 |--------|-------------|
 | left    | Open as left hand sidebar. DEFAULT |
 | right   | Open as right hand sidebar. |
+| top     | Open as top window. |
+| botom   | Open as bottom window. |
 | float   | Open as floating window. |
 | current | Open within the current window, like netrw or vinegar would. |
 

--- a/lua/neo-tree/command/parser.lua
+++ b/lua/neo-tree/command/parser.lua
@@ -26,8 +26,8 @@ M.setup = function(all_source_names)
       values = {
         "left",
         "right",
-        --"top", --technically valid, but why show it if no one will use it?
-        --"bottom", --technically valid, but why show it if no one will use it?
+        "top",
+        "bottom",
         "float",
         "current",
       },

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -202,8 +202,9 @@ local config = {
   nesting_rules = {},
   window = { -- see https://github.com/MunifTanjim/nui.nvim/tree/main/lua/nui/popup for
              -- possible options. These can also be functions that return these options.
-    position = "left", -- left, right, float, current
+    position = "left", -- left, right, top, bottom, float, current
     width = 40, -- applies to left and right positions
+    height = 15, -- applies to top and bottom positions
     popup = { -- settings that apply to float position only
       size = {
         height = "80%",

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -695,9 +695,15 @@ create_window = function(state)
   state.current_position = state.current_position or default_position
 
   local bufname = string.format("neo-tree %s [%s]", state.name, state.id)
+  local size_opt, default_size
+  if state.current_position == "top" or state.current_position == "bottom" then
+    size_opt, default_size = "window.height", "15"
+  else
+    size_opt, default_size = "window.width", "40"
+  end
   local win_options = {
     ns_id = highlights.ns_id,
-    size = utils.resolve_config_option(state, "window.width", "40"),
+    size = utils.resolve_config_option(state, size_opt, default_size),
     position = state.current_position,
     relative = "editor",
     buf_options = {


### PR DESCRIPTION
Some external sources, for example my [diagnostic source](https://github.com/mrbjarksen/neo-tree-diagnostics.nvim), may benefit from opening windows at the top or bottom positions. This PR enables these positions and sets the default height of top and bottom windows to 15 rows.