### PR TITLE
feat: New node-scanning algorithm and empty folder states

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -365,6 +365,8 @@ local config = {
     async_directory_scan = "auto", -- "auto"   means refreshes are async, but it's synchronous when called from the Neotree commands.
                                    -- "always" means directory scans are always async.
                                    -- "never"  means directory scans are never async.
+    scan_mode = "shallow", -- "shallow": Don't scan into directories to detect possible empty directory a priori
+                           -- "deep": Scan into directories to detect empty or grouped empty directories a priori.
     bind_to_cwd = true, -- true creates a 2-way binding between vim's cwd and neo-tree's root
     cwd_target = {
       sidebar = "tab",   -- sidebar is when position = left or right

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -196,6 +196,7 @@ local config = {
       folder_closed = "",
       folder_open = "",
       folder_empty = "ﰊ",
+      folder_empty_open = "ﰊ",
       -- The next two settings are only a fallback, if you use nvim-web-devicons and configure default icons there
       -- then these will never be used.
       default = "*",

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -262,13 +262,18 @@ M.filtered_by = function(config, node, state)
   return result
 end
 
+
+
 M.icon = function(config, node, state)
+  local empty = ""
+  local empty_open = ""
+
   local icon = config.default or " "
   local highlight = config.highlight or highlights.FILE_ICON
   if node.type == "directory" then
     highlight = highlights.DIRECTORY_ICON
     if node.loaded and not node:has_children() then
-      icon = config.folder_empty or config.folder_open or "-"
+      icon = not node.empty_expanded and empty or empty_open
     elseif node:is_expanded() then
       icon = config.folder_open or "-"
     else

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -265,15 +265,14 @@ end
 
 
 M.icon = function(config, node, state)
-  local empty = ""
-  local empty_open = ""
-
   local icon = config.default or " "
   local highlight = config.highlight or highlights.FILE_ICON
   if node.type == "directory" then
     highlight = highlights.DIRECTORY_ICON
     if node.loaded and not node:has_children() then
-      icon = not node.empty_expanded and empty or empty_open
+      icon = not node.empty_expanded
+        and config.folder_empty
+        or config.folder_empty_open
     elseif node:is_expanded() then
       icon = config.folder_open or "-"
     else

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -404,6 +404,9 @@ M.toggle_directory = function(state, node, path_to_reveal, skip_redraw, recursiv
     if path_to_reveal then
       renderer.focus_node(state, path_to_reveal)
     end
+  else
+    node.empty_expanded = not node.empty_expanded
+    renderer.redraw(state)
   end
 end
 

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -404,7 +404,7 @@ M.toggle_directory = function(state, node, path_to_reveal, skip_redraw, recursiv
     if path_to_reveal then
       renderer.focus_node(state, path_to_reveal)
     end
-  else
+  elseif require("neo-tree").config.filesystem.scan_mode == "deep" then
     node.empty_expanded = not node.empty_expanded
     renderer.redraw(state)
   end

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -167,7 +167,6 @@ end
 
 local function get_children_async(path, callback)
   uv.fs_opendir(path, function(_, dir)
-    print("Async cb of: " .. path)
     uv.fs_readdir(dir, function(_, stats)
       local children = {}
       if stats then
@@ -201,7 +200,6 @@ local function scan_dir_sync(context, path)
 end
 
 local function scan_dir_async(context, path, callback)
-  process_node(context, path)
   get_children_async(path, function(children)
     for _, child in ipairs(children) do
       create_node(context, child)
@@ -216,6 +214,7 @@ local function scan_dir_async(context, path, callback)
         end
       end
     end
+    process_node(context, path)
     callback(path)
   end)
 end
@@ -242,7 +241,7 @@ local function async_scan(context, path)
     )
   else -- scan_mode == "shallow"
     -- prepend the root path
-    table.insert(context.paths_to_load, 1, path)
+    -- table.insert(context.paths_to_load, 1, path)
 
     context.directories_scanned = 0
     context.directories_to_scan = #context.paths_to_load

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1115,31 +1115,34 @@ M.show_nodes = function(sourceItems, state, parentId, callback)
 
   if state.group_empty_dirs then
     if parent then
-      -- this is a lazy load of a single sub folder
-      group_empty_dirs(sourceItems)
-      if #sourceItems == 1 and sourceItems[1].type == "directory" then
-        -- This folder needs to be grouped.
-        -- The goal is to just update the existing node in place.
-        -- To avoid digging into private internals of Nui, we will just export the entire level and replace
-        -- the one node. This keeps it in the right order, because nui doesn't have methods to replace something
-        -- in place.
-        -- We can't just mutate the existing node because we have to change it's id which would break Nui's
-        -- internal state.
-        local item = sourceItems[1]
-        parentId = parent:get_parent_id()
-        local siblings = state.tree:get_nodes(parentId)
-        for i, node in pairs(siblings) do
-          if node.id == parent.id then
-            item.name = parent.name .. utils.path_separator .. item.name
-            item.level = level - 1
-            item.is_loaded = utils.truthy(item.children)
-            siblings[i] = NuiTree.Node(item, item.children)
-            break
-          end
-        end
-        sourceItems = nil -- this is a signal to skip the rest of the processing
-        state.tree:set_nodes(siblings, parentId)
+      for i, item in ipairs(sourceItems) do
+        sourceItems[i] = group_empty_dirs(item)
       end
+      -- this is a lazy load of a single sub folder
+      -- group_empty_dirs(sourceItems)
+      -- if #sourceItems == 1 and sourceItems[1].type == "directory" then
+      --   -- This folder needs to be grouped.
+      --   -- The goal is to just update the existing node in place.
+      --   -- To avoid digging into private internals of Nui, we will just export the entire level and replace
+      --   -- the one node. This keeps it in the right order, because nui doesn't have methods to replace something
+      --   -- in place.
+      --   -- We can't just mutate the existing node because we have to change it's id which would break Nui's
+      --   -- internal state.
+      --   local item = sourceItems[1]
+      --   parentId = parent:get_parent_id()
+      --   local siblings = state.tree:get_nodes(parentId)
+      --   for i, node in pairs(siblings) do
+      --     if node.id == parent.id then
+      --       item.name = parent.name .. utils.path_separator .. item.name
+      --       item.level = level - 1
+      --       item.is_loaded = utils.truthy(item.children)
+      --       siblings[i] = NuiTree.Node(item, item.children)
+      --       break
+      --     end
+      --   end
+      --   sourceItems = nil -- this is a signal to skip the rest of the processing
+      --   state.tree:set_nodes(siblings, parentId)
+      -- end
     else
       -- if we are rendering a whole tree, just group the children because we don'the
       -- want to change the root nodes

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1115,34 +1115,38 @@ M.show_nodes = function(sourceItems, state, parentId, callback)
 
   if state.group_empty_dirs then
     if parent then
-      for i, item in ipairs(sourceItems) do
-        sourceItems[i] = group_empty_dirs(item)
+      local scan_mode = require("neo-tree").config.filesystem.scan_mode
+      if scan_mode == "deep" then
+        for i, item in ipairs(sourceItems) do
+          sourceItems[i] = group_empty_dirs(item)
+        end
+      else
+        -- this is a lazy load of a single sub folder
+        group_empty_dirs(sourceItems)
+        if #sourceItems == 1 and sourceItems[1].type == "directory" then
+          -- This folder needs to be grouped.
+          -- The goal is to just update the existing node in place.
+          -- To avoid digging into private internals of Nui, we will just export the entire level and replace
+          -- the one node. This keeps it in the right order, because nui doesn't have methods to replace something
+          -- in place.
+          -- We can't just mutate the existing node because we have to change it's id which would break Nui's
+          -- internal state.
+          local item = sourceItems[1]
+          parentId = parent:get_parent_id()
+          local siblings = state.tree:get_nodes(parentId)
+          for i, node in pairs(siblings) do
+            if node.id == parent.id then
+              item.name = parent.name .. utils.path_separator .. item.name
+              item.level = level - 1
+              item.is_loaded = utils.truthy(item.children)
+              siblings[i] = NuiTree.Node(item, item.children)
+              break
+            end
+          end
+          sourceItems = nil -- this is a signal to skip the rest of the processing
+          state.tree:set_nodes(siblings, parentId)
+        end
       end
-      -- this is a lazy load of a single sub folder
-      -- group_empty_dirs(sourceItems)
-      -- if #sourceItems == 1 and sourceItems[1].type == "directory" then
-      --   -- This folder needs to be grouped.
-      --   -- The goal is to just update the existing node in place.
-      --   -- To avoid digging into private internals of Nui, we will just export the entire level and replace
-      --   -- the one node. This keeps it in the right order, because nui doesn't have methods to replace something
-      --   -- in place.
-      --   -- We can't just mutate the existing node because we have to change it's id which would break Nui's
-      --   -- internal state.
-      --   local item = sourceItems[1]
-      --   parentId = parent:get_parent_id()
-      --   local siblings = state.tree:get_nodes(parentId)
-      --   for i, node in pairs(siblings) do
-      --     if node.id == parent.id then
-      --       item.name = parent.name .. utils.path_separator .. item.name
-      --       item.level = level - 1
-      --       item.is_loaded = utils.truthy(item.children)
-      --       siblings[i] = NuiTree.Node(item, item.children)
-      --       break
-      --     end
-      --   end
-      --   sourceItems = nil -- this is a signal to skip the rest of the processing
-      --   state.tree:set_nodes(siblings, parentId)
-      -- end
     else
       -- if we are rendering a whole tree, just group the children because we don'the
       -- want to change the root nodes


### PR DESCRIPTION
This PR implements open/closed states for empty folders which is required in order to complete [my other PR](https://github.com/nvim-neo-tree/neo-tree.nvim/pull/522).

This involved actively checking wheter newly revealed folder nodes are empty and if so, showing the "empty folder" icon directly. This led me to the idea to also check if the folder contains only a single child directory. By applying this check recursively, and scanning down the chain such directories, neo-tree will directly display all grouped directories if "group_empty_directories" is set. This recursive scanning will not recursively explode and scan exponentially many nodes, as it only scans what really needs to be shown in the tree. (See the GIF below).

[![neo-tree-demo.gif](https://s4.gifyu.com/images/neo-tree-demo.gif)](https://gifyu.com/image/SEVT7)

This PR is still a WIP and before I proceed I would like to get some feedback on the following points:
1. Is this functionality appreciated?
2. As of now, I basically rewrote `sync_scan` and `async_scan` in `fs_scan.lua`. Would you want to make this the default behaviour or should it be opt-in setting a new config option (for example "prescan_empty_folders")?
3. In the original implementation of `sync_scan` and `async_scan` there is the possibility to scan recusively based on what is set in `context-recursive`. From what I could tell, recusive option only behaved correctly in sync version (and of course blocked neovim if opening neo-tree in large projects.) Is this code path actively used? If yes and in case my implementation would become the default, I would have to add this recursive behaviour to the new implementation as well.

Best,
Zenoli