### PR TITLE
fix(setup): save and restore foldcolumn option

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -105,6 +105,7 @@ local store_local_window_settings = function(winid)
   prior_window_options[tostring(winid)] = {
     cursorline = vim.wo.cursorline,
     cursorlineopt = vim.wo.cursorlineopt,
+    foldcolumn = vim.wo.foldcolumn,
     wrap = vim.wo.wrap,
     list = vim.wo.list,
     spell = vim.wo.spell,
@@ -123,6 +124,7 @@ local restore_local_window_settings = function(winid)
   if wo then
     vim.wo.cursorline = wo.cursorline
     vim.wo.cursorlineopt = wo.cursorlineopt
+    vim.wo.foldcolumn = wo.foldcolumn
     vim.wo.wrap = wo.wrap
     vim.wo.list = wo.list
     vim.wo.spell = wo.spell


### PR DESCRIPTION
Fixes #867

I've gone through the `neo-tree` source code and nowhere does it set `foldcolumn` so I'm honestly not sure when/where it's getting set to `0`, but this does resolve the issue perfectly. Let me know what you think!