### PR TITLE
feat(command): add close_all_subnodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ use {
             ["w"] = "open_with_window_picker",
             --["P"] = "toggle_preview", -- enter preview mode, which shows the current node without focusing
             ["C"] = "close_node",
+            -- ['C'] = 'close_all_subnodes',
             ["z"] = "close_all_nodes",
             --["Z"] = "expand_all_nodes",
             ["a"] = { 

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -191,11 +191,14 @@ C             = close_node:  Close node if it is open, else close it's parent.
 
 z         = close_all_nodes: Close all nodes in the tree.
 
+         close_all_subnodes: Same as "close_node", but also recursively collapse
+                             all subnodes, similar to "close_all_nodes"
+
            expand_all_nodes: Expand all directory nodes in the tree recursively.
 
 P          = toggle_preview: Toggles "preview mode", see |neo-tree-preview-mode| 
 
-l          = focus_preview: Focus the active preview window
+l           = focus_preview: Focus the active preview window
 
 <esc>      = revert_preview: Ends "preview_mode" if it is enabled, and reverts
                              any preview windows to what was being shown before

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -104,11 +104,6 @@ M.add_directory = function(state, callback)
   fs_actions.create_directory(in_directory, callback, using_root_directory)
 end
 
-M.close_all_nodes = function(state)
-  renderer.collapse_all_nodes(state.tree)
-  renderer.redraw(state)
-end
-
 M.expand_all_nodes = function(state, toggle_directory)
   if toggle_directory == nil then
     toggle_directory = function(_, node)
@@ -157,6 +152,28 @@ M.close_node = function(state, callback)
     renderer.redraw(state)
     renderer.focus_node(state, target_node:get_id())
   end
+end
+
+M.close_all_subnodes = function(state)
+  local tree = state.tree
+  local node = tree:get_node()
+  local parent_node = tree:get_node(node:get_parent_id())
+  local target_node
+
+  if node:has_children() and node:is_expanded() then
+    target_node = node
+  else
+    target_node = parent_node
+  end
+
+  renderer.collapse_all_nodes(tree, target_node:get_id())
+  renderer.redraw(state)
+  renderer.focus_node(state, target_node:get_id())
+end
+
+M.close_all_nodes = function(state)
+  renderer.collapse_all_nodes(state.tree)
+  renderer.redraw(state)
 end
 
 M.close_window = function(state)

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -536,14 +536,13 @@ M.get_expanded_nodes = function(tree, root_node_id)
   local node_ids = {}
 
   local function process(node)
+    local id = node:get_id()
     if node:is_expanded() then
-      local id = node:get_id()
       table.insert(node_ids, id)
-
-      if node:has_children() then
-        for _, child in ipairs(tree:get_nodes(id)) do
-          process(child)
-        end
+    end
+    if node:has_children() then
+      for _, child in ipairs(tree:get_nodes(id)) do
+        process(child)
       end
     end
   end
@@ -561,8 +560,8 @@ M.get_expanded_nodes = function(tree, root_node_id)
   return node_ids
 end
 
-M.collapse_all_nodes = function(tree)
-  local expanded = M.get_expanded_nodes(tree)
+M.collapse_all_nodes = function(tree, root_node_id)
+  local expanded = M.get_expanded_nodes(tree, root_node_id)
   for _, id in ipairs(expanded) do
     local node = tree:get_node(id)
     if utils.is_expandable(node) then


### PR DESCRIPTION
Implement #696:
- Added a command `close_all_subnodes` that behaves analogously to `close_node` but also collapses all nodes in the subtree. 
- Also changed `renderer.get_expanded_nodes()` to search for expanded subnodes of already collapsed nodes (this might make `close_all_nodes` slower, so I'm not sure if it should be changed or not)