### PR TITLE
fix: set correct winid when window.position = current

### DIFF
--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -244,7 +244,6 @@ end
 M.setup = function(config, is_auto_config)
   M.config = require("neo-tree.setup").merge_config(config, is_auto_config)
   local netrw = require("neo-tree.setup.netrw")
-  netrw.config = M.config
   if not is_auto_config and netrw.get_hijack_netrw_behavior() ~= "disabled" then
     vim.cmd("silent! autocmd! FileExplorer *")
   end

--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -244,6 +244,7 @@ end
 M.setup = function(config, is_auto_config)
   M.config = require("neo-tree.setup").merge_config(config, is_auto_config)
   local netrw = require("neo-tree.setup.netrw")
+  netrw.config = M.config
   if not is_auto_config and netrw.get_hijack_netrw_behavior() ~= "disabled" then
     vim.cmd("silent! autocmd! FileExplorer *")
   end

--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -72,7 +72,8 @@ M.execute = function(args)
 
   -- Now get the correct state
   local state
-  if args.position == "current" then
+  local requested_position = args.position or nt.config[args.source].window.position
+  if requested_position == "current" then
     local winid = vim.api.nvim_get_current_win()
     state = manager.get_state(args.source, nil, winid)
   else

--- a/lua/neo-tree/setup/netrw.lua
+++ b/lua/neo-tree/setup/netrw.lua
@@ -5,14 +5,16 @@ local command = require("neo-tree.command")
 local M = {}
 
 local get_position = function(source_name)
-  local pos = utils.get_value(M, "config." .. source_name .. ".window.position", "left")
+  local nt = require("neo-tree")
+  local default_pos = utils.get_value(nt.config, "window.position", "left", true)
+  local pos = utils.get_value(nt.config, source_name .. ".window.position", default_pos, true)
   return pos
 end
 
 M.get_hijack_netrw_behavior = function()
   local nt = require("neo-tree")
   local option = "filesystem.hijack_netrw_behavior"
-  local hijack_behavior = utils.get_value(nt.config, option, "open_default")
+  local hijack_behavior = utils.get_value(nt.config, option, "open_default", true)
   if hijack_behavior == "disabled" then
     return hijack_behavior
   elseif hijack_behavior == "open_default" then

--- a/lua/neo-tree/setup/netrw.lua
+++ b/lua/neo-tree/setup/netrw.lua
@@ -6,7 +6,7 @@ local M = {}
 
 local get_position = function(source_name)
   local nt = require("neo-tree")
-  local pos = utils.get_value(nt.config, source_name .. ".window.position", default_pos, true)
+  local pos = utils.get_value(nt.config, source_name .. ".window.position", "left", true)
   return pos
 end
 

--- a/lua/neo-tree/setup/netrw.lua
+++ b/lua/neo-tree/setup/netrw.lua
@@ -5,7 +5,9 @@ local command = require("neo-tree.command")
 local M = {}
 
 local get_position = function(source_name)
-  local pos = utils.get_value(M, "config." .. source_name .. ".window.position", "left", true)
+  local nt = require("neo-tree")
+  local default_pos = utils.get_value(nt.config, "window.position", "left", true)
+  local pos = utils.get_value(nt.config, source_name .. ".window.position", default_pos, true)
   return pos
 end
 

--- a/lua/neo-tree/setup/netrw.lua
+++ b/lua/neo-tree/setup/netrw.lua
@@ -5,9 +5,7 @@ local command = require("neo-tree.command")
 local M = {}
 
 local get_position = function(source_name)
-  local nt = require("neo-tree")
-  local default_pos = utils.get_value(nt.config, "window.position", "left", true)
-  local pos = utils.get_value(nt.config, source_name .. ".window.position", default_pos, true)
+  local pos = utils.get_value(M, "config." .. source_name .. ".window.position", "left", true)
   return pos
 end
 

--- a/lua/neo-tree/setup/netrw.lua
+++ b/lua/neo-tree/setup/netrw.lua
@@ -6,7 +6,6 @@ local M = {}
 
 local get_position = function(source_name)
   local nt = require("neo-tree")
-  local default_pos = utils.get_value(nt.config, "window.position", "left", true)
   local pos = utils.get_value(nt.config, source_name .. ".window.position", default_pos, true)
   return pos
 end


### PR DESCRIPTION
Fixes #845 and #822

`:Neotree` and the default `hijack_netrw` behaviour would fail if `config.window.postion = current`. It seems that both `execute` in`command/init.lua` and `hijack` in `setup/netrw.lua` didn't set the correct winid in state when `config.window.position = current`. Changes to fix this are minimal and just involve getting the window position from the config.

This is my first PR to open source 🥳 and I'm quite new to neovim plugin development, any feedback would be appreciated.
