### PR TITLE
fix(hijack): Hijack on setup for lazy load

### DIFF
--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -246,6 +246,7 @@ M.setup = function(config, is_auto_config)
   local netrw = require("neo-tree.setup.netrw")
   if not is_auto_config and netrw.get_hijack_netrw_behavior() ~= "disabled" then
     vim.cmd("silent! autocmd! FileExplorer *")
+    netrw.hijack()
   end
 end
 


### PR DESCRIPTION
closes: #828 Can not open file on first `<cr>` in lazy load.

[My comment](https://github.com/nvim-neo-tree/neo-tree.nvim/issues/828#issuecomment-1529131383) explains the detail of this bug.

With this fix, when the setup function is called, neo-tree examines current buffer once to check if its a dir buffer or not.

Usually, this check is done in an autocmd [defined here](https://github.com/nvim-neo-tree/neo-tree.nvim/blob/8d485aab32da9b8841d4af977f992b82b14af469/lua/neo-tree/setup/init.lua#L150) but this is too late in the case of lazy loading.

In order to make neo-tree work properly, we need to guarantee that the alternating buffer `"#"` must NOT be a _`dir buffer`_, and this hijack in setup function guarantees that even on lazy loading.

### Please Test It

I am pinging people over on the issue thread. I kindly ask you to test my change out if it works in your environment.
@mtfcd @barreiroleo @Oscarteg @miversen33 @lcrownover

```lua
return {
  "pysan3/neo-tree.nvim",
  branch = "hijack-on-setup-for-lazy-load",
  lazy = true,
  dependencies = {
    { "MunifTanjim/nui.nvim" },
    { "nvim-tree/nvim-web-devicons" },
  },
  cmd = { "Neotree" },
  keys = {
    { "<Leader>e", "<Cmd>Neotree toggle<CR>", remap = false, silent = true, desc = "<Cmd>Neotree toggle<CR>" },
  },
  opts = {} -- YOUR SETUP
}
```

### Old Behavior

![record](https://user-images.githubusercontent.com/41065736/235377972-d673b8ad-ab8e-4c0f-8dd3-9cdd382e813a.gif)

- Please ignore `NVIM_LIGHT_ENV`. It's doing nothing.
- I'm pressing `<CR>` two times, one for each launch of neo-tree.