### PR TITLE
add neotree buffer valid check

### DIFF
--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -122,9 +122,9 @@ end
 M.get_state_for_window = function(winid)
   local winid = winid or vim.api.nvim_get_current_win()
   local bufnr = vim.api.nvim_win_get_buf(winid)
-  local _, source_name = pcall(vim.api.nvim_buf_get_var, bufnr, "neo_tree_source")
-  local _, position = pcall(vim.api.nvim_buf_get_var, bufnr, "neo_tree_position")
-  if not source_name or not position then
+  local source_status, source_name = pcall(vim.api.nvim_buf_get_var, bufnr, "neo_tree_source")
+  local position_status, position = pcall(vim.api.nvim_buf_get_var, bufnr, "neo_tree_position")
+  if not source_status or not position_status then
     return nil
   end
 

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -37,7 +37,9 @@ M.clean_invalid_neotree_buffers = function(force)
 
   for _, buf in ipairs(vim.api.nvim_list_bufs()) do
     local bufname = vim.fn.bufname(buf)
-    if string.match(bufname, "neo%-tree [^ ]+ %[%d+]") then
+    local is_neotree_buffer = string.match(bufname, "neo%-tree [^ ]+ %[%d+]")
+    local is_valid_neotree, _ = pcall(vim.api.nvim_buf_get_var, buf, "neo_tree_source")
+    if is_neotree_buffer and not is_valid_neotree then
       vim.api.nvim_buf_delete(buf, { force = true })
     end
   end


### PR DESCRIPTION
Fixes a flick issue in #767 by adding a validity check to make sure neo-tree does not close a valid neo-tree window on session restore.