### PR TITLE
feat: do not show "Window settings restored" message

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -129,10 +129,10 @@ local restore_local_window_settings = function(winid)
     vim.wo.number = wo.number
     vim.wo.relativenumber = wo.relativenumber
     vim.wo.winhighlight = wo.winhighlight
-    log.info("Window settings restored")
+    log.debug("Window settings restored")
     vim.api.nvim_win_set_var(0, "neo_tree_settings_applied", false)
   else
-    log.info("No window settings to restore")
+    log.debug("No window settings to restore")
   end
 end
 


### PR DESCRIPTION
That message should have been logged at the `debug` level.
