### PR TITLE
feat: add same_level config option

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -335,7 +335,6 @@ local config = {
         -- some commands may take optional config options, see `:h neo-tree-mappings` for details
         config = {
           show_path = "none", -- "none", "relative", "absolute"
-          insert_as = "child" -- "child", "sibling" - Overrides the global `insert_as` config.
         }
       },
       ["A"] = "add_directory", -- also accepts the config.show_path and config.insert_as options.

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -298,6 +298,7 @@ local config = {
       -- you can also specify border here, if you want a different setting from
       -- the global popup_border_style.
     },
+    same_level = false, -- Create and paste/move files/directories on the same level as the directory under cursor (as opposed to within the directory under cursor).
     -- Mappings for tree window. See `:h neo-tree-mappings` for a list of built-in commands.
     -- You can also create your own commands by providing a function instead of a string.
     mapping_options = {

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -299,6 +299,9 @@ local config = {
       -- the global popup_border_style.
     },
     same_level = false, -- Create and paste/move files/directories on the same level as the directory under cursor (as opposed to within the directory under cursor).
+    insert_as = "child", -- Affects how nodes get inserted into the tree during creation/pasting/moving of files if the node under the cursor is a directory:
+                        -- "child":   Insert nodes as children of the directory under cursor.
+                        -- "sibling": Insert nodes  as siblings of the directory under cursor.
     -- Mappings for tree window. See `:h neo-tree-mappings` for a list of built-in commands.
     -- You can also create your own commands by providing a function instead of a string.
     mapping_options = {
@@ -331,17 +334,18 @@ local config = {
         "add",
         -- some commands may take optional config options, see `:h neo-tree-mappings` for details
         config = {
-          show_path = "none" -- "none", "relative", "absolute"
+          show_path = "none", -- "none", "relative", "absolute"
+          insert_as = "child" -- "child", "sibling" - Overrides the global `insert_as` config.
         }
       },
-      ["A"] = "add_directory", -- also accepts the config.show_path option.
+      ["A"] = "add_directory", -- also accepts the config.show_path and config.insert_as options.
       ["d"] = "delete",
       ["r"] = "rename",
       ["y"] = "copy_to_clipboard",
       ["x"] = "cut_to_clipboard",
       ["p"] = "paste_from_clipboard",
-      ["c"] = "copy", -- takes text input for destination, also accepts the config.show_path option
-      ["m"] = "move", -- takes text input for destination, also accepts the config.show_path option
+      ["c"] = "copy", -- takes text input for destination, also accepts the config.show_path and config.insert_as options
+      ["m"] = "move", -- takes text input for destination, also accepts the config.show_path and config.insert_as options
       ["e"] = "toggle_auto_expand_width",
       ["q"] = "close_window",
       ["?"] = "show_help",

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -20,14 +20,14 @@ local function get_folder_node(state, node)
   if not node then
     node = tree:get_node()
   end
-  local use_parent_local = state.config.same_level
-  local use_parent_global = require("neo-tree").config.window.same_level
+  local use_parent_local = state.config.same_level == "sibling"
+  local use_parent_global = require("neo-tree").config.window.insert_as == "sibling"
   local use_parent
   local is_open_dir = node.type == "directory" and (node:is_expanded() or node.empty_expanded)
   if not use_parent_global then
     use_parent = use_parent_local
   else
-    use_parent = use_parent_local ~= false
+    use_parent = use_parent_local ~= "child"
   end
   if use_parent and not is_open_dir then
     return tree:get_node(node:get_parent_id())
@@ -396,9 +396,9 @@ M.paste_from_clipboard = function(state, callback)
 
     paste_complete = function(source, destination)
       if callback then
-        local same_level = require("neo-tree").config.window.same_level
+        local insert_as = require("neo-tree").config.window.insert_as
         -- open the folder so the user can see the new files
-        local node = same_level and state.tree:get_node() or state.tree:get_node(folder)
+        local node = insert_as == "sibling" and state.tree:get_node() or state.tree:get_node(folder)
         if not node then
           log.warn("Could not find node for " .. folder)
         end

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -20,7 +20,14 @@ local function get_folder_node(state, node)
   if not node then
     node = tree:get_node()
   end
-  local use_parent = require("neo-tree").config.window.same_level
+  local use_parent_local = state.config.same_level
+  local use_parent_global = require("neo-tree").config.window.same_level
+  local use_parent
+  if not use_parent_global then
+    use_parent = use_parent_local
+  else
+    use_parent = use_parent_local ~= false
+  end
   if use_parent then
     return tree:get_node(node:get_parent_id())
   end

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -20,15 +20,17 @@ local function get_folder_node(state, node)
   if not node then
     node = tree:get_node()
   end
-  local use_parent_local = state.config.same_level == "sibling"
-  local use_parent_global = require("neo-tree").config.window.insert_as == "sibling"
+
+  local insert_as_local = state.config.insert_as
+  local insert_as_global = require("neo-tree").config.window.insert_as
   local use_parent
-  local is_open_dir = node.type == "directory" and (node:is_expanded() or node.empty_expanded)
-  if not use_parent_global then
-    use_parent = use_parent_local
+  if insert_as_local then
+    use_parent = insert_as_local == "sibling"
   else
-    use_parent = use_parent_local ~= "child"
+    use_parent = insert_as_global == "sibling"
   end
+
+  local is_open_dir = node.type == "directory" and (node:is_expanded() or node.empty_expanded)
   if use_parent and not is_open_dir then
     return tree:get_node(node:get_parent_id())
   end

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -23,12 +23,13 @@ local function get_folder_node(state, node)
   local use_parent_local = state.config.same_level
   local use_parent_global = require("neo-tree").config.window.same_level
   local use_parent
+  local is_open_dir = node.type == "directory" and (node:is_expanded() or node.empty_expanded)
   if not use_parent_global then
     use_parent = use_parent_local
   else
     use_parent = use_parent_local ~= false
   end
-  if use_parent then
+  if use_parent and not is_open_dir then
     return tree:get_node(node:get_parent_id())
   end
 

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -19,6 +19,11 @@ local function get_folder_node(tree, node)
   if not node then
     node = tree:get_node()
   end
+  local use_parent = require("neo-tree").config.window.same_level
+  if use_parent then
+    return tree:get_node(node:get_parent_id())
+  end
+
   if node.type == "directory" then
     return node
   end
@@ -384,8 +389,9 @@ M.paste_from_clipboard = function(state, callback)
 
     paste_complete = function(source, destination)
       if callback then
+        local same_level = require("neo-tree").config.window.same_level
         -- open the folder so the user can see the new files
-        local node = state.tree:get_node(folder)
+        local node = same_level and state.tree:get_node() or state.tree:get_node(folder)
         if not node then
           log.warn("Could not find node for " .. folder)
         end

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -15,7 +15,8 @@ local Preview = require("neo-tree.sources.common.preview")
 ---@param tree table to look for nodes
 ---@param node table to look for folder parent
 ---@return table table
-local function get_folder_node(tree, node)
+local function get_folder_node(state, node)
+  local tree = state.tree
   if not node then
     node = tree:get_node()
   end
@@ -27,7 +28,7 @@ local function get_folder_node(tree, node)
   if node.type == "directory" then
     return node
   end
-  return get_folder_node(tree, tree:get_node(node:get_parent_id()))
+  return get_folder_node(state, tree:get_node(node:get_parent_id()))
 end
 
 ---The using_root_directory is used to decide what part of the filename to show
@@ -36,7 +37,7 @@ end
 ---@return string The root path from which the relative source path should be taken
 local function get_using_root_directory(state)
   -- default to showing only the basename of the path
-  local using_root_directory = get_folder_node(state.tree):get_id()
+  local using_root_directory = get_folder_node(state):get_id()
   local show_path = state.config.show_path
   if show_path == "absolute" then
     using_root_directory = ""
@@ -70,8 +71,7 @@ end
 ---@param state table The state of the source
 ---@param callback function The callback to call when the command is done. Called with the parent node as the argument.
 M.add = function(state, callback)
-  local tree = state.tree
-  local node = get_folder_node(tree)
+  local node = get_folder_node(state)
   local in_directory = node:get_id()
   local using_root_directory = get_using_root_directory(state)
   fs_actions.create_node(in_directory, callback, using_root_directory)
@@ -81,8 +81,7 @@ end
 ---@param state table The state of the source
 ---@param callback function The callback to call when the command is done. Called with the parent node as the argument.
 M.add_directory = function(state, callback)
-  local tree = state.tree
-  local node = get_folder_node(tree)
+  local node = get_folder_node(state)
   local in_directory = node:get_id()
   local using_root_directory = get_using_root_directory(state)
   fs_actions.create_directory(in_directory, callback, using_root_directory)
@@ -378,7 +377,7 @@ end
 ---@param callback function The callback to call when the command is done. Called with the parent node as the argument.
 M.paste_from_clipboard = function(state, callback)
   if state.clipboard then
-    local folder = get_folder_node(state.tree):get_id()
+    local folder = get_folder_node(state):get_id()
     -- Convert to list so to make it easier to pop items from the stack.
     local clipboard_list = {}
     for _, item in pairs(state.clipboard) do


### PR DESCRIPTION
Hi, first of all, thanks for this amazing plugin!
This is my first contribution and I kept the PR minimal because I want to first assess whether this feature is even wanted before diving deeper into the setup.

I propose to add a `same_level` boolean config option to control the behaviour on how created/pasted/moved files/directories get inserted into the tree:

The behaviour is only affected if the cursor during creation/pasting/moving is on a directory node. Currently, the items get inserted inside the directory under cursor. I personally find it more intuitive if they get inserted on the same level (i.e. "as siblings") to the directory under cursor, much like it behaves currently when the cursor is on a file.

If you think this feature is worth continuing to work on let me know. If no, feel free to decline the PR. If yes, I would also like to add  the `same_level` flag withing the `config` table of the specific commands (i.e. next to `config.show_path` which would take precedence over the global `same_level` options.