### PR TITLE
fix: use correct conversion between tabid and tabnr when tracking cwd

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1319,7 +1319,8 @@ Fired before opening a new Neo-tree window. Called with the following arg:
                                                      *neo-tree-window-event-args*
 The event argument for all window events is a table with the following keys:
     `winid`    = the |winid| of the window being opened or closed.
-    `tabnr`    = the tab number that the window is in.
+    `tabid`    = id of the tab that the window is in.
+    `tabnr`    = (deprecated) number of the tab that the window is in.
     `source`   = the name of the source that is in the window, such as "filesystem".
     `position` = the position of the window, i.e. "left", "bottom", "right".
 
@@ -1620,7 +1621,8 @@ code or integrations if you need it. The |filetype| of the main window is
 `neo-tree`. The buffer will also have these local variables set:
 
 `winid` The window handle of the window that it was created in.
-`tabnr` The tab number that it was created in.
+`tabid` The id of the tab that it was created in.
+`tabnr` (deprecated) The number of the tab that it was created in.
 `source` The name of the source that created it, i.e. filesystem, buffers, etc.
 
 Please note that if the buffer is displayed in another window or tab, it's

--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -165,8 +165,8 @@ M.get_prior_window = function(ignore_filetypes)
   local ignore = utils.list_to_dict(ignore_filetypes)
   ignore["neo-tree"] = true
 
-  local tabnr = vim.api.nvim_get_current_tabpage()
-  local wins = utils.get_value(M, "config.prior_windows", {}, true)[tabnr]
+  local tabid = vim.api.nvim_get_current_tabpage()
+  local wins = utils.get_value(M, "config.prior_windows", {}, true)[tabid]
   if wins == nil then
     return -1
   end

--- a/lua/neo-tree/sources/buffers/init.lua
+++ b/lua/neo-tree/sources/buffers/init.lua
@@ -59,8 +59,8 @@ M.follow = function()
 end
 
 local buffers_changed_internal = function()
-  for _, tabnr in ipairs(vim.api.nvim_list_tabpages()) do
-    local state = manager.get_state(M.name, tabnr)
+  for _, tabid in ipairs(vim.api.nvim_list_tabpages()) do
+    local state = manager.get_state(M.name, tabid)
     if state.path and renderer.window_exists(state) then
       items.get_opened_buffers(state)
       if state.follow_current_file then

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -20,8 +20,8 @@ local wrap = function(func)
   return utils.wrap(func, M.name)
 end
 
-local get_state = function(tabnr)
-  return manager.get_state(M.name, tabnr)
+local get_state = function(tabid)
+  return manager.get_state(M.name, tabid)
 end
 
 -- TODO: DEPRECATED in 1.19, remove in 2.0

