### PR TITLE
fix: Clickable filesystem source winbar component closes neo-tree immediately

### DIFF
--- a/lua/neo-tree/ui/selector.lua
+++ b/lua/neo-tree/ui/selector.lua
@@ -384,11 +384,10 @@ _G.___neotree_selector_click = function(id, _, _, _)
     log.warn("state not found for window ", winid, "; ignoring click")
     return
   end
-  vim.api.nvim_set_current_win(winid)
   require("neo-tree.command").execute({
     source = sources[source_index],
     position = state.current_position,
-    action = "show",
+    action = "focus",
   })
 end
 


### PR DESCRIPTION
Hi, I think this is enough to fix #565
I'm still investigating why `action = 'show'` fails on a floating window.

#### Some Notes
- `prev_source, next_source` (i.e. `<`, `>`) uses `action = 'focus'` instead
- Works without fix for `config.window.position = 'left'` and all other options except `'float'`
- Switching to other sources has no problem even with `'float'`

I thought that `action = 'show'` will cache or whatever and speed up the switch, but looking at the code, I don't think there are any downsides by doing it this way. (And this is how `<`, `>` was implemented in the first place, which did not cause any problem)