### PR TITLE
Configurable source selector entries

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -771,7 +771,7 @@ source to add to the bar. A second optional `display_name` key can be
 provided to modify how you wish that source to appear in the bar. It is
 safe to add sources that do not exist, they will simply be omitted from
 the bar if they cannot be found.
-NOTE: If `source_selector` is enabled (via `winbar=true` or `statusbar=true`)
+NOTE: If `source_selector` is enabled (via `winbar=true` or `statusline=true`)
 then the `default_source` will be updated to be the first entry of
 `sources`.
 

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -729,12 +729,6 @@ type notations.
                     display_name = "  Git "                          -- string | nil
                 },
             },
-            tab_labels = {                                            -- table
-                filesystem = "  Files ",                             -- string | nil
-                buffers =    "  Buffers ",                           -- string | nil
-                git_status = "  Git ",                               -- string | nil
-                diagnostics = " 裂Diagnostics " ,                     -- string | nil
-            },
             content_layout = "start",                                 -- string
             tabs_layout = "equal",                                    -- string
             truncation_character = "…",                               -- string

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -715,6 +715,20 @@ type notations.
             winbar = false, -- toggle to show selector on winbar
             statusline = false, -- toggle to show selector on statusline
             show_scrolled_off_parent_node = false,                    -- boolean
