### PR TITLE
fix(fs_actions): check window valid on close buf

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -24,7 +24,7 @@ local function clear_buffer(path)
   local alt = vim.fn.bufnr("#")
   -- Check all windows to see if they are using the buffer
   for _, win in ipairs(vim.api.nvim_list_wins()) do
-    if vim.api.nvim_win_get_buf(win) == buf then
+    if vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_buf(win) == buf then
       -- if there is no alternate buffer yet, create a blank one now
       if alt < 1 or alt == buf then
         alt = vim.api.nvim_create_buf(true, false)


### PR DESCRIPTION
Same thing as #644 but when removing an item rather than closing it.

Checked a few other places that window operations are done (specifically `nvim_win_get_buf`) and most don't have as simple of a path forward if the window is not valid, or apply to the Neotree window itself where we are often sure beforehand that it is indeed valid.