### PR TITLE
feat(document_symbols): added follow_cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ following features:
 	- [x] Symbols nesting
 	- [x] Configurable kinds' name and icon
 	- [x] Auto-refresh symbol list
+        - [x] Follow cursor
 - [ ] Commands
 	- [x] Jump to symbols, open symbol in split,... (`open_split` and friends)
 	- [x] Rename symbols (`rename`)
@@ -578,6 +579,8 @@ following features:
    - [x] LSP Support
    - [x] LSP server selection (blacklist, use first, use all, etc.)
 - [ ] CoC Support
+
+See #879 for the tracking issue of these features.
 
 This source is currently experimental, so in order to use it, you need to first 
 add `"document_symbols"` to `config.sources` and open it with the command

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1698,6 +1698,9 @@ by the LSP request "textDocument/documentSymbols".
 
 Its configuration includes the following options:
 
+follow_cursor~
+If set to `true`, will automatically focus on the symbol under the cursor.
+
 kinds~
 A table specifying how LSP kinds should be rendered. Each entry should map the
 LSP kind name to an icon and a highlight group, for example 

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -514,6 +514,7 @@ local config = {
     },
   },
   document_symbols = {
+    follow_cursor = false,
     client_filters = "first",
     renderers = {
       root = {

--- a/lua/neo-tree/sources/document_symbols/commands.lua
+++ b/lua/neo-tree/sources/document_symbols/commands.lua
@@ -22,7 +22,7 @@ M.jump_to_symbol = function(state, node)
   end
   vim.api.nvim_set_current_win(state.lsp_winid)
   local symbol_loc = node.extra.selection_range.start
-  vim.api.nvim_win_set_cursor(state.lsp_winid, { symbol_loc[1], symbol_loc[2] })
+  vim.api.nvim_win_set_cursor(state.lsp_winid, { symbol_loc[1] + 1, symbol_loc[2] })
 end
 
 M.rename = function(state)


### PR DESCRIPTION
Added functionalities to `document_symbols` to automatically focus on the symbol under the cursor. Turn this on by adding `document_symbols.follow_cursor = true`