### PR TITLE
fix: fix split command

### DIFF
--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -585,7 +585,7 @@ M.open_file = function(state, path, open_cmd, bufnr)
             vim.cmd("b" .. bufnr)
           end
         else
-          result, err = pcall(vim.cmd, split_command .. escaped_path)
+          result, err = pcall(vim.cmd, split_command .. " " .. escaped_path)
         end
 
         vim.api.nvim_win_set_width(winid, width)


### PR DESCRIPTION
Sometimes I get this error when I use Windows.

![image](https://user-images.githubusercontent.com/47070852/230610083-14fb5ceb-8ef6-4d8a-83a2-66f0fc813867.png)
