### PR TITLE
docs(readme): add Nerd Fonts v3 fix guide for source selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,13 @@ require("neo-tree").setup({
       StaticMethod = { icon = '󰠄 ', hl = 'Function' },
     }
   },
+  -- Add this section only if you've configured source selector.
+  source_selector = {
+    sources = {
+      { source = "filesystem", display_name = " 󰉓 Files " },
+      { source = "git_status", display_name = " 󰊢 Git " },
+    },
+  },
   -- Other options ...
 })
 ```


### PR DESCRIPTION
While #921 has mentioned about fixing about Nerd Fonts v3, it missed about source selector. This PR adds it.