### PR TITLE
feat(git): async git interface for `get_repository_root`

### DIFF
--- a/lua/neo-tree/git/status.lua
+++ b/lua/neo-tree/git/status.lua
@@ -201,129 +201,136 @@ local function parse_lines_batch(context, job_complete_callback)
 end
 
 M.status_async = function(path, base, opts)
-  local git_root = git_utils.get_repository_root(path)
-  if utils.truthy(git_root) then
-    log.trace("git.status.status_async called")
-  else
-    log.trace("status_async: not a git folder: ", path)
-    return false
-  end
-
-  local event_id = "git_status_" .. git_root
-  local context = {
-    git_root = git_root,
-    git_status = {},
-    exclude_directories = false,
-    lines = {},
-    lines_parsed = 0,
-    batch_size = opts.batch_size or 1000,
-    batch_delay = opts.batch_delay or 10,
-    max_lines = opts.max_lines or 100000,
-  }
-
-  local should_process = function(err, line, job, err_msg)
-    if vim.v.dying > 0 or vim.v.exiting ~= vim.NIL then
-      job:shutdown()
-      return false
-    end
-    if err and err > 0 then
-      log.error(err_msg, err, line)
-      return false
-    end
-    return true
-  end
-
-  local job_complete_callback = function()
-    utils.debounce(event_id, nil, nil, nil, utils.debounce_action.COMPLETE_ASYNC_JOB)
-    vim.schedule(function()
-      events.fire_event(events.GIT_STATUS_CHANGED, {
-        git_root = context.git_root,
-        git_status = context.git_status,
-      })
-    end)
-  end
-
-  local parse_lines = vim.schedule_wrap(function()
-    parse_lines_batch(context, job_complete_callback)
-  end)
-
-  utils.debounce(event_id, function()
-    local staged_job = Job:new({
-      command = "git",
-      args = { "-C", git_root, "diff", "--staged", "--name-status", base, "--" },
-      enable_recording = false,
-      maximium_results = context.max_lines,
-      on_stdout = vim.schedule_wrap(function(err, line, job)
-        if should_process(err, line, job, "status_async staged error:") then
-          table.insert(context.lines, line)
-        end
-      end),
-      on_stderr = function(err, line)
-        if err and err > 0 then
-          log.error("status_async staged error: ", err, line)
-        end
-      end,
-    })
-
-    local unstaged_job = Job:new({
-      command = "git",
-      args = { "-C", git_root, "diff", "--name-status" },
-      enable_recording = false,
-      maximium_results = context.max_lines,
-      on_stdout = vim.schedule_wrap(function(err, line, job)
-        if should_process(err, line, job, "status_async unstaged error:") then
-          if line then
-            line = " " .. line
-          end
-          table.insert(context.lines, line)
-        end
-      end),
-      on_stderr = function(err, line)
-        if err and err > 0 then
-          log.error("status_async unstaged error: ", err, line)
-        end
-      end,
-    })
-
-    local untracked_job = Job:new({
-      command = "git",
-      args = { "-C", git_root, "ls-files", "--exclude-standard", "--others" },
-      enable_recording = false,
-      maximium_results = context.max_lines,
-      on_stdout = vim.schedule_wrap(function(err, line, job)
-        if should_process(err, line, job, "status_async untracked error:") then
-          if line then
-            line = "?	" .. line
-          end
-          table.insert(context.lines, line)
-        end
-      end),
-      on_stderr = function(err, line)
-        if err and err > 0 then
-          log.error("status_async untracked error: ", err, line)
-        end
-      end,
-    })
-
-    local showUntracked = vim.fn.systemlist({
-      "git",
-      "-C",
-      git_root,
-      "config",
-      "--get",
-      "status.showUntrackedFiles",
-    })
-    log.debug("git status.showUntrackedFiles =", showUntracked[1])
-    if showUntracked[1] == "no" then
-      unstaged_job:after(parse_lines)
-      Job.chain(staged_job, unstaged_job)
+  git_utils.get_repository_root(path, function(git_root)
+    if utils.truthy(git_root) then
+      log.trace("git.status.status_async called")
     else
-      untracked_job:after(parse_lines)
-      Job.chain(staged_job, unstaged_job, untracked_job)
+      log.trace("status_async: not a git folder: ", path)
+      return false
     end
-  end, 1000, utils.debounce_strategy.CALL_FIRST_AND_LAST, utils.debounce_action.START_ASYNC_JOB)
 
-  return true
+    local event_id = "git_status_" .. git_root
+    local context = {
+      git_root = git_root,
+      git_status = {},
+      exclude_directories = false,
+      lines = {},
+      lines_parsed = 0,
+      batch_size = opts.batch_size or 1000,
+      batch_delay = opts.batch_delay or 10,
+      max_lines = opts.max_lines or 100000,
+    }
+
+    local should_process = function(err, line, job, err_msg)
+      if vim.v.dying > 0 or vim.v.exiting ~= vim.NIL then
+        job:shutdown()
+        return false
+      end
+      if err and err > 0 then
+        log.error(err_msg, err, line)
+        return false
+      end
+      return true
+    end
+
+    local job_complete_callback = function()
+      utils.debounce(event_id, nil, nil, nil, utils.debounce_action.COMPLETE_ASYNC_JOB)
+      vim.schedule(function()
+        events.fire_event(events.GIT_STATUS_CHANGED, {
+          git_root = context.git_root,
+          git_status = context.git_status,
+        })
+      end)
+    end
+
+    local parse_lines = vim.schedule_wrap(function()
+      parse_lines_batch(context, job_complete_callback)
+    end)
+
+    utils.debounce(event_id, function()
+      local staged_job = Job:new({
+        command = "git",
+        args = { "-C", git_root, "diff", "--staged", "--name-status", base, "--" },
+        enable_recording = false,
+        maximium_results = context.max_lines,
+        on_stdout = vim.schedule_wrap(function(err, line, job)
+          if should_process(err, line, job, "status_async staged error:") then
+            table.insert(context.lines, line)
+          end
+        end),
+        on_stderr = function(err, line)
+          if err and err > 0 then
+            log.error("status_async staged error: ", err, line)
+          end
+        end,
+      })
+
+      local unstaged_job = Job:new({
+        command = "git",
+        args = { "-C", git_root, "diff", "--name-status" },
+        enable_recording = false,
+        maximium_results = context.max_lines,
+        on_stdout = vim.schedule_wrap(function(err, line, job)
+          if should_process(err, line, job, "status_async unstaged error:") then
+            if line then
+              line = " " .. line
+            end
+            table.insert(context.lines, line)
+          end
+        end),
+        on_stderr = function(err, line)
+          if err and err > 0 then
+            log.error("status_async unstaged error: ", err, line)
+          end
+        end,
+      })
+
+      local untracked_job = Job:new({
+        command = "git",
+        args = { "-C", git_root, "ls-files", "--exclude-standard", "--others" },
+        enable_recording = false,
+        maximium_results = context.max_lines,
+        on_stdout = vim.schedule_wrap(function(err, line, job)
+          if should_process(err, line, job, "status_async untracked error:") then
+            if line then
+              line = "?	" .. line
+            end
+            table.insert(context.lines, line)
+          end
+        end),
+        on_stderr = function(err, line)
+          if err and err > 0 then
+            log.error("status_async untracked error: ", err, line)
+          end
+        end,
+      })
+
+      Job:new({
+        command = "git",
+        args = {
+          "-C",
+          git_root,
+          "config",
+          "--get",
+          "status.showUntrackedFiles",
+        },
+        enabled_recording = true,
+        on_exit = function(self, _, _)
+          local result = self:result()
+          log.debug("git status.showUntrackedFiles =", result[1])
+          if result[1] == "no" then
+            unstaged_job:after(parse_lines)
+            Job.chain(staged_job, unstaged_job)
+          else
+            untracked_job:after(parse_lines)
+            Job.chain(staged_job, unstaged_job, untracked_job)
+          end
+        end,
+      }):start()
+    end, 1000, utils.debounce_strategy.CALL_FIRST_AND_LAST, utils.debounce_action.START_ASYNC_JOB)
+
+    return true
+  end)
 end
 
 return M

