### PR TITLE
fix(config): prioritize default source-specific configs over user general configs

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -572,8 +572,8 @@ M.merge_config = function(user_config, is_auto_config)
     source_default_config.window = vim.tbl_deep_extend(
       "force",
       default_config.window or {},
-      source_default_config.window or {},
-      user_config.window or {}
+      user_config.window or {},
+      source_default_config.window or {}
     )
 
     merge_renderers(default_config, source_default_config, user_config)


### PR DESCRIPTION
Currently, any user-defined generic window configuration (`user_config.window`) will override default source-specific window configuration (e.g `default_config.git_status.window`). The current priority is
```
default_config.window < default_config.source.window < user_config.window < user_config.source.window
```
So for example, if I map `A` to `add_directory` in my user config for all windows, which will override the source-specific keymap (`["A"] = git_add_all`).

I think the expected behavior should be 
```
default_config.window < user_config.window < default_config.source.window < user_config.source.window
```