### PR TITLE
fix: do not auto clean up buffers after session restore, unless opted in

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -9,6 +9,7 @@ local config = {
     "git_status",
   },
   add_blank_line_at_top = false, -- Add a blank line at the top of the tree.
+  auto_clean_after_session_restore = false, -- Automatically clean up broken neo-tree buffers saved in sessions
   close_if_last_window = false, -- Close Neo-tree if it is the last window left in the tab
   -- popup_border_style is for input and confirmation dialogs.
   -- Configurtaion of floating window is done in the individual source sections.

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -94,13 +94,6 @@ local define_events = function()
       require("neo-tree.ui.renderer").update_floating_window_layouts()
     end,
   })
-
-  events.subscribe({
-    event = events.VIM_AFTER_SESSION_LOAD,
-    handler = function()
-      require("neo-tree.ui.renderer").clean_invalid_neotree_buffers(true)
-    end,
-  })
 end
 
 local prior_window_options = {}
@@ -624,6 +617,16 @@ M.merge_config = function(user_config, is_auto_config)
     local module = require(mod_root)
     manager.setup(source_name, M.config[source_name], M.config, module)
     manager.redraw(source_name)
+  end
+
+  if M.config.auto_clean_after_session_restore then
+    require("neo-tree.ui.renderer").clean_invalid_neotree_buffers(false)
+    events.subscribe({
+      event = events.VIM_AFTER_SESSION_LOAD,
+      handler = function()
+        require("neo-tree.ui.renderer").clean_invalid_neotree_buffers(true)
+      end,
+    })
   end
 
   events.subscribe({

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -841,7 +841,6 @@ create_window = function(state)
     tabnr = state.tabnr,
   }
   events.fire_event(events.NEO_TREE_WINDOW_BEFORE_OPEN, event_args)
-  M.clean_invalid_neotree_buffers(false)
 
   if state.current_position == "float" then
     state.force_float = nil


### PR DESCRIPTION
fixes #778

This moves the session cleanup functionality to an opt-in feature instead of enabling it automatically for everyone.

The new config option is:
```lua
  auto_clean_after_session_restore = false, -- Automatically clean up broken neo-tree buffers saved in sessions
```

I also moved the first cleanup action from the renderer to the setup function.
