### PR TITLE
fix: opening multiple current neo-tree windows

### DIFF
--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -146,7 +146,9 @@ do_show_or_focus = function(args, state, force_navigate)
     if not window_exists then
       -- Clear the space in case another source is already open
       local target_position = args.position or state.current_position or state.window.position
-      manager.close_all(target_position)
+      if target_position ~= "current" then
+        manager.close_all(target_position)
+      end
     end
   end
 


### PR DESCRIPTION
When opening a new neo-tree window with the `current` position, do not close all other `current` windows.
This allows having multiple `current` windows side-by-side on the same tabpage.

It was possible before with the following combination (open neo-tree in one buffer, then split it):
```
:e .<CR>:vs
```


This opened two neo-tree windows side-by-side (when `hijack_netrw_behavior` was set to `open_current`).

https://user-images.githubusercontent.com/889383/200114060-d441d519-240c-458d-a1c6-5fd47fbd44ff.mp4

However, when trying to it the other way around (open two buffers side by side, open neo-tree in one of them, then switch to the other buffer and open neo-tree in that one):

```
:vs<CR>:Neotree position=current<CR><C-W>p:Neotree position=current
```

Opening the second neo-tree window closed the first one.


https://user-images.githubusercontent.com/889383/200114080-2e5459b9-92f5-431f-8348-59e7a15afcdf.mp4



With this fix, both combinations lead to the same result of having two independent neo-tree windows side-by-side with the `current` position.


https://user-images.githubusercontent.com/889383/200114089-e1ea2b0d-d100-46fa-bd16-212e54d3a4e8.mp4

My neo-tree config in case that is relevant: https://github.com/Gelio/ubuntu-dotfiles/blob/4cb7abb39849f75b51a504fd120e1d2511071cb8/install/neovim/stowed/.config/nvim/lua/plugins.lua#L91-L156
