### PR TITLE
fix: no cursorline when using cursorlineopt=number

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -105,6 +105,7 @@ M.buffer_enter_event = function()
     end
     vim.cmd([[
     setlocal cursorline
+    setlocal cursorlineopt=line
     setlocal nowrap
     setlocal nolist nospell nonumber norelativenumber
     ]])


### PR DESCRIPTION
Small fix to set `cursorlineopt=line` to ensure a visible cursorline when `cursorlineopt=number` is set globally.