--- a/lua/neo-tree/git/utils.lua
+++ b/lua/neo-tree/git/utils.lua
@@ -1,26 +1,51 @@
+local Job = require("plenary.job")
+
 local utils = require("neo-tree.utils")
 local log = require("neo-tree.log")
 
 local M = {}
 
-M.get_repository_root = function(path)
-  local cmd = { "git", "rev-parse", "--show-toplevel" }
+M.get_repository_root = function(path, callback)
+  local args = { "rev-parse", "--show-toplevel" }
   if utils.truthy(path) then
-    cmd = { "git", "-C", path, "rev-parse", "--show-toplevel" }
+    args = { "-C", path, "rev-parse", "--show-toplevel" }
   end
-  local ok, git_root = utils.execute_command(cmd)
-  if not ok then
-    log.trace("GIT ROOT ERROR ", git_root)
-    return nil
-  end
-  git_root = git_root[1]
+  if type(callback) == "function" then
+    Job:new({
+      command = "git",
+      args = args,
+      enabled_recording = true,
+      on_exit = function(self, code, _)
+        if code ~= 0 then
+          log.trace("GIT ROOT ERROR ", self:stderr_result())
+          callback(nil)
+          return
+        end
+        local git_root = self:result()[1]
 
-  if utils.is_windows then
-    git_root = utils.windowize_path(git_root)
-  end
+        if utils.is_windows then
+          git_root = utils.windowize_path(git_root)
+        end
 
-  log.trace("GIT ROOT for '", path, "' is '", git_root, "'")
-  return git_root
+        log.trace("GIT ROOT for '", path, "' is '", git_root, "'")
+        callback(git_root)
+      end,
+    }):start()
+  else
+    local ok, git_root = utils.execute_command({ "git", unpack(args) })
+    if not ok then
+      log.trace("GIT ROOT ERROR ", git_root)
+      return nil
+    end
+    git_root = git_root[1]
+
+    if utils.is_windows then
+      git_root = utils.windowize_path(git_root)
+    end
+
+    log.trace("GIT ROOT for '", path, "' is '", git_root, "'")
+    return git_root
+  end
 end
 
 return M