+            sources = {                                               -- table
+                {
+                    source = "filesystem",                            -- string
+                    display_name = "  Files "                        -- string | nil
+                },
+                {
+                    source = "buffers",                               -- string
+                    display_name = "  Buffers                        -- string | nil
+                },
+                {
+                    source = "git_status",                            -- string
+                    display_name = "  Git "                          -- string | nil
+                },
+            },
             tab_labels = {                                            -- table
                 filesystem = "  Files ",                             -- string | nil
                 buffers =    "  Buffers ",                           -- string | nil
@@ -750,10 +764,16 @@ Configuration Options:
 When `show_scrolled_off_parent_node` is `true`, tabs are replaced with the parent
 path of the top visible node when scrolled down.
 
-`tab_labels` is a table to configure the characters shown on each tab. Keys of
-the table should match the source names defined in `sources`. Value is what is
-printed inside the tab. If value is `nil` or not set, the source name is used
-instead.
+`sources` is a table to configure the contents of the bar. Previously known
+as `tab_labels`. Sources should be a table of tables. Each table inside
+`sources` must contain a `source` key, which will refer to the "name" of the
+source to add to the bar. A second optional `display_name` key can be
+provided to modify how you wish that source to appear in the bar. It is
+safe to add sources that do not exist, they will simply be omitted from
+the bar if they cannot be found.
+NOTE: If `source_selector` is enabled (via `winbar=true` or `statusbar=true`)
+then the `default_source` will be updated to be the first entry of
+`sources`.
 
 `content_layout` defines how the labels are placed inside a tab. This only takes
 effect when the tab width is greater than the length of label i.e.

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -51,9 +51,10 @@ local config = {
     statusline = false, -- toggle to show selector on statusline
     show_scrolled_off_parent_node = false, -- this will replace the tabs with the parent path
                                            -- of the top visible node when scrolled down.
-    tab_labels = { -- falls back to source_name if nil
-      diagnostics = " 裂Diagnostics ",
-      document_symbols = "  Symbols ",
+    sources = {
+      { source = "filesystem" },
+      { source = "buffers" },
+      { source = "git_status" },
     },
     content_layout = "start", -- only with `tabs_layout` = "equal", "focus"
     --                start  : |/ 裡 bufname     \/...

--- a/lua/neo-tree/setup/deprecations.lua
+++ b/lua/neo-tree/setup/deprecations.lua
@@ -34,12 +34,12 @@ M.migrate = function(config)
   migrations = {}
 
   local moved = function(old, new, converter)
-    local exising = utils.get_value(config, old)
-    if type(exising) ~= "nil" then
+    local existing = utils.get_value(config, old)
+    if type(existing) ~= "nil" then
       if type(converter) == "function" then
-        exising = converter(exising)
+        existing = converter(existing)
       end
-      utils.set_value(config, new, exising)
+      utils.set_value(config, new, existing)
       config[old] = nil
       migrations[#migrations + 1] =
         string.format("The `%s` option has been deprecated, please use `%s` instead.", old, new)

--- a/lua/neo-tree/setup/deprecations.lua
+++ b/lua/neo-tree/setup/deprecations.lua
@@ -67,10 +67,19 @@ M.migrate = function(config)
     return not value
   end
 
+  local tab_to_source_migrator = function(labels)
+    local converted_sources = {}
+    for entry, label in pairs(labels) do
+      table.insert(converted_sources, { source = entry, display_name = label })
+    end
+    return converted_sources
+  end
+
   moved("filesystem.filters", "filesystem.filtered_items")
   moved("filesystem.filters.show_hidden", "filesystem.filtered_items.hide_dotfiles", opposite)
   moved("filesystem.filters.respect_gitignore", "filesystem.filtered_items.hide_gitignored")
   moved("open_files_do_not_replace_filetypes", "open_files_do_not_replace_types")
+  moved("source_selector.tab_labels", "source_selector.sources", tab_to_source_migrator)
   removed("filesystem.filters.gitignore_source")
   removed("filesystem.filter_items.gitignore_source")
   renamed_value("filesystem.hijack_netrw_behavior", "open_split", "open_current")

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -648,7 +648,7 @@ M.merge_config = function(user_config, is_auto_config)
   end
 
   -- Validate that the source_selector.sources are all available and if any
-  -- aren't remove, remove them
+  -- aren't, remove them
   local source_selector_sources = {}
   for _, ss_source in ipairs(M.config.source_selector.sources or {}) do
     local source_match = false

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -618,7 +618,7 @@ M.merge_config = function(user_config, is_auto_config)
   -- Setting new "sources" to be the parsed names of the sources
   M.config.sources = all_source_names
 
-  if ( M.config.source_selector.winbar or M.config.source_selector.statusbar )
+  if ( M.config.source_selector.winbar or M.config.source_selector.statusline )
     and M.config.source_selector.sources
     and not user_config.default_source then
     -- Set the default source to the head of these

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -618,6 +618,17 @@ M.merge_config = function(user_config, is_auto_config)
   -- Setting new "sources" to be the parsed names of the sources
   M.config.sources = all_source_names
 
+  if ( M.config.source_selector.winbar or M.config.source_selector.statusbar )
+    and M.config.source_selector.sources
+    and not user_config.default_source then
+    -- Set the default source to the head of these
+    -- This resolves some weirdness with the source selector having
+    -- a different "head" item than our current default.
+    -- Removing this line makes Neo-tree show the "filesystem"
+    -- source instead of whatever the first item in the config is.
+    -- Probably don't remove this unless you have a better fix for that
+    M.config.default_source = M.config.source_selector.sources[1].source
+  end
   -- Check if the default source is not included in config.sources
   -- log a warning and then "pick" the first in the sources list
   local match = false
@@ -635,6 +646,25 @@ M.merge_config = function(user_config, is_auto_config)
   if not M.config.enable_git_status then
     M.config.git_status_async = false
   end
+
+  -- Validate that the source_selector.sources are all available and if any
+  -- aren't remove, remove them
+  local source_selector_sources = {}
+  for _, ss_source in ipairs(M.config.source_selector.sources or {}) do
+    local source_match = false
+    for _, source in ipairs(M.config.sources) do
+      if ss_source.source == source then
+        source_match = true
+        break
+      end
+    end
+    if source_match then
+      table.insert(source_selector_sources, ss_source)
+    else
+      log.debug(string.format("Unable to locate Neo-tree extension %s", ss_source.source))
+    end
+  end
+  M.config.source_selector.sources = source_selector_sources
 
   file_nesting.setup(M.config.nesting_rules)
 

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -371,9 +371,10 @@ end
 
 M.next_source = function(state)
   local sources = require("neo-tree").config.sources
+  local sources = require("neo-tree").config.source_selector.sources
   local next_source = sources[1]
-  for i, source in ipairs(sources) do
-    if source == state.name then
+  for i, source_info in ipairs(sources) do
+    if source_info.source == state.name then
       next_source = sources[i + 1]
       if not next_source then
         next_source = sources[1]
@@ -383,7 +384,7 @@ M.next_source = function(state)
   end
 
   require("neo-tree.command").execute({
-    source = next_source,
+    source = next_source.source,
     position = state.current_position,
     action = "focus",
   })
@@ -391,9 +392,10 @@ end
 
 M.prev_source = function(state)
   local sources = require("neo-tree").config.sources
+  local sources = require("neo-tree").config.source_selector.sources
   local next_source = sources[#sources]
-  for i, source in ipairs(sources) do
-    if source == state.name then
+  for i, source_info in ipairs(sources) do
+    if source_info.source == state.name then
       next_source = sources[i - 1]
       if not next_source then
         next_source = sources[#sources]
@@ -403,7 +405,7 @@ M.prev_source = function(state)
   end
 
   require("neo-tree.command").execute({
-    source = next_source,
+    source = next_source.source,
     position = state.current_position,
     action = "focus",
   })

--- a/lua/neo-tree/sources/document_symbols/init.lua
+++ b/lua/neo-tree/sources/document_symbols/init.lua
@@ -7,7 +7,10 @@ local events = require("neo-tree.events")
 local utils = require("neo-tree.utils")
 local symbols = require("neo-tree.sources.document_symbols.lib.symbols_utils")
 
-local M = { name = "document_symbols" }
+local M = {
+  name = "document_symbols",
+  display_name = '  Symbols '
+}
 
 local get_state = function()
   return manager.get_state(M.name)

--- a/lua/neo-tree/ui/selector.lua
+++ b/lua/neo-tree/ui/selector.lua
@@ -12,7 +12,7 @@ local M = {}
 ---@param source_index integer: index of the source
 ---@return integer
 local calc_click_id_from_source = function(winid, source_index)
-  local base_number = #require("neo-tree").config.sources + 1
+  local base_number = #require("neo-tree").config.source_selector.sources + 1
   return base_number * winid + source_index
 end
 
@@ -22,7 +22,7 @@ end
 ---@param click_id integer: click_id
 ---@return integer, integer
 local calc_source_from_click_id = function(click_id)
-  local base_number = #require("neo-tree").config.sources + 1
+  local base_number = #require("neo-tree").config.source_selector.sources + 1
   return math.floor(click_id / base_number), click_id % base_number
 end
 ---sep_tbl:
@@ -104,7 +104,7 @@ local get_selector_tab_info = function(source_name, source_index, is_active, sep
   end
   local source_config = config[source_name] or {}
   local get_strlen = vim.api.nvim_strwidth
-  local text = separator_config.tab_labels[source_name] or source_config.display_name or source_name
+  local text = separator_config.sources[source_index].display_name or source_config.display_name or source_name
   local text_length = get_strlen(text)
   if separator_config.tabs_min_width ~= nil and text_length < separator_config.tabs_min_width then
     text = M.text_layout(text, separator_config.content_layout, separator_config.tabs_min_width)
@@ -262,10 +262,11 @@ M.get_selector = function(state, width)
 
   -- generate information of each tab (look `get_selector_tab_info` for type hint)
   local tabs = {}
-  local active_index = #config.sources
+  local sources = config.source_selector.sources
+  local active_index = #sources
   local length_sum, length_active, length_separators = 0, 0, 0
-  for i, source_name in ipairs(config.sources) do
-    local is_active = source_name == state.name
+  for i, source_info in ipairs(sources) do
+    local is_active = source_info.source == state.name
     if is_active then
       active_index = i
     end
@@ -273,9 +274,9 @@ M.get_selector = function(state, width)
       i,
       active_index,
       config.source_selector.show_separator_on_edge == false and i == 1,
-      config.source_selector.show_separator_on_edge == false and i == #config.sources
+      config.source_selector.show_separator_on_edge == false and i == #sources
     )
-    local element = get_selector_tab_info(source_name, i, is_active, separator)
+    local element = get_selector_tab_info(source_info.source, i, is_active, separator)
     length_sum = length_sum + element.length
     length_separators = length_separators + element.length - element.text_length
     if is_active then
@@ -375,7 +376,7 @@ _G.___neotree_selector_click = function(id, _, _, _)
   if id < 1 then
     return
   end
-  local sources = require("neo-tree").config.sources
+  local sources = require("neo-tree").config.source_selector.sources
   local winid, source_index = calc_source_from_click_id(id)
   local state = manager.get_state_for_window(winid)
   if state == nil then
@@ -383,7 +384,7 @@ _G.___neotree_selector_click = function(id, _, _, _)
     return
   end
   require("neo-tree.command").execute({
-    source = sources[source_index],
+    source = sources[source_index].source,
     position = state.current_position,
     action = "focus",
   })

--- a/lua/neo-tree/ui/selector.lua
+++ b/lua/neo-tree/ui/selector.lua
@@ -99,7 +99,7 @@ local get_selector_tab_info = function(source_name, source_index, is_active, sep
   local config = require("neo-tree").config
   local separator_config = utils.resolve_config_option(config, "source_selector", nil)
   if separator_config == nil then
-    log.warn("Cannot find source_selector config. `create_selector` abort.")
+    log.warn("Cannot find source_selector config. `get_selector` abort.")
     return {}
   end
   local source_config = config[source_name] or {}
@@ -248,7 +248,7 @@ end
 M.get_selector = function(state, width)
   local config = require("neo-tree").config
   if config == nil then
-    log.warn("Cannot find config. `create_selector` abort.")
+    log.warn("Cannot find config. `get_selector` abort.")
     return nil
   end
   local winid = state.winid or vim.api.nvim_get_current_win()


### PR DESCRIPTION
RE: #479

Replaces `source_selector.tab_labels` with `source_selector.sources`.

Why? This allows users to have **much** more choice over the things that are displayed in their source selector. Previously, all sources in Neo-tree were added to the source selector and there was no way to remove any of them. This will get especially painful as Neo-tree grows and more developers write sources for it.

Additionally I added some logic to ensure that if `source_selector` is active, (IE one of the display bar options is enabled), that the first option in source selector is set to the `default_source` so that when users execute `:Neotree`, their source selector properly displays the first item in the sources.

Lastly, I fixed a few logs that had invalid function names in them, and updated the name of a mispelled variable because it annoyed me lol.

Please let me know your feedback!

Tagging users from #479 that participated as that PR was closed:
@cseickel @mrbjarksen @pysan3 @mehalter