### PR TITLE
fix(fs): check window is valid before replacing buffers

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -45,7 +45,7 @@ end
 ---@param new_buf number
 local function replace_buffer_in_windows(old_buf, new_buf)
   for _, win in ipairs(vim.api.nvim_list_wins()) do
-    if vim.api.nvim_win_get_buf(win) == old_buf then
+    if vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_buf(win) == old_buf then
       vim.api.nvim_win_set_buf(win, new_buf)
     end
   end


### PR DESCRIPTION
Fix #632

Admittedly I did not do much debugging to find out what the actual issue is (e.g. are we assuming that the window should be valid, and it not being messes with something else?), however in any case it seems logical to check first that the window we are targeting is indeed valid before trying to call functions on it.