### PR TITLE
fix: nvim-window-picker buftype rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ use {
               -- filter using buffer options
               bo = {
                 -- if the file type is one of following, the window will be ignored
-                filetype = { 'neo-tree', "neo-tree-popup", "notify", "quickfix" },
+                filetype = { 'neo-tree', "neo-tree-popup", "notify" },
 
                 -- if the buffer type is one of following, the window will be ignored
-                buftype = { 'terminal' },
+                buftype = { 'terminal', "quickfix" },
               },
             },
             other_win_hl_color = '#e35e4f',


### PR DESCRIPTION
`quickfix` window filetype is `qf`,
`quickfix` window buftype is `quickfix`,
 so move to buftype.

thanks.