### PR TITLE
873 source selector shenanigans

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
       - v2.x
       - v3.x
   pull_request:
-    branches:
-      - main
 
 jobs:
   stylua-check:

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -50,9 +50,6 @@ local config = {
     show_scrolled_off_parent_node = false, -- this will replace the tabs with the parent path
                                            -- of the top visible node when scrolled down.
     tab_labels = { -- falls back to source_name if nil
-      filesystem = "  Files ",
-      buffers =    "  Buffers ",
-      git_status = "  Git ",
       diagnostics = " 裂Diagnostics ",
     },
     content_layout = "start", -- only with `tabs_layout` = "equal", "focus"

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -596,8 +596,17 @@ M.merge_config = function(user_config, is_auto_config)
   end
   --print(vim.inspect(default_config.filesystem))
 
+  -- Moving user_config.sources to user_config.orig_sources
+  user_config.orig_sources = user_config.sources and user_config.sources or {}
+
   -- apply the users config
   M.config = vim.tbl_deep_extend("force", default_config, user_config)
+
+  -- RE: 873, fixes issue with invalid source checking by overriding
+  -- source table with name table
+  -- Setting new "sources" to be the parsed names of the sources
+  M.config.sources = all_source_names
+
   if not M.config.enable_git_status then
     M.config.git_status_async = false
   end

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -607,6 +607,20 @@ M.merge_config = function(user_config, is_auto_config)
   -- Setting new "sources" to be the parsed names of the sources
   M.config.sources = all_source_names
 
+  -- Check if the default source is not included in config.sources
+  -- log a warning and then "pick" the first in the sources list
+  local match = false
+  for _, source in ipairs(M.config.sources) do
+      if source == M.config.default_source then
+        match = true
+        break
+      end
+  end
+  if not match then
+    M.config.default_source = M.config.sources[1]
+    log.warn(string.format("Invalid default source found in configuration. Using first available source: %s", M.config.default_source))
+  end
+
   if not M.config.enable_git_status then
     M.config.git_status_async = false
   end

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -560,6 +560,7 @@ M.merge_config = function(user_config, is_auto_config)
     source_default_config.components = module.components or require(mod_root .. ".components")
     source_default_config.commands = module.commands or require(mod_root .. ".commands")
     source_default_config.name = source_name
+    source_default_config.display_name = module.display_name or source_default_config.name
 
     if user_config.use_default_mappings == false then
       default_config.window.mappings = {}

--- a/lua/neo-tree/sources/buffers/init.lua
+++ b/lua/neo-tree/sources/buffers/init.lua
@@ -9,7 +9,10 @@ local events = require("neo-tree.events")
 local manager = require("neo-tree.sources.manager")
 local git = require("neo-tree.git")
 
-local M = { name = "buffers" }
+local M = {
+  name = "buffers",
+  display_name = "  Buffers "
+}
 
 local wrap = function(func)
   return utils.wrap(func, M.name)

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -11,7 +11,10 @@ local manager = require("neo-tree.sources.manager")
 local git = require("neo-tree.git")
 local glob = require("neo-tree.sources.filesystem.lib.globtopattern")
 
-local M = { name = "filesystem" }
+local M = {
+  name = "filesystem",
+  display_name = "  Files "
+}
 
 local wrap = function(func)
   return utils.wrap(func, M.name)

--- a/lua/neo-tree/sources/git_status/init.lua
+++ b/lua/neo-tree/sources/git_status/init.lua
@@ -8,7 +8,10 @@ local items = require("neo-tree.sources.git_status.lib.items")
 local events = require("neo-tree.events")
 local manager = require("neo-tree.sources.manager")
 
-local M = { name = "git_status" }
+local M = {
+  name = "git_status",
+  display_name = "  Git "
+}
 
 local wrap = function(func)
   return utils.wrap(func, M.name)

--- a/lua/neo-tree/ui/selector.lua
+++ b/lua/neo-tree/ui/selector.lua
@@ -102,8 +102,9 @@ local get_selector_tab_info = function(source_name, source_index, is_active, sep
     log.warn("Cannot find source_selector config. `create_selector` abort.")
     return {}
   end
+  local source_config = config[source_name] or {}
   local get_strlen = vim.api.nvim_strwidth
-  local text = separator_config.tab_labels[source_name] or source_name
+  local text = separator_config.tab_labels[source_name] or source_config.display_name or source_name
   local text_length = get_strlen(text)
   if separator_config.tabs_min_width ~= nil and text_length < separator_config.tabs_min_width then
     text = M.text_layout(text, separator_config.content_layout, separator_config.tabs_min_width)


### PR DESCRIPTION
This accomplishes 3 things

1) Resolves the issues initially reported in #873 (Source selector now reads names instead of module paths)  
2) Corrects potential error in `default_source` being nil (and tosses a warning to the user in the event that they do set it to nil)  
3) Adds a new attribute that sources can return called `display_name`. This is then interpreted into the source selectors "tab" name. If this attribute isn't provided, the source's name is used instead. These can still currently be overridden by the `config.source_selector.tab_labels`. I have also updated the internal sources to use this `display_name` instead of relying on the configuration to provide it for them.
