### PR TITLE
doc: make longer example collapsible

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Press `?` in the Neo-tree window to view the list of mappings.
 ## Quickstart
 
 #### Longer Example for Packer:
+<details>
+  <summary>
+    Click to view
+  </summary>
   
 ```lua
 use {
@@ -334,7 +338,8 @@ use {
     end
 }
 ```
-
+</details>
+  
 _The above configuration is not everything that can be changed, it's just the
 parts you might want to change first._
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Press `?` in the Neo-tree window to view the list of mappings.
 #### Longer Example for Packer:
 <details>
   <summary>
-    Click to view
+    Click to view longer example for Packer.nvim
   </summary>
   
 ```lua


### PR DESCRIPTION
Not sure if this is a good idea, but I find the longer example section in the README too long to scroll through, making it hard to get to the next part of the guide. 