### PR TITLE
feat(renderer): Ignore never show on empty dirs

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -180,13 +180,22 @@ local function get_children_async(path, callback)
   end, 1000)
 end
 
+local function filter_never_shows(paths, context)
+  if paths == nil or #paths < 1 then
+    return paths
+  end
+  return vim.tbl_filter(function(c)
+    return not context.is_a_never_show_file(c.path)
+  end, paths)
+end
+
 local function scan_dir_sync(context, path)
   process_node(context, path)
   local children = get_children_sync(path)
   for _, child in ipairs(children) do
     create_node(context, child)
     if child.type == "directory" then
-      local grandchild_nodes = get_children_sync(child.path)
+      local grandchild_nodes = filter_never_shows(get_children_sync(child.path), context)
       if
         grandchild_nodes == nil
         or #grandchild_nodes == 0

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1176,7 +1176,7 @@ M.show_nodes = function(sourceItems, state, parentId, callback)
       local scan_mode = require("neo-tree").config.filesystem.scan_mode
       if scan_mode == "deep" then
         for i, item in ipairs(sourceItems) do
-          sourceItems[i] = group_empty_dirs(item)
+          sourceItems[i] = filter_never_shows(group_empty_dirs(item))
         end
       else
         -- this is a lazy load of a single sub folder
@@ -1211,7 +1211,7 @@ M.show_nodes = function(sourceItems, state, parentId, callback)
       for _, item in ipairs(sourceItems) do
         if item.children ~= nil then
           for i, child in ipairs(item.children) do
-            item.children[i] = group_empty_dirs(child)
+            item.children[i] = filter_never_shows(group_empty_dirs(child))
           end
         end
       end

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1095,13 +1095,24 @@ draw = function(nodes, state, parent_id)
   M.position.restore(state)
 end
 
+local function filter_never_shows(node_tbl)
+  if node_tbl == nil or #node_tbl == 0 then
+    return node_tbl
+  end
+  return vim.tbl_filter(function(e)
+    local filtered_by = e.filtered_by or {}
+    return not filtered_by.never_show
+  end, node_tbl)
+end
+
 local function group_empty_dirs(node)
   if node.children == nil then
     return node
   end
 
-  local first_child = node.children[1]
-  if #node.children == 1 and first_child.type == "directory" then
+  local filtered_children = filter_never_shows(node.children)
+  local first_child = filtered_children[1]
+  if #filtered_children == 1 and first_child.type == "directory" then
     -- this is the only path that changes the tree
     -- at each step where we discover an empty directory, merge it's name with the parent
     -- then skip over it
@@ -1169,7 +1180,7 @@ M.show_nodes = function(sourceItems, state, parentId, callback)
         end
       else
         -- this is a lazy load of a single sub folder
-        group_empty_dirs(sourceItems)
+        sourceItems = filter_never_shows(group_empty_dirs(sourceItems))
         if #sourceItems == 1 and sourceItems[1].type == "directory" then
           -- This folder needs to be grouped.
           -- The goal is to just update the existing node in place.


### PR DESCRIPTION
closes #906. Please read the issue for detailed explanation.

When a directory contains a `never_show` file (e.g. `.DS_Store` in the examples), those files are counted and prevent `group_empty_dirs` to be executed.

This PR fixes that behavior and ignores `never_show` files in the first place.

FYI, `e.filtered_by.never_show` is set here.

https://github.com/nvim-neo-tree/neo-tree.nvim/blob/8d485aab32da9b8841d4af977f992b82b14af469/lua/neo-tree/sources/common/file-items.lua#L114-L148

## Old Behavior

![record](https://user-images.githubusercontent.com/41065736/235451038-02a4a844-9765-4d19-9a9d-c323193907bb.gif)

## New Behavior

![record](https://user-images.githubusercontent.com/41065736/235451191-5df68a06-2706-4eca-b63a-922f3a4f75d4.gif)

