### PR TITLE
feat: Auto Width or Full Name Under Cursor (related to #547)

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -287,6 +287,7 @@ local config = {
     position = "left", -- left, right, top, bottom, float, current
     width = 40, -- applies to left and right positions
     height = 15, -- applies to top and bottom positions
+    auto_expand_width = false, -- expand the window when file exceeds the window width. does not work with position = "float"
     popup = { -- settings that apply to float position only
       size = {
         height = "80%",

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -481,7 +481,7 @@ local config = {
     window = {
       mappings = {
         ["<cr>"] = "toggle_node",
-        ["e"] = "example_command",
+        ["<C-e>"] = "example_command",
         ["d"] = "show_debug_info",
       },
     },

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -338,6 +338,7 @@ local config = {
       ["p"] = "paste_from_clipboard",
       ["c"] = "copy", -- takes text input for destination, also accepts the config.show_path option
       ["m"] = "move", -- takes text input for destination, also accepts the config.show_path option
+      ["e"] = "toggle_auto_expand_width",
       ["q"] = "close_window",
       ["?"] = "show_help",
       ["<"] = "prev_source",

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -146,7 +146,13 @@ M.toggle_auto_expand_width = function(state)
   end
   state.window.auto_expand_width = state.window.auto_expand_width == false
   if not state.window.auto_expand_width then
-    vim.api.nvim_win_set_width(0, state.window.width)
+    if (state.window.last_user_width or state.window.width) >= vim.api.nvim_win_get_width(0) then
+      state.window.last_user_width = state.window.width
+    end
+    vim.api.nvim_win_set_width(0, state.window.last_user_width)
+    state.win_width = state.window.last_user_width
+    state.longest_width_exact = 0
+    log.trace(string.format("Collapse auto_expand_width."))
   end
   renderer.redraw(state)
 end

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -140,6 +140,17 @@ M.close_window = function(state)
   renderer.close(state)
 end
 
+M.toggle_auto_expand_width = function(state)
+  if state.window.position == "float" then
+    return
+  end
+  state.window.auto_expand_width = state.window.auto_expand_width == false
+  if not state.window.auto_expand_width then
+    vim.api.nvim_win_set_width(0, state.window.width)
+  end
+  renderer.redraw(state)
+end
+
 local copy_node_to_clipboard = function(state, node)
   state.clipboard = state.clipboard or {}
   local existing = state.clipboard[node.id]

--- a/lua/neo-tree/sources/common/container.lua
+++ b/lua/neo-tree/sources/common/container.lua
@@ -187,7 +187,8 @@ local merge_content = function(context)
   -- * Repeat until all layers have been merged.
   -- * Join the left and right tables together and return.
   --
-  local remaining_width = context.container_width
+  local huge_number = 2000
+  local remaining_width = context.auto_expand_width and huge_number or context.container_width
   local left, right = {}, {}
   local left_width, right_width = 0, 0
 
@@ -253,6 +254,9 @@ local merge_content = function(context)
     end
   end
 
+  if context.auto_expand_width then
+    remaining_width = context.container_width + remaining_width - huge_number
+  end
   if remaining_width > 0 and #right > 0 then
     table.insert(left, { text = string.rep(" ", remaining_width) })
   end
@@ -271,6 +275,7 @@ M.render = function(config, node, state, available_width)
     left_padding = config.left_padding,
     right_padding = config.right_padding,
     enable_character_fade = config.enable_character_fade,
+    auto_expand_width = state.window.auto_expand_width and state.window.position ~= "float",
   }
 
   render_content(config, node, state, context)

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -335,7 +335,10 @@ local prepare_node = function(item, state)
         end
       end
     end
-    state.longest_width_exact = math.max(state.longest_width_exact, vim.api.nvim_strwidth(line:content()) + 1)
+    state.longest_width_exact = math.max(
+      state.longest_width_exact,
+      vim.api.nvim_strwidth(line:content()) + 1
+    )
   end
 
   return line
@@ -916,12 +919,14 @@ end
 
 ---Renders the given tree and expands window width if needed
 --@param state table The state containing tree to render. Almost same as state.tree:render()
-render_tree = function (state)
+render_tree = function(state)
   state.tree:render()
   if state.window.auto_expand_width and state.window.position ~= "float" then
     state.window.last_user_width = vim.api.nvim_win_get_width(0)
     if state.longest_width_exact > state.window.last_user_width then
-      log.trace(string.format("`auto_expand_width: on. Expanding width to %s.", state.longest_width_exact))
+      log.trace(
+        string.format("`auto_expand_width: on. Expanding width to %s.", state.longest_width_exact)
+      )
       vim.api.nvim_win_set_width(0, state.longest_width_exact)
       state.win_width = state.longest_width_exact
       render_tree(state)

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -335,6 +335,12 @@ local prepare_node = function(item, state)
         end
       end
     end
+    if state.window.auto_expand_width and state.window.position ~= "float" then
+      local str_length = vim.api.nvim_strwidth(line:content())
+      if str_length > vim.api.nvim_win_get_width(0) then
+        vim.api.nvim_win_set_width(0, str_length)
+      end
+    end
   end
 
   return line


### PR DESCRIPTION
Hi, I love the extensibility of this plugin.

I think this feature (#547) is quite useful, especially when you want to peek a filename or dealing with very deep file structures.

I tried to implement this feature with the following configs and I would like to hear your opinions.

## What I did

### 1. Added option `window.auto_expand_width`

Default: `false`

Usually, long file names and deep hierarchy folders (by the indents) are truncated and goes underneath modified symbols etc. However, by setting this to `true`, the filename is not truncated and instead, the window width is expanded (ignoring `window.width` option) to show the whole content.

|Default|`window.auto_expand_width = true`|
|-|-|
|![image](https://user-images.githubusercontent.com/41065736/197484689-62cae1b9-d718-4d61-945f-a9e3cfa78a6b.png)|![image](https://user-images.githubusercontent.com/41065736/197484790-35fecaf5-71ef-4f94-83b9-41f99143e367.png)|

What it differs from `width = "fit_content"` is that the window width expands even after launching neotree, meaning that when a new folder with a very longfile name is expanded, neotree window adjusts its width to fit the new filename.

![2022-10-24 18-04-27](https://user-images.githubusercontent.com/41065736/197492718-15de9906-6a90-43ef-ba73-9f7dcb2a9bc1.gif)

### 2. Added command `toggle_auto_expand_width` (with keybind)

Although I added the above feature, I actually like the fading effect on normal circumstances.
So I created a keybind that toggles `window.auto_expand_width`.

In my usecase (and IMO recommended to everybody) is to keep `window.auto_expand_width` option to `false` and toggle the feature whenever needed.

Currently it is binded to `e`. In the gif bellow, I am pressing `e` several times after opening neotree.

![2022-10-24 18-04-53](https://user-images.githubusercontent.com/41065736/197493467-cfc70c9b-eec7-4bd4-a8cc-cd6143ed13e4.gif)

## Know Issues

There are some issues with the current implementation. However, I don't think this is a big problem because, first of all, not so many people are going to use (or even notice) this feature, and second, it hardly effects the usability.

- Window width of the lines above the `very-long-file-name.txt` is not updated
  - This is pretty much impossible to fix because the length of lines are calculated on the fly.
  - Not a big problem since it will get fixed by `renderer.redraw(state)`, i.e. doing any of the followings
    - reopen neotree
    - open another directory or make a new file or do something that will fire an update
- The default keybind `e` conflicts with `example.window.example_command`?
  - I have never used this keybind and have no idea what it is for.
  - I would like to hear @cseickel and others' ideas about a better keybinding.
- Currently disabled for `window.position = "float"`
  - With the floating window, it looks awkward after resizing the window.
  - Therefore, I currently disable this feature on floating window.
  - Floating windows tend to have a wider width by default and I find myself rarely overflowing the width in the first place. (Fig: tested on floating windows; The right side of the window is kinda broken.)
![Screenshot_20221024_170959](https://user-images.githubusercontent.com/41065736/197497306-97c74fe0-be05-4dd7-a418-8eb6dec4801b.png)

I hope this helps,
pysan3