### PR TITLE
fix(git): make `mark_ignored` async

### DIFF
--- a/tests/neo-tree/ui/icons_spec.lua
+++ b/tests/neo-tree/ui/icons_spec.lua
@@ -68,6 +68,8 @@ describe("ui/icons", function()
 
       vim.api.nvim_win_set_cursor(winid, { 3, 0 })
       u.feedkeys("<CR>")
+            
+      vim.wait(100)
 
       u.assert_buf_lines(bufnr, {
         string.format("  %s", fs_tree.abspath):sub(1, 42),
@@ -105,6 +107,8 @@ describe("ui/icons", function()
 
       vim.api.nvim_win_set_cursor(winid, { 3, 0 })
       u.feedkeys("<CR>")
+            
+      vim.wait(100)
 
       u.assert_buf_lines(bufnr, {
         vim.fn.strcharpart(string.format("  %s", fs_tree.abspath), 0, 40),
@@ -166,6 +170,8 @@ describe("ui/icons", function()
 
       vim.api.nvim_win_set_cursor(winid, { 3, 0 })
       u.feedkeys("<CR>")
+            
+      vim.wait(100)
 
       u.assert_buf_lines(bufnr, {
         string.format(" o %s", fs_tree.abspath):sub(1, 40),
@@ -203,6 +209,8 @@ describe("ui/icons", function()
 
       vim.api.nvim_win_set_cursor(winid, { 3, 0 })
       u.feedkeys("<CR>")
+            
+      vim.wait(100)
 
       u.assert_buf_lines(bufnr, {
         vim.fn.strcharpart(string.format(" o %s", fs_tree.abspath), 0, 40),


### PR DESCRIPTION
This PR introduces an alternative async interface for `git.mark_ignored`. By providing a callback to the function, it will run the git operations via `luv.spawn` instead of `vim.fn.systemlist`.
In the async interface, the files to be checked are fed through the stdin, instead of through the CLI arguments. This is because certain collection of filenames causes `luv` to fail to spawn the git process (maybe because of the length or certain unicode characters?). If there are any performance issues caused by the pipe method, I'll try to investigate further on it.