### PR TITLE
Fix syntax of Packer example in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ use {
             ["<cr>"] = "open",
             ["<esc>"] = "revert_preview",
             ["P"] = { "toggle_preview", config = { use_float = true } },
-            ["l"] = "focus_preview"
+            ["l"] = "focus_preview",
             ["S"] = "open_split",
             ["s"] = "open_vsplit",
             -- ["S"] = "split_with_window_picker",


### PR DESCRIPTION
Just adding a missing comma in the config example.