### PR TITLE
fix(git): hide gitignored and apply show git status when non-ascii charact…

### DIFF
--- a/lua/neo-tree/git/ignored.lua
+++ b/lua/neo-tree/git/ignored.lua
@@ -59,7 +59,6 @@ M.mark_ignored = function(state, items, callback)
     if utils.is_windows then
       --on Windows, git seems to return quotes and double backslash "path\\directory"
       result = vim.tbl_map(function(item)
-        item = item:gsub('"', "")
         item = item:gsub("\\\\", "\\")
         return item
       end, result)
@@ -74,6 +73,13 @@ M.mark_ignored = function(state, items, callback)
         end
       end
     end
+    result = vim.tbl_map(function(item)
+      -- remove leading and trailing " from git output
+      item = item:gsub('^"', ""):gsub('"$', "")
+      -- convert octal encoded lines to utf-8
+      item = git_utils.octal_to_utf8(item)
+      return item
+    end, result)
     return result
   end
 

--- a/lua/neo-tree/git/status.lua
+++ b/lua/neo-tree/git/status.lua
@@ -73,8 +73,11 @@ local parse_git_status_line = function(context, line)
     relative_path = line_parts[3]
   end
 
-  -- remove any " due to whitespace in the path
-  relative_path = relative_path:gsub('^"', ""):gsub('$"', "")
+  -- remove any " due to whitespace or utf-8 in the path
+  relative_path = relative_path:gsub('^"', ""):gsub('"$', "")
+  -- convert octal encoded lines to utf-8
+  relative_path = git_utils.octal_to_utf8(relative_path)
+
   if utils.is_windows == true then
     relative_path = utils.windowize_path(relative_path)
   end

--- a/lua/neo-tree/git/utils.lua
+++ b/lua/neo-tree/git/utils.lua
@@ -48,4 +48,12 @@ M.get_repository_root = function(path, callback)
   end
 end
 
+M.octal_to_utf8 = function(text)
+  -- git uses octal encoding for utf-8 filepaths, convert octal back to utf-8
+  text = text:gsub("\\([0-7][0-7][0-7])", function(octal)
+    return string.char(tonumber(octal, 8))
+  end)
+  return text
+end
+
 return M


### PR DESCRIPTION
Hello!

Non-ascii characters caused two problems with git functionality in the tree view due to git's octal utf-8 encoding.

(1) Hiding gitignored did not work. 
(2) Git status of a file was not displayed

For instance, if a git project was under a directory "~/säde/", the 'ä' in the path would become "\303\244" and no files would be hidden in the tree view based on gitignore.
If a filename contained 'ä', the git status, e.g. unstaged, would not show in the tree view.

This PR applies a fix to both git/status.lua and git/ignored.lua to convert any octal patterns to proper utf-8 through a util function in git/utils.lua.