### PR TITLE
fix(highlight): tab separator respects transparent background

### DIFF
--- a/lua/neo-tree/ui/highlights.lua
+++ b/lua/neo-tree/ui/highlights.lua
@@ -269,8 +269,8 @@ M.setup = function()
 
   M.create_highlight_group(M.TAB_ACTIVE, {}, nil, nil, "bold")
   M.create_highlight_group(M.TAB_INACTIVE, {}, "141414", "777777")
-  M.create_highlight_group(M.TAB_SEPARATOR_ACTIVE, {}, nil, "0a0a0a")
-  M.create_highlight_group(M.TAB_SEPARATOR_INACTIVE, {}, "141414", "101010")
+  M.create_highlight_group(M.TAB_SEPARATOR_ACTIVE, {}, nil, nil)
+  M.create_highlight_group(M.TAB_SEPARATOR_INACTIVE, {}, nil, nil)
 end
 
 return M


### PR DESCRIPTION

Before:
<img width="434" alt="WeChatdc2aac08516f9ccb67117192343ed4f3" src="https://user-images.githubusercontent.com/54089360/194506474-c22c85ab-247e-45a3-a0c3-e8e44fc243c8.png">

After:
<img width="454" alt="WeChat6242ff23b6c30e9d108b3b40ed1aba68" src="https://user-images.githubusercontent.com/54089360/194506616-98bfc0ff-11e1-4c53-aba4-a6e035a20ad5.png">