--- a/tests/neo-tree/sources/manager_spec.lua
+++ b/tests/neo-tree/sources/manager_spec.lua
@@ -1,0 +1,125 @@
+pcall(require, "luacov")
+
+local u = require("tests.utils")
+local verify = require("tests.utils.verify")
+
+local manager = require('neo-tree.sources.manager')
+
+local get_dirs = function(winid)
+  winid = winid or vim.api.nvim_get_current_win()
+  local tabnr = vim.api.nvim_tabpage_get_number(vim.api.nvim_win_get_tabpage(winid))
+  local winnr = vim.api.nvim_win_get_number(winid)
+  return {
+    win = vim.fn.getcwd(winnr),
+    tab = vim.fn.getcwd(-1, tabnr),
+    global = vim.fn.getcwd(-1, -1),
+  }
+end
+
+local get_state_for_tab = function(tabid)
+  for _, state in ipairs(manager._get_all_states()) do
+    if state.tabid == tabid then
+      return state
+    end
+  end
+end
+
+local get_tabnr = function(tabid)
+    return vim.api.nvim_tabpage_get_number(tabid or vim.api.nvim_get_current_tabpage())
+end
+
+describe("Manager", function()
+  local test = u.fs.init_test({
+    items = {
+      {
+        name = "foo",
+        type = "dir",
+        items = {
+          { name = "foofile1.txt", type = "file" },
+        },
+      },
+      { name = "topfile1.txt", type = "file", id = "topfile1" },
+    },
+  })
+
+  test.setup()
+
+  local fs_tree = test.fs_tree
+
+  -- Just make sure we start all tests in the expected state
+  before_each(function()
+    u.eq(1, #vim.api.nvim_list_wins())
+    u.eq(1, #vim.api.nvim_list_tabpages())
+    vim.cmd.lcd(fs_tree.abspath)
+    vim.cmd.tcd(fs_tree.abspath)
+    vim.cmd.cd(fs_tree.abspath)
+  end)
+
+  after_each(function()
+    u.clear_environment()
+  end)
+
+  local setup_2_tabs = function()
+    -- create 2 tabs
+    local tab1 = vim.api.nvim_get_current_tabpage()
+    local win1 = vim.api.nvim_get_current_win()
+    vim.cmd.tabnew()
+    local tab2 = vim.api.nvim_get_current_tabpage()
+    local win2 = vim.api.nvim_get_current_win()
+    u.neq(tab2, tab1)
+    u.neq(win2, win1)
+
+    -- set different directories
+    vim.api.nvim_set_current_tabpage(tab2)
+    local base_dir = vim.fn.getcwd()
+    vim.cmd.tcd('foo')
+    local new_dir = vim.fn.getcwd()
+
+    -- open neo-tree
+    vim.api.nvim_set_current_tabpage(tab1)
+    vim.cmd.Neotree('show')
+    vim.api.nvim_set_current_tabpage(tab2)
+    vim.cmd.Neotree('show')
+
+    return {
+      tab1 = tab1,
+      tab2 = tab2,
+      win1 = win1,
+      win2 = win2,
+      tab1_dir = base_dir,
+      tab2_dir = new_dir,
+    }
+  end
+
+  it("should respect changed tab cwd", function()
+    local ctx = setup_2_tabs()
+
+    local state1 = get_state_for_tab(ctx.tab1)
+    local state2 = get_state_for_tab(ctx.tab2)
+    u.eq(ctx.tab1_dir, manager.get_cwd(state1))
+    u.eq(ctx.tab2_dir, manager.get_cwd(state2))
+  end)
+
+  it("should have correct tab cwd after  tabs order is changed", function()
+    local ctx = setup_2_tabs()
+
+    -- tab numbers should be the same as ids
+    u.eq(1, get_tabnr(ctx.tab1))
+    u.eq(2, get_tabnr(ctx.tab2))
+
+    -- swap tabs
+    vim.cmd.tabfirst()
+    vim.cmd.tabmove('+1')
+
+    -- make sure tabs have been swapped
+    u.eq(2, get_tabnr(ctx.tab1))
+    u.eq(1, get_tabnr(ctx.tab2))
+
+    -- verify that tab dirs are the same as nvim tab cwd
+    local state1 = get_state_for_tab(ctx.tab1)
+    local state2 = get_state_for_tab(ctx.tab2)
+    u.eq(get_dirs(ctx.win1).tab, manager.get_cwd(state1))
+    u.eq(get_dirs(ctx.win2).tab, manager.get_cwd(state2))
+  end)
+end)
+


### PR DESCRIPTION
I noticed that neo-tree cwd was sometimes getting out of sync with the real value. After some investigation I found that the manager uses `nvim_get_current_tabpage` to get the value stored in state (tabid but is called tabnr in code), but then uses the same value to get tab cwd using `vim.fn.getcwd` (which expects tab number). The values used in API and in vimscript functions are slightly different - tabnr is the visible position of a tab, while tabid refers to the tab object. 

To reproduce the bugs that I was expecting start Neovim, open two tabs, then set different tabcwd for one of the tabs and open neo-tree in both tabs. Then use `:tabmove +1` in the first (leftmost) tab - neo-tree will be out of sync with the actual tab cwd (as returned by `vim.fn.getcwd(-1, 0)`). You can also compare `vim.api.nvim_get_current_tabpage()` with `vim.fn.tabpagenr()`.

I changed all usages of "tabnr" in code to "tabid" whenever we are referring to API tab handles. To avoid breaking changes I left the following incorrect names: 
* `tabnr` in event args (NEO_TREE_WINDOW_BEFORE_CLOSE, NEO_TREE_WINDOW_BEFORE_OPEN)
* buffer variable `neo_tree_tabnr`
* mentions about these in neo-tree.txt

One notable change that I had to do was in TabClosed event handler. It passes `<afile>` which is a tab number. It was previously being used incorrectly to dispose tab (state was stored by tabid). I found no way to get tabid of the tab that has just been closed. Normally to convert tabnr to tabid we would have to find it iterating over output of `nvim_list_tabpages`, but inside the TabClosed handler this tab is already deleted. Instead of this I created dispose_invalid_tabs which deletes tabs based on `nvim_tabpage_is_valid`. This needs to be scheduled to next tick as inside the event handler the tab still appears to be valid. If scheduling to next tick is not acceptable then we would have to use `nvim_list_tabpages` and find `state.tabid` in the returned list as `nvim_list_tabpages` won't list the already deleted tab even when not scheduled.