### PR TITLE
fix: plain match "%" in command line completion

### DIFF
--- a/lua/neo-tree/command/completion.lua
+++ b/lua/neo-tree/command/completion.lua
@@ -57,21 +57,21 @@ M.complete_args = function(argLead, cmdLine)
       -- may be the start of a new key=value pair
       for _, key in ipairs(parser.list_args) do
         key = tostring(key)
-        if key:find(argLead) and not parsed[key] then
+        if key:find(argLead, 1, true) and not parsed[key] then
           table.insert(candidates, key .. "=")
         end
       end
 
       for _, key in ipairs(parser.path_args) do
         key = tostring(key)
-        if key:find(argLead) and not parsed[key] then
+        if key:find(argLead, 1, true) and not parsed[key] then
           table.insert(candidates, key .. "=./")
         end
       end
 
       for _, key in ipairs(parser.ref_args) do
         key = tostring(key)
-        if key:find(argLead) and not parsed[key] then
+        if key:find(argLead, 1, true) and not parsed[key] then
           table.insert(candidates, key .. "=")
         end
       end
@@ -107,7 +107,7 @@ M.complete_args = function(argLead, cmdLine)
       key_already_used = type(parsed[value]) ~= "nil"
     end
 
-    if not key_already_used and value:find(argLead) then
+    if not key_already_used and value:find(argLead, 1, true) then
       table.insert(candidates, value)
     end
   end


### PR DESCRIPTION
fix "%" in command line completion

## reproduced

``` lua
-- minimal_init.lua
vim.opt.runtimepath:append('~/.local/share/nvim/site/pack/p/start/plenary.nvim/')
vim.opt.runtimepath:append('~/.local/share/nvim/site/pack/p/start/nui.nvim/')
vim.opt.runtimepath:append('~/.local/share/nvim/site/pack/p/start/neo-tree.nvim/')

vim.cmd("runtime plugin/neo-tree.vim")
require("neo-tree").setup({})
```

1. nvim --clean
2. luafile minimal_init.lua
3. :NeoTree %\<Tab>

### expected
no errors.

### actual
error occured.
```
E5108: Error executing lua ...start/neo-tree.nvim//lua/neo-tree/command/completi
on.lua:60: malformed pattern (ends with '%')
stack traceback:
        [C]: in function 'find'
        ...start/neo-tree.nvim//lua/neo-tree/command/completion.lua:60: in funct
ion <...start/neo-tree.nvim//lua/neo-tree/command/completion.lua:49>
```

## env

- windows 10 & WSL & wezterm
- nvim --version
```
NVIM v0.8.0-dev-1207-g183984880
Build type: RelWithDebInfo
LuaJIT 2.1.0-beta3
```
- neo-tree.nvim: use e968cda


(thanks great plugin)