### PR TITLE
fix(queue): don't go to next node if it has been removed

### DIFF
--- a/lua/neo-tree/events/queue.lua
+++ b/lua/neo-tree/events/queue.lua
@@ -71,10 +71,12 @@ function Queue:for_each(func)
   local node = self._list.head
   while node ~= nil do
     local result = func(node.value)
+    local node_is_next = false
     if result then
       if type(result) == "boolean" then
         local node_to_remove = node
         node = node.next
+        node_is_next = true
         self._list:remove_node(node_to_remove)
       elseif type(result) == "table" then
         if type(result.handled) == "boolean" and result.handled == true then
@@ -88,8 +90,8 @@ function Queue:for_each(func)
           return result
         end
       end
-      node = node.next
-    else
+    end
+    if not node_is_next then
       node = node.next
     end
   end


### PR DESCRIPTION
If an event handler should be removed (by way of `once = true` or the handler returning `true`), the event queue erroneously skips handling the next node and jumps two nodes ahead. If this is the last event in the queue, this also results in an error (attempt to index a nil value).