### PR TITLE
Do not notify log level when user set log_level='warn'

### DIFF
--- a/lua/neo-tree/log.lua
+++ b/lua/neo-tree/log.lua
@@ -99,7 +99,6 @@ log.new = function(config, standalone)
     if levels[level] then
       if config.level ~= level then
         config.level = level
-        notify("Log level set to " .. level, config.modes[2])
       end
     else
       notify("Invalid log level: " .. level, config.modes[5])


### PR DESCRIPTION
I set log_level='warn' because the notifications are noisy. But when open nvim, it always show a notification like below.

<img width="539" alt="CleanShot 2022-09-07 at 11 06 58@2x" src="https://user-images.githubusercontent.com/1998490/188779827-93590960-ed6a-4fdd-8bd1-0685f58b7188.png">

It is unnecessary, because user know what configuration written.