### PR TITLE
fix(command): use `b` when open_cmd is `e` instead of `edit`

### DIFF
--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -381,7 +381,7 @@ end
 ---@param open_cmd string The vimcommand to use to open the file
 M.open_file = function(state, path, open_cmd)
   open_cmd = open_cmd or "edit"
-  if open_cmd == "edit" then
+  if open_cmd == "edit" or open_cmd == "e" then
     -- If the file is already open, switch to it.
     local bufnr = M.find_buffer_by_name(path)
     if bufnr > 0 then


### PR DESCRIPTION
The function `utils.open_file` smartly uses the command `b` instead of `edit` to avoid some overhead if the file is loaded in a buffer. The definition of `open` in `neo-tree.sources.common.commands` (and by extension, the `open` command in all built-in sources) fails to take advantage of this, however, by using `e` instead of `edit`. 
This PR fixes this behavior, electing to accept `e` in addition to `edit`, to look for an open buffer.