### PR TITLE
feat (fs_actions): add brace expansion for creating files / folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,12 +214,13 @@ use {
             --["Z"] = "expand_all_nodes",
             ["a"] = { 
               "add",
+              -- this command supports BASH style brace expansion ("x{a,b,c}" -> xa,xb,xc). see `:h neo-tree-file-actions` for details
               -- some commands may take optional config options, see `:h neo-tree-mappings` for details
               config = {
                 show_path = "none" -- "none", "relative", "absolute"
               }
             },
-            ["A"] = "add_directory", -- also accepts the optional config.show_path option like "add".
+            ["A"] = "add_directory", -- also accepts the optional config.show_path option like "add". this also supports BASH style brace expansion.
             ["d"] = "delete",
             ["r"] = "rename",
             ["y"] = "copy_to_clipboard",

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -243,9 +243,21 @@ a    = add:                  Create a new file OR directory. Add a `/` to the
                              `"absolute"`: is the full path to the current
                                          directory.
 
+                             The file path also supports BASH style brace
+                             expansion. sequence style ("{00..05..2}") as well
+                             as nested braces. Here are some examples how this
+                             expansion works.
+
+                             "x{a..e..2}"           : "xa", "xc", "xe"
+                             "file.txt{,.bak}"      : "file.txt", "file.txt.bak"
+                             "./{a,b}/{00..02}.lua" : "./a/00.lua", "./a/01.lua",
+                                                      "./a/02.lua", "./b/00.lua",
+                                                      "./b/01.lua", "./b/02.lua"
+
 A    = add_directory:        Create a new directory, in this mode it does not
-                             need to end with a `/`. Also accepts
-                             `config.show_path` options
+                             need to end with a `/`. The path also supports
+                             BASH style brace expansion as explained in `add`
+                             command. Also accepts `config.show_path` options
 
 d    = delete:               Delete the selected file or directory.
                              Supports visual selection.~


### PR DESCRIPTION
Hi, big thanks for the nice plugin again.

This PR aims to implement the brace expansion feature just like BASH (probly POSIX compatible?) shell as suggested in #647.

The core implementation is in `require("neo-tree.utils").brace_expand(s)` which handles all expansion and return a list of strings being expanded. If no expansion is found, it returns a one-element list with the raw input.

The calculation is not done by using the shell or anything and is just emulated inside lua, meaning that Windows users can also use this feature with the bash syntax.

## More Testing Needed!!

I am pretty sure I was able to cover all edge cases but it would be nice if anyone could double check if I hadn't screwed up anything.
The basic syntax of bash brace expansion can be found [here](https://effective-shell.com/part-6-advanced-techniques/understanding-shell-expansion/) or [here](https://facelessuser.github.io/bracex/) or by googling.

Here are some examples I checked myself.
| Input                    | Output                                                                                   |
| ------------------------ | ---------------------------------------------------------------------------------------- |
| `"x{a..e..2}"`           | `{ "xa", "xc", "xe" }`                                                                   |
| `"file.txt{,.bak}"`      | `{ "file.txt", "file.txt.bak" }`                                                         |
| `"./{a,b}/{00..02}.lua"` | `{ "./a/00.lua", "./a/01.lua", "./a/02.lua", "./b/00.lua", "./b/01.lua", "./b/02.lua" }` |

## README

I would be very happy if you could mention this feature in the README.

I do not know any other file explorer-like plugin in vim / neovim that has this feature and I think this would be a killing feature against the other options :)

Best,
pysan3