### PR TITLE
feat(fs_actions): check file existence on fs_open error

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -365,11 +365,16 @@ M.create_node = function(in_directory, callback, using_root_directory)
             + loop.constants.O_TRUNC
           local fd = loop.fs_open(destination, "w", open_mode)
           if not fd then
-            api.nvim_err_writeln("Could not create file " .. destination)
-            return
+            if not loop.fs_stat(destination) then
+              api.nvim_err_writeln("Could not create file " .. destination)
+              return
+            else
+              log.warn("Failed to complete file creation of " .. destination)
+            end
+          else
+            loop.fs_chmod(destination, 420)
+            loop.fs_close(fd)
           end
-          loop.fs_chmod(destination, 420)
-          loop.fs_close(fd)
         end
 
         vim.schedule(function()


### PR DESCRIPTION
This might be more of a workaround than a fix but in case of working with directories mounted from samba, `fs_open` seems to fail internally after file creation but before assigning file permission.

https://github.com/nvim-neo-tree/neo-tree.nvim/issues/911#issue-1692135414

I could not diagnose the core problem but it seems to fail regardless of neo-tree as shown in the following code which end up creating a file but with permission set to `r-xr-xr-w` (I guess it's more of a samba bug?).

So, to workaround this, I'd like neo-tree to not simply bail out when `fd` is nil [here](https://github.com/nvim-neo-tree/neo-tree.nvim/blob/8d485aab32da9b8841d4af977f992b82b14af469/lua/neo-tree/sources/filesystem/lib/fs_actions.lua#L367) but rather actually check the file existence and continue on when file was indeed created.

After that, to solve the samba issue, user can overwrite the permission with `vim.fn.setfperm` in the `FILE_ADDED` event handler. (Tested that this method works with samba files)

Best,

```lua
-- test `fs_open` in samba folder
local loop = vim.loop

local open_mode = loop.constants.O_CREAT + loop.constants.O_WRONLY + loop.constants.O_TRUNC
local dst = "g"
local fd, err = loop.fs_open(dst, "w", open_mode)
assert(not err, err)
```

```txt
E5108: Error executing lua [string ":source (no file)"]:6: EACCES: permission denied: g
stack traceback:
	[C]: in function 'assert'
	[string ":source (no file)"]:6: in main chunk
```