### PR TITLE
fix(fs): error when escaping out of `add` and `add_directory`

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -277,6 +277,10 @@ M.create_directory = function(in_directory, callback, using_root_directory)
   end
 
   inputs.input("Enter name for new directory:", base, function(destinations)
+    if not destinations then
+      return
+    end
+
     for _, destination in ipairs(utils.brace_expand(destinations)) do
       if not destination or destination == base then
         return
@@ -326,6 +330,10 @@ M.create_node = function(in_directory, callback, using_root_directory)
     'Enter name for new file or directory (dirs end with a "/"):',
     base,
     function(destinations)
+      if not destinations then
+        return
+      end
+
       for _, destination in ipairs(utils.brace_expand(destinations)) do
         if not destination or destination == base then
           return


### PR DESCRIPTION
When pressing `a` into `escape` in neo-tree, I ran into this error, this fixes the issue for me

```
Error executing vim.schedule lua callback: ...eovimPackages/start/neo-tree.nvim/lua/neo-tree/utils.lua:833: attempt to index local 's' (a nil value)
stack traceback:
	...eovimPackages/start/neo-tree.nvim/lua/neo-tree/utils.lua:833: in function 'brace_expand_split'
	...eovimPackages/start/neo-tree.nvim/lua/neo-tree/utils.lua:951: in function 'brace_expand'
	....nvim/lua/neo-tree/sources/filesystem/lib/fs_actions.lua:329: in function 'on_confirm'
	...eovimPackages/start/dressing.nvim/lua/dressing/input.lua:108: in function ''
	vim/_editor.lua: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```