### PR TITLE
feat(renderer): Create a dummy window to prevent window flickering

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -367,6 +367,9 @@ local config = {
         ["]g"] = "next_git_modified",
       }
     },
+    show_split_window_immediately = false, -- true creates a window right away, before starting async_directory_scan.
+    --                                     -- ONLY WORKS WITH SPLIT WINDOWS. (i.e. does not affect opening in float or current)
+    --                                     -- this should prevent flickering of windows on switching sources.
     async_directory_scan = "auto", -- "auto"   means refreshes are async, but it's synchronous when called from the Neotree commands.
                                    -- "always" means directory scans are always async.
                                    -- "never"  means directory scans are never async.


### PR DESCRIPTION
Let's tackle this after the fuzzy sorter is settled, but I created a logic to create a dummy window before the rendering starts for `filesystem` source to prevent a flash of window movement.

For more details of this problem, please read #713 and #744.
Thanks to @charbelnicolas, providing a screen record as well.

For the internal explanation of this issue please read [this comment](https://github.com/nvim-neo-tree/neo-tree.nvim/issues/713#issuecomment-1419304319).

I have exposed a config option as noted below to toggle this behavior as well, which however defaults to false so that it does not change any behavior at all by default.

```lua
require("neo-tree").setup({
  filesystem = {
    show_split_window_immediately = false, -- true creates a window right away, before starting async_directory_scan.
    --                                     -- ONLY WORKS WITH SPLIT WINDOWS. (i.e. does not affect opening in float or current)
    --                                     -- this should prevent flickering of windows on switching sources.

  -- THIS WILL AFFECT THE BEHAVIOR WITH FOLLOWING OPTIONS
    async_directory_scan = "auto" or "always",
  },
  git_status_async = true,
  window = {
    position = "left" or "right" or "top" or "bottom",
    -- basically not "float" nor "current"
  },
})
```

For those who are willing test this out (THANK YOU!!), please load the plugin with these options. (Suppose using lazy)

```lua
return {
  "pysan3/neo-tree.nvim"
  branch = "dummy-window-on-source-switch",
  opts = {
    ... -- your regular configs
    filesystem = {
      show_split_window_immediately = true -- make it to true (defaults to false)
    },
  },
}
```