--- a/lua/neo-tree/log.lua
+++ b/lua/neo-tree/log.lua
@@ -57,11 +57,8 @@ end
 log.new = function(config, standalone)
   config = vim.tbl_deep_extend("force", default_config, config)
 
-  local outfile = string.format(
-    "%s/%s.log",
-    vim.api.nvim_call_function("stdpath", { "data" }),
-    config.plugin
-  )
+  local outfile =
+    string.format("%s/%s.log", vim.api.nvim_call_function("stdpath", { "data" }), config.plugin)
 
   local obj
   if standalone then

--- a/lua/neo-tree/setup/deprecations.lua
+++ b/lua/neo-tree/setup/deprecations.lua
@@ -41,11 +41,8 @@ M.migrate = function(config)
       end
       utils.set_value(config, new, exising)
       config[old] = nil
-      migrations[#migrations + 1] = string.format(
-        "The `%s` option has been deprecated, please use `%s` instead.",
-        old,
-        new
-      )
+      migrations[#migrations + 1] =
+        string.format("The `%s` option has been deprecated, please use `%s` instead.", old, new)
     end
   end
 
@@ -61,12 +58,8 @@ M.migrate = function(config)
     local value = utils.get_value(config, key)
     if value == old_value then
       utils.set_value(config, key, new_value)
-      migrations[#migrations + 1] = string.format(
-        "The `%s=%s` option has been renamed to `%s`.",
-        key,
-        old_value,
-        new_value
-      )
+      migrations[#migrations + 1] =
+        string.format("The `%s=%s` option has been renamed to `%s`.", key, old_value, new_value)
     end
   end
 

--- a/lua/neo-tree/sources/filesystem/lib/filter_external.lua
+++ b/lua/neo-tree/sources/filesystem/lib/filter_external.lua
@@ -138,40 +138,38 @@ M.find_files = function(opts)
   end
   local item_count = 0
   local over_limit = false
-  Job
-    :new({
-      command = cmd,
-      cwd = path,
-      args = args,
-      enable_recording = false,
-      on_stdout = function(err, line)
-        if not over_limit then
-          if opts.on_insert then
-            opts.on_insert(err, line)
+  Job:new({
+    command = cmd,
+    cwd = path,
+    args = args,
+    enable_recording = false,
+    on_stdout = function(err, line)
+      if not over_limit then
+        if opts.on_insert then
+          opts.on_insert(err, line)
+        end
+        item_count = item_count + 1
+        over_limit = maximum_results and item_count > maximum_results
+      end
+    end,
+    on_stderr = function(err, line)
+      if not over_limit then
+        if opts.on_insert then
+          if not err then
+            err = line
           end
-          item_count = item_count + 1
-          over_limit = maximum_results and item_count > maximum_results
+          opts.on_insert(err, line)
         end
-      end,
-      on_stderr = function(err, line)
-        if not over_limit then
-          if opts.on_insert then
-            if not err then
-              err = line
-            end
-            opts.on_insert(err, line)
-          end
-          item_count = item_count + 1
-          over_limit = maximum_results and item_count > maximum_results
-        end
-      end,
-      on_exit = function(_, return_val)
-        if opts.on_exit then
-          opts.on_exit(return_val)
-        end
-      end,
-    })
-    :start()
+        item_count = item_count + 1
+        over_limit = maximum_results and item_count > maximum_results
+      end
+    end,
+    on_exit = function(_, return_val)
+      if opts.on_exit then
+        opts.on_exit(return_val)
+      end
+    end,
+  }):start()
 end
 
 return M

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -82,7 +82,7 @@ local render_context = function(context)
     if root.is_link then
       path = root.link_to
     end
-    fs_watch.watch_git_index(path)
+    fs_watch.watch_git_index(path, require("neo-tree").config.git_status_async)
   end
   fs_watch.updated_watched()
 
@@ -365,7 +365,7 @@ M.stop_watchers = function(state)
     local loaded_folders = renderer.select_nodes(state.tree, function(node)
       return node.type == "directory" and node.loaded
     end)
-    fs_watch.unwatch_git_index(state.path)
+    fs_watch.unwatch_git_index(state.path, require("neo-tree").config.git_status_async)
     for _, folder in ipairs(loaded_folders) do
       log.trace("Unwatching folder ", folder.path)
       if folder.is_link then

--- a/lua/neo-tree/sources/filesystem/lib/fs_watch.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_watch.lua
@@ -14,16 +14,30 @@ local flags = {
 
 local watched = {}
 
-local get_dot_git_folder = function(path)
-  local git_root = git.get_repository_root(path)
-  if git_root then
-    local git_folder = utils.path_join(git_root, ".git")
-    local stat = vim.loop.fs_stat(git_folder)
-    if stat and stat.type == "directory" then
-      return git_folder, git_root
+local get_dot_git_folder = function(path, callback)
+  if type(callback) == "function" then
+    git.get_repository_root(path, function(git_root)
+      if git_root then
+        local git_folder = utils.path_join(git_root, ".git")
+        local stat = vim.loop.fs_stat(git_folder)
+        if stat and stat.type == "directory" then
+          callback(git_folder, git_root)
+        end
+      else
+        callback(nil, nil)
+      end
+    end)
+  else
+    local git_root = git.get_repository_root(path)
+    if git_root then
+      local git_folder = utils.path_join(git_root, ".git")
+      local stat = vim.loop.fs_stat(git_folder)
+      if stat and stat.type == "directory" then
+        return git_folder, git_root
+      end
     end
+    return nil, nil
   end
-  return nil, nil
 end
 
 M.show_watched = function()
@@ -76,25 +90,32 @@ M.watch_folder = function(path, custom_callback, allow_git_watch)
   h.references = h.references + 1
 end
 
-M.watch_git_index = function(path)
-  local git_folder, git_root = get_dot_git_folder(path)
-  if git_folder then
-    local git_event_callback = vim.schedule_wrap(function(err, fname)
-      if fname and fname:match("^.+%.lock$") then
-        return
-      end
-      if fname and fname:match("^%._null-ls_.+") then
-        -- null-ls temp file: https://github.com/jose-elias-alvarez/null-ls.nvim/pull/1075
-        return
-      end
-      if err then
-        log.error("git_event_callback: ", err)
-        return
-      end
-      events.fire_event(events.GIT_EVENT, { path = fname, repository = git_root })
-    end)
+M.watch_git_index = function(path, async)
+  local function watch_git_folder(git_folder, git_root)
+    if git_folder then
+      local git_event_callback = vim.schedule_wrap(function(err, fname)
+        if fname and fname:match("^.+%.lock$") then
+          return
+        end
+        if fname and fname:match("^%._null-ls_.+") then
+          -- null-ls temp file: https://github.com/jose-elias-alvarez/null-ls.nvim/pull/1075
+          return
+        end
+        if err then
+          log.error("git_event_callback: ", err)
+          return
+        end
+        events.fire_event(events.GIT_EVENT, { path = fname, repository = git_root })
+      end)
 
-    M.watch_folder(git_folder, git_event_callback, true)
+      M.watch_folder(git_folder, git_event_callback, true)
+    end
+  end
+
+  if async then
+    get_dot_git_folder(path, watch_git_folder)
+  else
+    watch_git_folder(get_dot_git_folder(path))
   end
 end
 
@@ -129,10 +150,17 @@ M.unwatch_folder = function(path, callback_id)
   end
 end
 
-M.unwatch_git_index = function(path)
-  local git_folder = get_dot_git_folder(path)
-  if git_folder then
-    M.unwatch_folder(git_folder)
+M.unwatch_git_index = function(path, async)
+  local function unwatch_git_folder(git_folder, _)
+    if git_folder then
+      M.unwatch_folder(git_folder)
+    end
+  end
+
+  if async then
+    get_dot_git_folder(path, unwatch_git_folder)
+  else
+    unwatch_git_folder(get_dot_git_folder(path))
   end
 end
 

--- a/lua/neo-tree/ui/highlights.lua
+++ b/lua/neo-tree/ui/highlights.lua
@@ -191,12 +191,8 @@ M.get_faded_highlight_group = function(hl_group_name, fade_percentage)
   local green = (f_green * fade_percentage) + (b_green * (1 - fade_percentage))
   local blue = (f_blue * fade_percentage) + (b_blue * (1 - fade_percentage))
 
-  local new_foreground = string.format(
-    "%s%s%s",
-    dec_to_hex(red, 2),
-    dec_to_hex(green, 2),
-    dec_to_hex(blue, 2)
-  )
+  local new_foreground =
+    string.format("%s%s%s", dec_to_hex(red, 2), dec_to_hex(green, 2), dec_to_hex(blue, 2))
 
   M.create_highlight_group(key, {}, hl_group.background, new_foreground, gui)
   faded_highlight_group_cache[key] = key
@@ -220,12 +216,8 @@ M.setup = function()
 
   M.create_highlight_group(M.END_OF_BUFFER, { "EndOfBuffer" })
 
-  local float_border_hl = M.create_highlight_group(
-    M.FLOAT_BORDER,
-    { "FloatBorder" },
-    normalnc_hl.background,
-    "444444"
-  )
+  local float_border_hl =
+    M.create_highlight_group(M.FLOAT_BORDER, { "FloatBorder" }, normalnc_hl.background, "444444")
 
   M.create_highlight_group(M.FLOAT_TITLE, {}, float_border_hl.background, normal_hl.foreground)
 

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -284,13 +284,8 @@ end
 M.render_component = function(component, item, state, remaining_width)
   local component_func = state.components[component[1]]
   if component_func then
-    local success, component_data, wanted_width = pcall(
-      component_func,
-      component,
-      item,
-      state,
-      remaining_width
-    )
+    local success, component_data, wanted_width =
+      pcall(component_func, component, item, state, remaining_width)
     if success then
       if component_data == nil then
         return { {} }
@@ -361,12 +356,8 @@ local prepare_node = function(item, state)
       remaining_cols = math.min(remaining_cols, longest + 4)
     end
     for _, component in ipairs(renderer) do
-      local component_data, component_wanted_width = M.render_component(
-        component,
-        item,
-        state,
-        remaining_cols
-      )
+      local component_data, component_wanted_width =
+        M.render_component(component, item, state, remaining_cols)
       local actual_width = 0
       if component_data then
         for _, data in ipairs(component_data) do

--- a/lua/neo-tree/ui/selector.lua
+++ b/lua/neo-tree/ui/selector.lua
@@ -227,11 +227,8 @@ M.get = function()
     return
   else
     local config = require("neo-tree").config
-    local scrolled_off = utils.resolve_config_option(
-      config,
-      "source_selector.show_scrolled_off_parent_node",
-      false
-    )
+    local scrolled_off =
+      utils.resolve_config_option(config, "source_selector.show_scrolled_off_parent_node", false)
     if scrolled_off then
       local node_text = M.get_scrolled_off_node_text(state)
       if node_text ~= nil then


### PR DESCRIPTION
This adds a callback argument to `git.utils.get_repository_root`, which allows the function to be called asynchronously.
Callers are also adjusted so that it respects the `async_git_status` option.

Also, I've been wondering, is it really necessary to have synchronous support at all? As long as the asynchronous version is implemented correctly, I can't imagine a user that would prefer to use the synchronous version. 

Once the async paths are battle-tested and its rough edges polished, what do you think about dropping non-async support in the next major version? I feel that it would simplify the codebase.