### PR TITLE
source selector refinement

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -48,6 +48,7 @@ local config = {
   source_selector = {
     winbar = false, -- toggle to show selector on winbar
     statusline = false, -- toggle to show selector on statusline
+    show_scrolled_off_parent_node = true,
     tab_labels = { -- falls back to source_name if nil
       filesystem = "   Files ",
       buffers =    "   Buffers ",

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -49,41 +49,41 @@ local config = {
     winbar = false, -- toggle to show selector on winbar
     statusline = false, -- toggle to show selector on statusline
     tab_labels = { -- falls back to source_name if nil
-      filesystem = "  Files   ",
-      buffers =    "  Buffers ",
-      git_status = "  Git     ",
+      filesystem = "   Files ",
+      buffers =    "   Buffers ",
+      git_status = "   Git ",
     },
-    content_layout = "center", -- only with `tabs_layout` = "equal", "focus"
+    content_layout = "start", -- only with `tabs_layout` = "equal", "focus"
     --                start  : |/ 裡 bufname     \/...
     --                end    : |/     裡 bufname \/...
     --                center : |/   裡 bufname   \/...
-    tabs_layout = "start", -- start, end, center, equal, focus
+    tabs_layout = "equal", -- start, end, center, equal, focus
     --             start  : |/  a  \/  b  \/  c  \            |
     --             end    : |            /  a  \/  b  \/  c  \|
     --             center : |      /  a  \/  b  \/  c  \      |
     --             equal  : |/    a    \/    b    \/    c    \|
     --             active : |/  focused tab    \/  b  \/  c  \|
     text_trunc_to_fit = true, -- toggle to truncate text in each tab when not enough width
-    tabs_min_width = nil, -- nil | int: if int padding is added based on `content_layout`
+    tabs_min_width = 11, -- nil | int: if int padding is added based on `content_layout`
     tabs_max_width = nil, -- this will truncate text even if `text_trunc_to_fit = false`
     padding = 0, -- can be int or table
     -- padding = { left = 2, right = 0 },
     -- separator = "▕", -- can be string or table, see below
+     separator = { left = "▏", right= "▕" },
     -- separator = { left = "/", right = "\\", override = nil },     -- |/  a  \/  b  \/  c  \...
     -- separator = { left = "/", right = "\\", override = "right" }, -- |/  a  \  b  \  c  \...
     -- separator = { left = "/", right = "\\", override = "left" },  -- |/  a  /  b  /  c  /...
     -- separator = { left = "/", right = "\\", override = "active" },-- |/  a  / b:active \  c  \...
-     separator = { left = "▏", right = "▕", override = "right" },  -- |/  a  /  b  /  c  /...
     -- separator = "|",                                              -- ||  a  |  b  |  c  |...
     separator_active = nil, -- set separators around the active tab. nil falls back to `source_selector.separator`
     show_separator_on_edge = false,
     --                       true  : |/    a    \/    b    \/    c    \|
     --                       false : |     a    \/    b    \/    c     |
-    highlight_tab = "NeoTreeDimText",
-    highlight_tab_active = "NeoTreeDirectoryName",
-    highlight_background = "NeoTreeCursorLine",
-    highlight_separator = "NeoTreeDimText",
-    highlight_separator_active = "NeoTreeDirectoryName",
+    highlight_tab = "NeoTreeTabInactive",
+    highlight_tab_active = "NeoTreeTabActive",
+    highlight_background = "NeoTreeTabInactive",
+    highlight_separator = "NeoTreeTabSeparatorInactive",
+    highlight_separator_active = "NeoTreeTabSeparatorActive",
   },
   --
   --event_handlers = {

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -50,9 +50,10 @@ local config = {
     statusline = false, -- toggle to show selector on statusline
     show_scrolled_off_parent_node = true,
     tab_labels = { -- falls back to source_name if nil
-      filesystem = "   Files ",
-      buffers =    "   Buffers ",
-      git_status = "   Git ",
+      filesystem = "  Files ",
+      buffers =    "  Buffers ",
+      git_status = "  Git ",
+      diagnostics = " 裂Diagnostics ",
     },
     content_layout = "start", -- only with `tabs_layout` = "equal", "focus"
     --                start  : |/ 裡 bufname     \/...
@@ -65,7 +66,7 @@ local config = {
     --             equal  : |/    a    \/    b    \/    c    \|
     --             active : |/  focused tab    \/  b  \/  c  \|
     text_trunc_to_fit = true, -- toggle to truncate text in each tab when not enough width
-    tabs_min_width = 11, -- nil | int: if int padding is added based on `content_layout`
+    tabs_min_width = nil, -- nil | int: if int padding is added based on `content_layout`
     tabs_max_width = nil, -- this will truncate text even if `text_trunc_to_fit = false`
     padding = 0, -- can be int or table
     -- padding = { left = 2, right = 0 },

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -119,9 +119,9 @@ end
 ---@return {table}| nil The state for the current buffer, or nil if it is not a
 ---neo-tree buffer.
 M.get_state_for_active_window = function()
-  local _, source = pcall(vim.api.nvim_buf_get_var, 0, "neo_tree_source")
+  local _, source_name = pcall(vim.api.nvim_buf_get_var, 0, "neo_tree_source")
   local _, position = pcall(vim.api.nvim_buf_get_var, 0, "neo_tree_position")
-  if not source or not position then
+  if not source_name or not position then
     return nil
   end
 

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -115,6 +115,25 @@ M.get_state = function(source_name, tabnr, winid)
   end
 end
 
+---Returns the state for the current buffer, assuming it is a neo-tree buffer.
+---@return {table}| nil The state for the current buffer, or nil if it is not a
+---neo-tree buffer.
+M.get_state_for_active_window = function()
+  local _, source = pcall(vim.api.nvim_buf_get_var, 0, "neo_tree_source")
+  local _, position = pcall(vim.api.nvim_buf_get_var, 0, "neo_tree_position")
+  if not source or not position then
+    return nil
+  end
+
+  local tabnr = vim.api.nvim_get_current_tabpage()
+  local winid = vim.api.nvim_get_current_win()
+  if position == "current" then
+    return M.get_state(source_name, tabnr, winid)
+  else
+    return M.get_state(source_name, tabnr, nil)
+  end
+end
+
 M.get_path_to_reveal = function(include_terminals)
   local win_id = vim.api.nvim_get_current_win()
   local cfg = vim.api.nvim_win_get_config(win_id)

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -116,17 +116,19 @@ M.get_state = function(source_name, tabnr, winid)
 end
 
 ---Returns the state for the current buffer, assuming it is a neo-tree buffer.
----@return {table}| nil The state for the current buffer, or nil if it is not a
+---@param winid number|nil The window id to use, if nil, the current window is used.
+---@return table|nil The state for the current buffer, or nil if it is not a
 ---neo-tree buffer.
-M.get_state_for_active_window = function()
-  local _, source_name = pcall(vim.api.nvim_buf_get_var, 0, "neo_tree_source")
-  local _, position = pcall(vim.api.nvim_buf_get_var, 0, "neo_tree_position")
+M.get_state_for_window = function(winid)
+  local winid = winid or vim.api.nvim_get_current_win()
+  local bufnr = vim.api.nvim_win_get_buf(winid)
+  local _, source_name = pcall(vim.api.nvim_buf_get_var, bufnr, "neo_tree_source")
+  local _, position = pcall(vim.api.nvim_buf_get_var, bufnr, "neo_tree_position")
   if not source_name or not position then
     return nil
   end
 
   local tabnr = vim.api.nvim_get_current_tabpage()
-  local winid = vim.api.nvim_get_current_win()
   if position == "current" then
     return M.get_state(source_name, tabnr, winid)
   else

--- a/lua/neo-tree/ui/highlights.lua
+++ b/lua/neo-tree/ui/highlights.lua
@@ -38,6 +38,10 @@ M.NORMALNC = "NeoTreeNormalNC"
 M.SIGNCOLUMN = "NeoTreeSignColumn"
 M.STATUS_LINE = "NeoTreeStatusLine"
 M.STATUS_LINE_NC = "NeoTreeStatusLineNC"
+M.TAB_ACTIVE = "NeoTreeTabActive"
+M.TAB_INACTIVE = "NeoTreeTabInactive"
+M.TAB_SEPARATOR_ACTIVE = "NeoTreeTabSeparatorActive"
+M.TAB_SEPARATOR_INACTIVE = "NeoTreeTabSeparatorInactive"
 M.VERTSPLIT = "NeoTreeVertSplit"
 M.WINSEPARATOR = "NeoTreeWinSeparator"
 M.END_OF_BUFFER = "NeoTreeEndOfBuffer"
@@ -61,14 +65,14 @@ end
 ---@param hl_group_name string The name of the highlight group.
 ---@param link_to_if_exists table A list of highlight groups to link to, in
 --order of priority. The first one that exists will be used.
----@param background string The background color to use, in hex, if the highlight group
+---@param background string|nil The background color to use, in hex, if the highlight group
 --is not defined and it is not linked to another group.
----@param foreground string The foreground color to use, in hex, if the highlight group
+---@param foreground string|nil The foreground color to use, in hex, if the highlight group
 --is not defined and it is not linked to another group.
----@gui string The gui to use, if the highlight group is not defined and it is not linked
+---@gui string|nil The gui to use, if the highlight group is not defined and it is not linked
 --to another group.
 ---@return table table The highlight group values.
-local function create_highlight_group(hl_group_name, link_to_if_exists, background, foreground, gui)
+M.create_highlight_group = function(hl_group_name, link_to_if_exists, background, foreground, gui)
   local success, hl_group = pcall(vim.api.nvim_get_hl_by_name, hl_group_name, true)
   if not success or not hl_group.foreground or not hl_group.background then
     for _, link_to in ipairs(link_to_if_exists) do
@@ -193,7 +197,7 @@ M.get_faded_highlight_group = function(hl_group_name, fade_percentage)
     dec_to_hex(blue, 2)
   )
 
-  create_highlight_group(key, {}, hl_group.background, new_foreground, gui)
+  M.create_highlight_group(key, {}, hl_group.background, new_foreground, gui)
   faded_highlight_group_cache[key] = key
   return key
 end
@@ -202,59 +206,64 @@ M.setup = function()
   -- Reset this here in case of color scheme change
   faded_highlight_group_cache = {}
 
-  local normal_hl = create_highlight_group(M.NORMAL, { "Normal" })
-  local normalnc_hl = create_highlight_group(M.NORMALNC, { "NormalNC", M.NORMAL })
+  local normal_hl = M.create_highlight_group(M.NORMAL, { "Normal" })
+  local normalnc_hl = M.create_highlight_group(M.NORMALNC, { "NormalNC", M.NORMAL })
 
-  create_highlight_group(M.SIGNCOLUMN, { "SignColumn", M.NORMAL })
+  M.create_highlight_group(M.SIGNCOLUMN, { "SignColumn", M.NORMAL })
 
-  create_highlight_group(M.STATUS_LINE, { "StatusLine" })
-  create_highlight_group(M.STATUS_LINE_NC, { "StatusLineNC" })
+  M.create_highlight_group(M.STATUS_LINE, { "StatusLine" })
+  M.create_highlight_group(M.STATUS_LINE_NC, { "StatusLineNC" })
 
-  create_highlight_group(M.VERTSPLIT, { "VertSplit" })
-  create_highlight_group(M.WINSEPARATOR, { "WinSeparator" })
+  M.create_highlight_group(M.VERTSPLIT, { "VertSplit" })
+  M.create_highlight_group(M.WINSEPARATOR, { "WinSeparator" })
 
-  create_highlight_group(M.END_OF_BUFFER, { "EndOfBuffer" })
+  M.create_highlight_group(M.END_OF_BUFFER, { "EndOfBuffer" })
 
-  local float_border_hl = create_highlight_group(
+  local float_border_hl = M.create_highlight_group(
     M.FLOAT_BORDER,
     { "FloatBorder" },
     normalnc_hl.background,
     "444444"
   )
 
-  create_highlight_group(M.FLOAT_TITLE, {}, float_border_hl.background, normal_hl.foreground)
-  create_highlight_group(M.TITLE_BAR, {}, float_border_hl.foreground, nil)
+  M.create_highlight_group(M.FLOAT_TITLE, {}, float_border_hl.background, normal_hl.foreground)
+  M.create_highlight_group(M.TITLE_BAR, {}, float_border_hl.foreground, nil)
 
-  create_highlight_group(M.BUFFER_NUMBER, { "SpecialChar" })
-  create_highlight_group(M.DIM_TEXT, {}, nil, "505050")
-  create_highlight_group(M.MESSAGE, {}, nil, "505050", "italic")
-  create_highlight_group(M.FADE_TEXT_1, {}, nil, "626262")
-  create_highlight_group(M.FADE_TEXT_2, {}, nil, "444444")
-  create_highlight_group(M.DOTFILE, {}, nil, "626262")
-  create_highlight_group(M.HIDDEN_BY_NAME, { M.DOTFILE }, nil, nil)
-  create_highlight_group(M.CURSOR_LINE, { "CursorLine" }, nil, nil, "bold")
-  create_highlight_group(M.DIRECTORY_NAME, { "Directory" }, "NONE", "NONE")
-  create_highlight_group(M.DIRECTORY_ICON, { "Directory" }, nil, "73cef4")
-  create_highlight_group(M.FILE_ICON, { M.DIRECTORY_ICON })
-  create_highlight_group(M.FILE_NAME, {}, "NONE", "NONE")
-  create_highlight_group(M.FILE_NAME_OPENED, {}, nil, nil, "bold")
-  create_highlight_group(M.SYMBOLIC_LINK_TARGET, { M.FILE_NAME })
-  create_highlight_group(M.FILTER_TERM, { "SpecialChar", "Normal" })
-  create_highlight_group(M.ROOT_NAME, {}, nil, nil, "bold,italic")
-  create_highlight_group(M.INDENT_MARKER, { M.DIM_TEXT })
-  create_highlight_group(M.EXPANDER, { M.DIM_TEXT })
-  create_highlight_group(M.MODIFIED, {}, nil, "d7d787")
-  create_highlight_group(M.WINDOWS_HIDDEN, { M.DOTFILE }, nil, nil)
+  M.create_highlight_group(M.BUFFER_NUMBER, { "SpecialChar" })
+  M.create_highlight_group(M.DIM_TEXT, {}, nil, "505050")
+  M.create_highlight_group(M.MESSAGE, {}, nil, "505050", "italic")
+  M.create_highlight_group(M.FADE_TEXT_1, {}, nil, "626262")
+  M.create_highlight_group(M.FADE_TEXT_2, {}, nil, "444444")
+  M.create_highlight_group(M.DOTFILE, {}, nil, "626262")
+  M.create_highlight_group(M.HIDDEN_BY_NAME, { M.DOTFILE }, nil, nil)
+  M.create_highlight_group(M.CURSOR_LINE, { "CursorLine" }, nil, nil, "bold")
+  M.create_highlight_group(M.DIRECTORY_NAME, { "Directory" }, "NONE", "NONE")
+  M.create_highlight_group(M.DIRECTORY_ICON, { "Directory" }, nil, "73cef4")
+  M.create_highlight_group(M.FILE_ICON, { M.DIRECTORY_ICON })
+  M.create_highlight_group(M.FILE_NAME, {}, "NONE", "NONE")
+  M.create_highlight_group(M.FILE_NAME_OPENED, {}, nil, nil, "bold")
+  M.create_highlight_group(M.SYMBOLIC_LINK_TARGET, { M.FILE_NAME })
+  M.create_highlight_group(M.FILTER_TERM, { "SpecialChar", "Normal" })
+  M.create_highlight_group(M.ROOT_NAME, {}, nil, nil, "bold,italic")
+  M.create_highlight_group(M.INDENT_MARKER, { M.DIM_TEXT })
+  M.create_highlight_group(M.EXPANDER, { M.DIM_TEXT })
+  M.create_highlight_group(M.MODIFIED, {}, nil, "d7d787")
+  M.create_highlight_group(M.WINDOWS_HIDDEN, { M.DOTFILE }, nil, nil)
 
-  create_highlight_group(M.GIT_ADDED, { "GitGutterAdd", "GitSignsAdd" }, nil, "5faf5f")
-  create_highlight_group(M.GIT_DELETED, { "GitGutterDelete", "GitSignsDelete" }, nil, "ff5900")
-  create_highlight_group(M.GIT_MODIFIED, { "GitGutterChange", "GitSignsChange" }, nil, "d7af5f")
-  local conflict = create_highlight_group(M.GIT_CONFLICT, {}, nil, "ff8700", "italic,bold")
-  create_highlight_group(M.GIT_IGNORED, { M.DOTFILE }, nil, nil)
-  create_highlight_group(M.GIT_RENAMED, { M.GIT_MODIFIED }, nil, nil)
-  create_highlight_group(M.GIT_STAGED, { M.GIT_ADDED }, nil, nil)
-  create_highlight_group(M.GIT_UNSTAGED, { M.GIT_CONFLICT }, nil, nil)
-  create_highlight_group(M.GIT_UNTRACKED, {}, nil, conflict.foreground, "italic")
+  M.create_highlight_group(M.GIT_ADDED, { "GitGutterAdd", "GitSignsAdd" }, nil, "5faf5f")
+  M.create_highlight_group(M.GIT_DELETED, { "GitGutterDelete", "GitSignsDelete" }, nil, "ff5900")
+  M.create_highlight_group(M.GIT_MODIFIED, { "GitGutterChange", "GitSignsChange" }, nil, "d7af5f")
+  local conflict = M.create_highlight_group(M.GIT_CONFLICT, {}, nil, "ff8700", "italic,bold")
+  M.create_highlight_group(M.GIT_IGNORED, { M.DOTFILE }, nil, nil)
+  M.create_highlight_group(M.GIT_RENAMED, { M.GIT_MODIFIED }, nil, nil)
+  M.create_highlight_group(M.GIT_STAGED, { M.GIT_ADDED }, nil, nil)
+  M.create_highlight_group(M.GIT_UNSTAGED, { M.GIT_CONFLICT }, nil, nil)
+  M.create_highlight_group(M.GIT_UNTRACKED, {}, nil, conflict.foreground, "italic")
+
+  M.create_highlight_group(M.TAB_ACTIVE, {}, nil, nil, "bold")
+  M.create_highlight_group(M.TAB_INACTIVE, {}, "080808", "888888")
+  M.create_highlight_group(M.TAB_SEPARATOR_ACTIVE, {}, nil, "3a3a3a")
+  M.create_highlight_group(M.TAB_SEPARATOR_INACTIVE, {}, "080808", "000000")
 end
 
 return M

--- a/lua/neo-tree/ui/highlights.lua
+++ b/lua/neo-tree/ui/highlights.lua
@@ -261,9 +261,9 @@ M.setup = function()
   M.create_highlight_group(M.GIT_UNTRACKED, {}, nil, conflict.foreground, "italic")
 
   M.create_highlight_group(M.TAB_ACTIVE, {}, nil, nil, "bold")
-  M.create_highlight_group(M.TAB_INACTIVE, {}, "080808", "888888")
-  M.create_highlight_group(M.TAB_SEPARATOR_ACTIVE, {}, nil, "3a3a3a")
-  M.create_highlight_group(M.TAB_SEPARATOR_INACTIVE, {}, "080808", "000000")
+  M.create_highlight_group(M.TAB_INACTIVE, {}, "101010", "888888")
+  M.create_highlight_group(M.TAB_SEPARATOR_ACTIVE, {}, nil, "303030")
+  M.create_highlight_group(M.TAB_SEPARATOR_INACTIVE, {}, "101010", "000000")
 end
 
 return M

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -918,7 +918,7 @@ draw = function(nodes, state, parent_id)
   state.tree:render()
 
   -- draw winbar / statusbar
-  require("neo-tree.ui.selector").set_source_selector(state, state.win_width)
+  require("neo-tree.ui.selector").set_source_selector(state)
 
   -- Restore the cursor position/focused node in the tree based on the state
   -- when it was last closed

--- a/lua/neo-tree/ui/selector.lua
+++ b/lua/neo-tree/ui/selector.lua
@@ -111,6 +111,15 @@ M.render_tab = function(left_sep, right_sep, sep_hl, text, tab_hl, click_id)
   return res
 end
 
+M.get = function()
+  local state = require("neo-tree.sources.manager").get_state_for_active_window()
+  if state == nil then
+    return
+  else
+    return M.create_selector(state, vim.api.nvim_win_get_width(0))
+  end
+end
+
 M.create_selector = function(state, width)
   local config = require("neo-tree").config
   if config == nil then
@@ -238,10 +247,10 @@ M.auto_set_source_selector = function(state)
   local sel_config = utils.resolve_config_option(require("neo-tree").config, "source_selector", {})
   local win_width = vim.api.nvim_win_get_width(state.winid)
   if sel_config and sel_config.winbar then
-    vim.wo[state.winid].winbar = M.create_selector(state, win_width)
+    vim.wo[state.winid].winbar = "%{%v:lua.require'neo-tree.ui.selector'.get()%}"
   end
   if sel_config and sel_config.statusline then
-    vim.wo[state.winid].statusline = M.create_selector(state, win_width)
+    vim.wo[state.winid].statusline = "%{%v:lua.require'neo-tree.ui.selector'.get()%}"
   end
 end
 


### PR DESCRIPTION
This is related to #427 #425 

I'll use this PR for further refinement of the source selector feature. Here is the current default look:

![image](https://user-images.githubusercontent.com/5160605/180110546-10128020-2065-42b0-960d-0fa1b64efe6a.png)

Next up is to:

- [x] make sure that it resizes along with the window resize
- [x] fix glitches with clicking when there are multiple trees open.
- [x] add "context", showing the current parent node when it scrolls off visible window

EDIT: These two will be handled separately. I think I'd like to refactor, move more config into the sources, and allow for other functionality besides just source selectors in the winbar.
- [ ] handle external sources
- [ ] add color to icons?