### PR TITLE
feat: commands can be defined globally. fixes #707

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ use {
             }
           },
         },
+        -- A list of functions, each representing a global custom command
+        -- that will be available in all sources (if not overridden in `opts[source_name].commands`)
+        -- see `:h neo-tree-global-custom-commands`
+        commands = {}
+
         window = {
           position = "left",
           width = 40,
@@ -299,7 +304,9 @@ use {
               ["<up>"] = "move_cursor_up",
               ["<C-p>"] = "move_cursor_up",
             },
-          }
+          },
+
+          commands = {} -- Add a custom command or override a global one using the same function name
         },
         buffers = {
           follow_current_file = true, -- This will find and focus the file in the active buffer every

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -9,6 +9,7 @@ Mappings .................... |neo-tree-mappings|
   View Changes .............. |neo-tree-view-changes|
   File Actions .............. |neo-tree-file-actions|
   Filter .................... |neo-tree-filter|
+  Global custom commands .... |neo-tree-custom-commands-global|
 Configuration ............... |neo-tree-configuration|
   Setup ..................... |neo-tree-setup|
   Source Selector ........... |neo-tree-source-selector|
@@ -481,6 +482,38 @@ You probably want #2:
      }
    })
 <
+
+GLOBAL CUSTOM COMMANDS                       *neo-tree-custom-commands-global*
+
+You can also have global custom commands that will be added to all available
+sources. If you need it you can then override it in a specific source.
+>lua
+   require("neo-tree").setup({
+     commands = {
+       hello = function()            -- define a global "hello world" function
+         print("Hello world")
+       end
+     },
+
+     window = {
+       mappings = {
+         ["<C-c>"] = "hello"
+                    -- define a global mapping to call 'hello' in every source
+       }
+     },
+
+     filesystem = {
+       commands = {
+         -- override implementation of the 'hello' action in filesystem source
+         hello = function()
+           print("Hello inside filesystem")
+         end
+       }
+     }
+   })
+<
+Now when pressing `<C-c>` in 'buffers' or 'git_status' it will print "Hello world",
+but in 'filesystem' it will print "Hello inside filesystem".
 
 CUSTOM MAPPINGS WITH VISUAL MODE
 

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -285,6 +285,21 @@ local config = {
     }
   },
   nesting_rules = {},
+  -- Global custom commands that will be available in all sources (if not overridden in `opts[source_name].commands`)
+  --
+  -- You can then reference the custom command by adding a mapping to it:
+  --    globally    -> `opts.window.mappings`
+  --    locally     -> `opt[source_name].window.mappings` to make it source specific.
+  --
+  -- commands = {              |  window {                 |  filesystem {
+  --   hello = function()      |    mappings = {           |    commands = {
+  --     print("Hello world")  |      ["<C-c>"] = "hello"  |      hello = function()
+  --   end                     |    }                      |        print("Hello world in filesystem")
+  -- }                         |  }                        |      end
+  --
+  -- see `:h neo-tree-global-custom-commands`
+  commands = {}, -- A list of functions
+
   window = { -- see https://github.com/MunifTanjim/nui.nvim/tree/main/lua/nui/popup for
              -- possible options. These can also be functions that return these options.
     position = "left", -- left, right, top, bottom, float, current

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -609,6 +609,10 @@ M.merge_config = function(user_config, is_auto_config)
       M.config[source_name].renderers[name] = merge_global_components_config(rndr, M.config)
     end
     local module = require(mod_root)
+    if M.config.commands then
+      M.config[source_name].commands =
+        vim.tbl_extend("keep", M.config[source_name].commands or {}, M.config.commands)
+    end
     manager.setup(source_name, M.config[source_name], M.config, module)
     manager.redraw(source_name)
   end


### PR DESCRIPTION
Added **global commands** feature. A user can specify a table with functions that will automatically be added to all sources. 
The table is `config.commands` and it's content is added to `config[source_name].commands` with `vim.tbl_extend`, and the "keep" option, to allow overriding the global implementation with a custom one in any source.

```lua
   require("neo-tree").setup({
     commands = {
       hello = function()            -- define a global "hello world" function
         print("Hello world")
       end
     },

     window = {
       mappings = {
         ["<C-c>"] = "hello"
                    -- define a global mapping to call 'hello' in every source
       }
     },

     filesystem = {
       commands = {
         -- override implementation of the 'hello' action in filesystem source
         hello = function()
           print("Hello inside filesystem")
         end
       }
     }
   })
```
This means that pressing `CTRL-c` in the `filesystem` source will result in a different effect than in other sources.
`hello` is therefore a global command, but in filesystem it is overwritten.