### PR TITLE
fix: cancel close_if_last_window if there is an unnamed modified buffer, fixes #605

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -222,9 +222,33 @@ M.win_enter_event = function()
     log.trace("win_count: ", win_count)
     if prior_exists and win_count == 1 and vim.o.filetype == "neo-tree" then
       local position = vim.api.nvim_buf_get_var(0, "neo_tree_position")
+      local source = vim.api.nvim_buf_get_var(0, "neo_tree_source")
       if position ~= "current" then
         -- close_if_last_window just doesn't make sense for a split style
         log.trace("last window, closing")
+        local state = require("neo-tree.sources.manager").get_state(source)
+        if state == nil then
+          return
+        end
+        local mod = utils.get_modified_buffers()
+        log.debug("close_if_last_window, modified files found: ", vim.inspect(mod))
+        for filename, is_modified in pairs(mod) do
+          if is_modified then
+            if vim.startswith(filename, "[No Name]#") then
+              bufnr = string.sub(filename, 11)
+              log.trace("close_if_last_window, showing unnamed modified buffer: ", filename)
+              vim.schedule(function()
+                log.warn(
+                  "Cannot close because an unnamed buffer is modified. Please save or discard this file."
+                )
+                vim.cmd("vsplit")
+                vim.api.nvim_win_set_width(win_id, state.window.width or 40)
+                vim.cmd("b" .. bufnr)
+              end)
+              return
+            end
+          end
+        end
         vim.cmd("q!")
         return
       end

--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -209,6 +209,9 @@ M.get_modified_buffers = function()
   local modified_buffers = {}
   for _, buffer in ipairs(vim.api.nvim_list_bufs()) do
     local buffer_name = vim.api.nvim_buf_get_name(buffer)
+    if buffer_name == nil or buffer_name == "" then
+      buffer_name = "[No Name]#" .. buffer
+    end
     modified_buffers[buffer_name] = vim.api.nvim_buf_get_option(buffer, "modified")
   end
   return modified_buffers


### PR DESCRIPTION
This fixes the situation described in #605 

The new strategy is to detect if there is an unnamed modified buffer, and if there is, it will open it and show a warning message.