### PR TITLE
feat!: add config to prevent replacing specific filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ use {
         popup_border_style = "rounded",
         enable_git_status = true,
         enable_diagnostics = true,
+        open_files_do_not_replace_filetypes = { "terminal", "trouble", "qf" }, -- when opening files, do not use windows containing these filetypes
         sort_case_insensitive = false, -- used when sorting files and directories in the tree
         sort_function = nil , -- use a custom function for sorting files and directories in the tree 
         -- sort_function = function (a,b)

--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -160,9 +160,13 @@ M.show_in_split = function(source_name, toggle_if_open)
   manager.show_in_split(source_name)
 end
 
-M.get_prior_window = function()
+M.get_prior_window = function(ignore_filetypes)
+  ignore_filetypes = ignore_filetypes or {}
+  local ignore = utils.list_to_dict(ignore_filetypes)
+  ignore["neo-tree"] = true
+
   local tabnr = vim.api.nvim_get_current_tabpage()
-  local wins = utils.get_value(M, "config.prior_windows", {})[tabnr]
+  local wins = utils.get_value(M, "config.prior_windows", {}, true)[tabnr]
   if wins == nil then
     return -1
   end
@@ -174,7 +178,7 @@ M.get_prior_window = function()
       if success and is_valid then
         local buf = vim.api.nvim_win_get_buf(last_win)
         local ft = vim.api.nvim_buf_get_option(buf, "filetype")
-        if ft ~= "neo-tree" then
+        if ignore[ft] ~= true then
           return last_win
         end
       end

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -34,6 +34,7 @@ local config = {
   log_level = "info", -- "trace", "debug", "info", "warn", "error", "fatal"
   log_to_file = false, -- true, false, "/path/to/file.log", use :NeoTreeLogs to show the file
   open_files_in_last_window = true, -- false = open files in top left window
+  open_files_do_not_replace_filetypes = { "terminal", "trouble", "qf" }, -- when opening files, do not use windows containing these filetypes
   popup_border_style = "NC", -- "double", "none", "rounded", "shadow", "single" or "solid"
   resize_timer_interval = 500, -- in ms, needed for containers to redraw right aligned and faded content
                                -- set to -1 to disable the resize timer entirely


### PR DESCRIPTION
closes #564, closes #802
default is set to not replace `{ "terminal", "trouble", "qf" }`
set `open_files_do_not_replace_filetypes = {}` to restore previous behavior.