### PR TITLE
fix: Prevent autocmd from failing when closing modified file

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -292,19 +292,22 @@ M.win_enter_event = function()
         log.debug("close_if_last_window, modified files found: ", vim.inspect(mod))
         for filename, buf_info in pairs(mod) do
           if buf_info.modified then
+            local buf_name, message
             if vim.startswith(filename, "[No Name]#") then
-              local bufnr = string.sub(filename, 11)
-              log.trace("close_if_last_window, showing unnamed modified buffer: ", filename)
-              vim.schedule(function()
-                log.warn(
-                  "Cannot close because an unnamed buffer is modified. Please save or discard this file."
-                )
-                vim.cmd("vsplit")
-                vim.api.nvim_win_set_width(win_id, state.window.width or 40)
-                vim.cmd("b" .. bufnr)
-              end)
-              return
+              buf_name = string.sub(filename, 11)
+              message = "Cannot close because an unnamed buffer is modified. Please save or discard this file."
+            else
+              buf_name = filename
+              message = "Cannot close because one of the files is modified. Please save or discard changes."
             end
+            log.trace("close_if_last_window, showing unnamed modified buffer: ", filename)
+            vim.schedule(function()
+              log.warn(message)
+              vim.cmd("rightbelow vertical split")
+              vim.api.nvim_win_set_width(win_id, state.window.width or 40)
+              vim.cmd("b" .. buf_name)
+            end)
+            return
           end
         end
         vim.cmd("q!")
@@ -331,6 +334,7 @@ M.win_enter_event = function()
           local bufnr = vim.api.nvim_get_current_buf()
           if bufnr ~= current_bufnr then
             -- The neo-tree buffer was replaced with something else, so we don't need to do anything.
+            log.trace("neo-tree buffer replaced with something else - no further action required")
             return
           end
           -- create a new tree for this window


### PR DESCRIPTION
This fixes #870 

The root cause was that the fix from #628 was only taking into account unnamed buffers stripping from buffer name `[NoName]#` prefix to obtain the buffer nr. This caused to trim first 12 characters from the filename, which then caused `vim.cmd("b" .. bufnr)` to fail as the filename could not be found. 

There is still some flickering due to buffer being temporarily closed, but I don't think that it can be prevented. 

It is much more visible in the video than in real life (probably due to compression :thinking:)
[Kooha-2023-05-27-20-25-40.webm](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/5662622/554645b9-4c10-48cb-b3ec-855ae9eb8286)