### PR TITLE
fix: handle backspacing correctly in fzy search

### DIFF
--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -184,6 +184,13 @@ end
 
 M.reset_search = function(state, refresh, open_current_node)
   log.trace("reset_search")
+  -- reset search state
+  state.fuzzy_finder_mode = nil
+  state.use_fzy = nil
+  state.fzy_sort_result_scores = nil
+  state.fzy_sort_file_list_cache = nil
+  state.sort_function_override = nil
+
   if refresh == nil then
     refresh = true
   end

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -184,11 +184,6 @@ end
 
 M.reset_search = function(state, refresh, open_current_node)
   log.trace("reset_search")
-  state.fuzzy_finder_mode = nil
-  state.use_fzy = nil
-  state.fzy_sort_result_scores = nil
-  state.fzy_sort_file_list_cache = nil
-  state.sort_function_override = nil
   if refresh == nil then
     refresh = true
   end

--- a/lua/neo-tree/sources/filesystem/lib/filter.lua
+++ b/lua/neo-tree/sources/filesystem/lib/filter.lua
@@ -20,6 +20,14 @@ M.show_filter = function(state, search_as_you_type, fuzzy_finder_mode, use_fzy)
   local height = vim.api.nvim_win_get_height(winid)
   local scroll_padding = 3
   local popup_msg = "Search:"
+
+  -- reset state that may be left over from previous search
+  state.fuzzy_finder_mode = nil
+  state.use_fzy = nil
+  state.fzy_sort_result_scores = nil
+  state.fzy_sort_file_list_cache = nil
+  state.sort_function_override = nil
+
   if search_as_you_type then
     if fuzzy_finder_mode == "directory" then
       popup_msg = "Filter Directories:"

--- a/lua/neo-tree/sources/filesystem/lib/filter.lua
+++ b/lua/neo-tree/sources/filesystem/lib/filter.lua
@@ -21,13 +21,6 @@ M.show_filter = function(state, search_as_you_type, fuzzy_finder_mode, use_fzy)
   local scroll_padding = 3
   local popup_msg = "Search:"
 
-  -- reset state that may be left over from previous search
-  state.fuzzy_finder_mode = nil
-  state.use_fzy = nil
-  state.fzy_sort_result_scores = nil
-  state.fzy_sort_file_list_cache = nil
-  state.sort_function_override = nil
-
   if search_as_you_type then
     if fuzzy_finder_mode == "directory" then
       popup_msg = "Filter Directories:"
@@ -63,27 +56,21 @@ M.show_filter = function(state, search_as_you_type, fuzzy_finder_mode, use_fzy)
     })
   end
 
-  local set_sort_by_score = function()
-    state.sort_function_override = function(a, b)
-      -- `state.fzy_sort_result_scores` should be defined in
-      -- `sources.filesystem.lib.filter_external.fzy_sort_files`
-      local result_scores = state.fzy_sort_result_scores or { foo = 0, baz = 0 }
-      local a_score = result_scores[a.path]
-      local b_score = result_scores[b.path]
-      if a_score == nil or b_score == nil then
-        log.debug(string.format([[Fzy: failed to compare %s: %s, %s: %s]], a.path, a_score, b.path, b_score))
-        local config = require("neo-tree").config
-        if config.sort_function ~= nil then
-          return config.sort_function(a, b)
-        end
-        return nil
+  local sort_by_score = function(a, b)
+    -- `state.fzy_sort_result_scores` should be defined in
+    -- `sources.filesystem.lib.filter_external.fzy_sort_files`
+    local result_scores = state.fzy_sort_result_scores or { foo = 0, baz = 0 }
+    local a_score = result_scores[a.path]
+    local b_score = result_scores[b.path]
+    if a_score == nil or b_score == nil then
+      log.debug(string.format([[Fzy: failed to compare %s: %s, %s: %s]], a.path, a_score, b.path, b_score))
+      local config = require("neo-tree").config
+      if config.sort_function ~= nil then
+        return config.sort_function(a, b)
       end
-      return a_score > b_score
+      return nil
     end
-  end
-  if use_fzy then
-    set_sort_by_score()
-    state.use_fzy = true
+    return a_score > b_score
   end
 
   local select_first_file = function()
@@ -159,6 +146,10 @@ M.show_filter = function(state, search_as_you_type, fuzzy_finder_mode, use_fzy)
         log.trace("Setting search in on_change to: " .. value)
         state.search_pattern = value
         state.fuzzy_finder_mode = fuzzy_finder_mode
+        if use_fzy then
+          state.sort_function_override = sort_by_score
+          state.use_fzy = true
+        end
         local callback = select_first_file
         if fuzzy_finder_mode == "directory" then
           callback = nil


### PR DESCRIPTION
fixes #794

This fixes problems related to making corrections in fzy search mode. Previously, it only worked correctly going forward,
as in adding characters without making corrections. It now works consistently with corrections because:

- The files found using `fd`/`find` are no longer cached at all. Another way to fix this would be to track the search term and reset the cache when the term gets shorter. I don't think that is worth the complication though.
- I fixed a bug where going to an empty input would reset your search settings for the session, sending you back to the old fuzzy search mode.

