### PR TITLE
feat(filesystem): use fd/find as first level filter in fzy, cancel jobs as needed

### DIFF
--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -184,6 +184,8 @@ end
 
 M.reset_search = function(state, refresh, open_current_node)
   log.trace("reset_search")
+  -- Cancel any pending search
+  require("neo-tree.sources.filesystem.lib.filter_external").cancel()
   -- reset search state
   state.fuzzy_finder_mode = nil
   state.use_fzy = nil


### PR DESCRIPTION
The advantage here is that the fzy search will work in much larger directories because we no longer try to load **all** of the files and fzy search in memory. Now we will have a first level search using the external program which searches for the existence of all of the characters in the term.

The downside is that it will no longer find matches that are in a different order than what you type. I think that is a reasonable trade off because the old way was only usable in small projects.

If we want to recreate a perfect fzy search, we should just use fzy itself. I think we may be able to use [nvim-fzf](https://github.com/vijaymarupudi/nvim-fzf) or at least lean from its code base.

The other change made here is that we now keep track of running jobs for the external find command and kill them when a new one comes in or when the search is exited.