### PR TITLE
feat: add focus_preview command

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ use {
             ["<cr>"] = "open",
             ["<esc>"] = "revert_preview",
             ["P"] = { "toggle_preview", config = { use_float = true } },
+            ["gp"] = "focus_preview"
             ["S"] = "open_split",
             ["s"] = "open_vsplit",
             -- ["S"] = "split_with_window_picker",

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ use {
             ["<cr>"] = "open",
             ["<esc>"] = "revert_preview",
             ["P"] = { "toggle_preview", config = { use_float = true } },
-            ["gp"] = "focus_preview"
+            ["l"] = "focus_preview"
             ["S"] = "open_split",
             ["s"] = "open_vsplit",
             -- ["S"] = "split_with_window_picker",

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -195,6 +195,8 @@ z         = close_all_nodes: Close all nodes in the tree.
 
 P          = toggle_preview: Toggles "preview mode", see |neo-tree-preview-mode| 
 
+gp         = focus_preview: Focuses active preview window
+
 <esc>      = revert_preview: Ends "preview_mode" if it is enabled, and reverts
                              any preview windows to what was being shown before
                              preview mode began.

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -195,7 +195,7 @@ z         = close_all_nodes: Close all nodes in the tree.
 
 P          = toggle_preview: Toggles "preview mode", see |neo-tree-preview-mode| 
 
-gp         = focus_preview: Focuses active preview window
+l          = focus_preview: Focus the active preview window
 
 <esc>      = revert_preview: Ends "preview_mode" if it is enabled, and reverts
                              any preview windows to what was being shown before

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -312,7 +312,7 @@ local config = {
       ["<cr>"] = "open",
       ["<esc>"] = "revert_preview",
       ["P"] = { "toggle_preview", config = { use_float = true } },
-      ["gp"] = "focus_preview",
+      ["l"] = "focus_preview",
       ["S"] = "open_split",
       -- ["S"] = "split_with_window_picker",
       ["s"] = "open_vsplit",

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -312,6 +312,7 @@ local config = {
       ["<cr>"] = "open",
       ["<esc>"] = "revert_preview",
       ["P"] = { "toggle_preview", config = { use_float = true } },
+      ["gp"] = "focus_preview",
       ["S"] = "open_split",
       -- ["S"] = "split_with_window_picker",
       ["s"] = "open_vsplit",

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -487,6 +487,10 @@ M.toggle_preview = function(state)
   Preview.toggle(state)
 end
 
+M.focus_preview = function()
+  Preview.focus()
+end
+
 ---Open file or directory
 ---@param state table The state of the source
 ---@param open_cmd string The vim command to use to open the file

--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -393,7 +393,7 @@ Preview.toggle = function(state)
     local preview_event = {
       event = events.VIM_CURSOR_MOVED,
       handler = function()
-        if not toggle_state then
+        if not toggle_state or vim.api.nvim_get_current_win() == instance.winid then
           return
         end
         if vim.api.nvim_get_current_win() == winid then
@@ -407,6 +407,12 @@ Preview.toggle = function(state)
       id = "preview-event",
     }
     instance:subscribe(source_name, preview_event)
+  end
+end
+
+Preview.focus = function()
+  if Preview.is_active() then
+    vim.fn.win_gotoid(instance.winid)
   end
 end
 


### PR DESCRIPTION
#672 

>Once you are in the preview window, it would be nice to add just two extra mappings:
>
>- One to close the window and end preview mode
>- One to move the cursor back to neo-tree

I didn't implement such additional mappings. 

- Moving the cursor back to the neo-tree: I don't think an additional mapping is necessary as this can be done with the present `:Neotree` commands and with vims window movement keys (`<C-w>h` `<C-w>` and the user-defined equivalents to it) etc..

- Close preview: I was not 100% sure about this one. But I also left it out for now, since the window can be closed with the standard commands for closing windows (i.e. `:q`). Users can also assign buffer local commands to close popup windows. But I can certainly see a use case for implementing this to make it specific to the preview. Please let me know what you think about how it could be implemented (Should it be another separate command to close the focused preview window?)