### PR TITLE
refactor(filesystem): fix recursive expand of nodes

### DIFF
--- a/lua/neo-tree/git/ignored.lua
+++ b/lua/neo-tree/git/ignored.lua
@@ -118,7 +118,7 @@ M.mark_ignored = function(state, items, callback)
         on_exit = function(self, code, _)
           local result
           if code ~= 0 then
-            log.debug("Failed to load ignored files for", state.path, ":", self:stderr_result())
+            log.debug("Failed to load ignored files for", folder, ":", self:stderr_result())
             result = {}
           else
             result = self:result()

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -114,9 +114,6 @@ end
 ---@param state table The state of the source
 ---@param node table A node to expand
 M.expand_all_nodes = function(state, node, source_expander)
-  if node == nil then
-    node = state.tree:get_node(state.path)
-  end
   log.debug("Expanding all nodes under " .. node:get_id())
   if source_expander == nil then
     source_expander = node_expander.default_expander

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -115,6 +115,7 @@ end
 ---@param node table A node to expand
 M.expand_all_nodes = function(state, node)
   log.debug("Expanding all nodes under " .. node:get_id())
+  renderer.position.set(state, nil)
   local task = function ()
     fs.expand_directory(state, node)
   end

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -113,16 +113,17 @@ end
 ---Expand all nodes
 ---@param state table The state of the source
 ---@param node table A node to expand
-M.expand_all_nodes = function(state, node, source_expander)
+---@param prefetcher table an object with two methods `prefetch(state, node)` and `should_prefetch(node) => boolean`
+M.expand_all_nodes = function(state, node, prefetcher)
   log.debug("Expanding all nodes under " .. node:get_id())
-  if source_expander == nil then
-    source_expander = node_expander.default_expander
+  if prefetcher == nil then
+    prefetcher = node_expander.default_prefetcher
   end
 
   renderer.position.set(state, nil)
 
   local task = function ()
-    node_expander.expand_directory_recursively(state, node, source_expander)
+    node_expander.expand_directory_recursively(state, node, prefetcher)
   end
   async.run(
       task,

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -117,7 +117,7 @@ M.expand_all_nodes = function(state, node)
   log.debug("Expanding all nodes under " .. node:get_id())
   renderer.position.set(state, nil)
   local task = function ()
-    fs.expand_directory(state, node)
+    fs.expand_directory_recursively(state, node)
   end
   async.run(
       task,

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -122,9 +122,7 @@ M.expand_all_nodes = function(state, node)
       task,
       function ()
         log.debug("All nodes expanded - redrawing")
-        vim.schedule_wrap(function()
-          renderer.redraw(state)
-        end)
+        renderer.redraw(state)
       end
     )
 end

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -2,7 +2,6 @@
 
 local vim = vim
 local fs_actions = require("neo-tree.sources.filesystem.lib.fs_actions")
-local fs = require("neo-tree.sources.filesystem")
 local utils = require("neo-tree.utils")
 local renderer = require("neo-tree.ui.renderer")
 local events = require("neo-tree.events")
@@ -12,6 +11,7 @@ local log = require("neo-tree.log")
 local help = require("neo-tree.sources.common.help")
 local Preview = require("neo-tree.sources.common.preview")
 local async = require("plenary.async")
+local node_expander = require("neo-tree.sources.common.node_expander")
 
 ---Gets the node parent folder
 ---@param state table to look for nodes
@@ -113,11 +113,19 @@ end
 ---Expand all nodes
 ---@param state table The state of the source
 ---@param node table A node to expand
-M.expand_all_nodes = function(state, node)
+M.expand_all_nodes = function(state, node, source_expander)
+  if node == nil then
+    node = state.tree:get_node(state.path)
+  end
   log.debug("Expanding all nodes under " .. node:get_id())
+  if source_expander == nil then
+    source_expander = node_expander.default_expander
+  end
+
   renderer.position.set(state, nil)
+
   local task = function ()
-    fs.expand_directory_recursively(state, node)
+    node_expander.expand_directory_recursively(state, node, source_expander)
   end
   async.run(
       task,

--- a/lua/neo-tree/sources/common/node_expander.lua
+++ b/lua/neo-tree/sources/common/node_expander.lua
@@ -1,0 +1,85 @@
+local log = require("neo-tree.log")
+
+local M = {}
+
+--- Recursively expand all loaded nodes under the given node
+--- returns table with all discovered nodes that need to be loaded 
+---@param node table a node to expand
+---@param state table current state of the source
+---@return table discovered nodes that need to be loaded
+local function expand_loaded(node, state, node_expander)
+    local function rec(current_node, to_load)
+      if node_expander.should_prefetch(current_node) then
+        log.trace("Node " .. current_node:get_id() .. "not loaded, saving for later")
+        table.insert(to_load, current_node)
+      else
+        if not current_node:is_expanded() then
+          current_node:expand()
+          state.explicitly_opened_directories[current_node:get_id()] = true
+        end
+        local children = state.tree:get_nodes(current_node:get_id())
+        log.debug("Expanding childrens of " .. current_node:get_id())
+        for _, child in ipairs(children) do
+          if child.type == "directory" then
+             rec(child, to_load)
+          else
+            log.trace("Child: " .. child.name .. " is not a directory, skipping")
+          end
+        end
+      end
+    end
+
+    local to_load = {}
+    rec(node, to_load)
+    return to_load
+end
+
+--- Recursively expands all nodes under the given node
+--- loading nodes if necessary.
+--- async method
+---@param node table a node to expand
+---@param state table current state of the source
+local function expand_and_load(node, state, node_expander)
+    local function rec(to_load, progress)
+      local to_load_current = expand_loaded(node, state, node_expander)
+      for _,v in ipairs(to_load_current) do
+        table.insert(to_load, v)
+      end
+      if progress <= #to_load then
+        M.expand_directory_recursively(state, to_load[progress], node_expander)
+        rec(to_load, progress + 1)
+      end
+    end
+    rec({}, 1)
+end
+
+--- Expands given node recursively loading all descendant nodes if needed
+--- async method
+---@param state table current state of the source
+---@param node table a node to expand
+M.expand_directory_recursively = function(state, node, node_expander)
+  log.debug("Expanding directory " .. node:get_id())
+  if node.type ~= "directory" then
+    return
+  end
+  state.explicitly_opened_directories = state.explicitly_opened_directories or {}
+  if node_expander.should_prefetch(node) then
+    local id = node:get_id()
+    state.explicitly_opened_directories[id] = true
+    node_expander.prefetch(state, node)
+    expand_loaded(node, state, node_expander)
+  else
+    expand_and_load(node, state, node_expander)
+  end
+end
+
+M.default_expander = {
+  prefetch = function (state, node)
+    log.debug("Default expander prefetch does nothing")
+  end,
+  should_prefetch = function (node)
+    return false
+  end
+}
+
+return M

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -68,6 +68,9 @@ M.delete_visual = function(state, selected_nodes)
 end
 
 M.expand_all_nodes = function(state, node)
+  if node == nil then
+    node = state.tree:get_node(state.path)
+  end
   cc.expand_all_nodes(state, node, fs.expander)
 end
 

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -68,10 +68,7 @@ M.delete_visual = function(state, selected_nodes)
 end
 
 M.expand_all_nodes = function(state)
-  local toggle_dir_no_redraw = function(_state, node)
-    fs.toggle_directory(_state, node, nil, true, true)
-  end
-  cc.expand_all_nodes(state, toggle_dir_no_redraw)
+  cc.expand_all_nodes(state, state.tree:get_node(state.path))
 end
 
 ---Shows the filter input, which will filter the tree.

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -71,7 +71,7 @@ M.expand_all_nodes = function(state, node)
   if node == nil then
     node = state.tree:get_node(state.path)
   end
-  cc.expand_all_nodes(state, node, fs.expander)
+  cc.expand_all_nodes(state, node, fs.prefetcher)
 end
 
 ---Shows the filter input, which will filter the tree.

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -67,8 +67,8 @@ M.delete_visual = function(state, selected_nodes)
   cc.delete_visual(state, selected_nodes, utils.wrap(refresh, state))
 end
 
-M.expand_all_nodes = function(state)
-  cc.expand_all_nodes(state, state.tree:get_node(state.path))
+M.expand_all_nodes = function(state, node)
+  cc.expand_all_nodes(state, node, fs.expander)
 end
 
 ---Shows the filter input, which will filter the tree.

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -471,7 +471,7 @@ local function expand_and_load(node, state)
         table.insert(to_load, v)
       end
       if progress <= #to_load then
-        M.expand_directory(state, to_load[progress])
+        M.expand_directory_recursively(state, to_load[progress])
         rec(to_load, progress + 1)
       end
     end

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -428,7 +428,7 @@ M.toggle_directory = function(state, node, path_to_reveal, skip_redraw, recursiv
   end
 end
 
-M.expander = {
+M.prefetcher = {
   prefetch = function (state, node)
     log.debug("Running fs prefetch for: " .. node:get_id())
     fs_scan.get_dir_items_async(state, node:get_id(), true)

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -10,6 +10,7 @@ local log = require("neo-tree.log")
 local manager = require("neo-tree.sources.manager")
 local git = require("neo-tree.git")
 local glob = require("neo-tree.sources.filesystem.lib.globtopattern")
+local async = require("plenary.async")
 
 local M = {
   name = "filesystem",
@@ -425,6 +426,78 @@ M.toggle_directory = function(state, node, path_to_reveal, skip_redraw, recursiv
   elseif require("neo-tree").config.filesystem.scan_mode == "deep" then
     node.empty_expanded = not node.empty_expanded
     renderer.redraw(state)
+  end
+end
+
+--- Recursively expand all loaded nodes under the given node
+--- returns table with all discovered nodes that need to be loaded 
+---@param node table a node to expand
+---@param state table current state of the source
+---@return table discovered nodes that need to be loaded
+local function expand_loaded(node, state)
+    local function rec(_node, to_load)
+      if _node.loaded == false then
+        table.insert(to_load, _node)
+      else
+        if not _node:is_expanded() then
+          _node:expand()
+          state.explicitly_opened_directories[_node:get_id()] = true
+        end
+        local children = state.tree:get_nodes(_node:get_id())
+        log.debug("Expanding childrens of " .. _node:get_id())
+        for _, child in ipairs(children) do
+          if child.type == "directory" then
+             rec(child, to_load)
+          else
+            log.trace("Child: " .. child.name .. " is not a directory, skipping")
+          end
+        end
+      end
+    end
+
+    local to_load = {}
+    rec(node, to_load)
+    return to_load
+end
+
+--- Recursively expands all nodes under the given node
+--- loading nodes if necessary.
+--- asyn method
+---@param node table a node to expand
+---@param state table current state of the source
+local function expand_and_load(node, state)
+    local function rec(to_load, progress)
+      local to_load_current = expand_loaded(node, state)
+      for _,v in ipairs(to_load_current) do
+        table.insert(to_load, v)
+      end
+      if progress <= #to_load then
+        M.expand_directory(state, to_load[progress])
+        rec(to_load, progress + 1)
+      end
+    end
+    rec({}, 1)
+end
+
+---Expands given node recursively loading all descendant nodes if needed
+---async method
+---@param state table current state of the source
+---@param node table a node to expand
+M.expand_directory = function(state, node)
+  log.debug("Expanding directory " .. node:get_id())
+  if node.type ~= "directory" then
+    return
+  end
+  state.explicitly_opened_directories = state.explicitly_opened_directories or {}
+  if node.loaded == false then
+    local id = node:get_id()
+    state.explicitly_opened_directories[id] = true
+    renderer.position.set(state, nil)
+    fs_scan.get_dir_items_async(state, id, true)
+    -- ignore results as we know here that all descendant nodes have been already loaded
+    expand_loaded(node ,state)
+  else
+    expand_and_load(node, state)
   end
 end
 

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -10,7 +10,6 @@ local log = require("neo-tree.log")
 local manager = require("neo-tree.sources.manager")
 local git = require("neo-tree.git")
 local glob = require("neo-tree.sources.filesystem.lib.globtopattern")
-local async = require("plenary.async")
 
 local M = {
   name = "filesystem",

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -493,8 +493,10 @@ M.expand_directory = function(state, node)
     state.explicitly_opened_directories[id] = true
     renderer.position.set(state, nil) -- todo should not be called recursively
     fs_scan.get_dir_items_async(state, id, true)
+    expand_loaded(node, state)
+  else
+    expand_and_load(node, state)
   end
-  expand_and_load(node, state)
 end
 
 return M

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -478,11 +478,11 @@ local function expand_and_load(node, state)
     rec({}, 1)
 end
 
----Expands given node recursively loading all descendant nodes if needed
----async method
+--- Expands given node recursively loading all descendant nodes if needed
+--- async method
 ---@param state table current state of the source
 ---@param node table a node to expand
-M.expand_directory = function(state, node)
+M.expand_directory_recursively = function(state, node)
   log.debug("Expanding directory " .. node:get_id())
   if node.type ~= "directory" then
     return
@@ -491,7 +491,6 @@ M.expand_directory = function(state, node)
   if node.loaded == false then
     local id = node:get_id()
     state.explicitly_opened_directories[id] = true
-    renderer.position.set(state, nil) -- todo should not be called recursively
     fs_scan.get_dir_items_async(state, id, true)
     expand_loaded(node, state)
   else

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -393,7 +393,7 @@ M.setup = function(config, global_config)
 end
 
 ---Expands or collapses the current node.
-M.toggle_directory = function(state, node, path_to_reveal, skip_redraw, recursive)
+M.toggle_directory = function(state, node, path_to_reveal, skip_redraw, recursive, callback)
   local tree = state.tree
   if not node then
     node = tree:get_node()
@@ -406,7 +406,7 @@ M.toggle_directory = function(state, node, path_to_reveal, skip_redraw, recursiv
     local id = node:get_id()
     state.explicitly_opened_directories[id] = true
     renderer.position.set(state, nil)
-    fs_scan.get_items(state, id, path_to_reveal, nil, false, recursive)
+    fs_scan.get_items(state, id, path_to_reveal, callback, false, recursive)
   elseif node:has_children() then
     local updated = false
     if node:is_expanded() then

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -462,7 +462,7 @@ end
 
 --- Recursively expands all nodes under the given node
 --- loading nodes if necessary.
---- asyn method
+--- async method
 ---@param node table a node to expand
 ---@param state table current state of the source
 local function expand_and_load(node, state)
@@ -492,13 +492,10 @@ M.expand_directory = function(state, node)
   if node.loaded == false then
     local id = node:get_id()
     state.explicitly_opened_directories[id] = true
-    renderer.position.set(state, nil)
+    renderer.position.set(state, nil) -- todo should not be called recursively
     fs_scan.get_dir_items_async(state, id, true)
-    -- ignore results as we know here that all descendant nodes have been already loaded
-    expand_loaded(node ,state)
-  else
-    expand_and_load(node, state)
   end
+  expand_and_load(node, state)
 end
 
 return M

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -236,13 +236,13 @@ local function scan_dir_async(context, path)
         or #grandchild_nodes == 0
         or #grandchild_nodes == 1 and grandchild_nodes[1].type == "directory"
       then
-        scan_dir_sync(context, child.path)
+        scan_dir_async(context, child.path)
       end
     end
   end
 
-  log.debug("scan_dir_async - finish " .. path)
   process_node(context, path)
+  log.debug("scan_dir_async - finish " .. path)
   return path
 end
 

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -190,7 +190,8 @@ local function scan_dir_sync(context, path)
       if
         grandchild_nodes == nil
         or #grandchild_nodes == 0
-        or #grandchild_nodes == 1 and grandchild_nodes[1].type == "directory"
+        or (#grandchild_nodes == 1 and grandchild_nodes[1].type == "directory")
+        or context.recursive
       then
         scan_dir_sync(context, child.path)
       end

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -11,9 +11,6 @@ local git = require("neo-tree.git")
 local events = require("neo-tree.events")
 local async = require("plenary.async")
 
-local Path = require("plenary.path")
-local os_sep = Path.path.sep
-
 local M = {}
 
 local on_directory_loaded = function(context, dir_path)
@@ -223,15 +220,15 @@ end
 local function scan_dir_async(context, path)
   log.debug("scan_dir_async - start " .. path)
 
-  local get_children = async.wrap(function (callback)
-    return get_children_async(path, callback)
-  end, 1)
+  local get_children = async.wrap(function (_path, callback)
+    return get_children_async(_path, callback)
+  end, 2)
 
-  local children = get_children()
+  local children = get_children(path)
   for _, child in ipairs(children) do
     create_node(context, child)
     if child.type == "directory" then
-      local grandchild_nodes = get_children_sync(child.path)
+      local grandchild_nodes = get_children(child.path)
       if
         grandchild_nodes == nil
         or #grandchild_nodes == 0

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -219,6 +219,7 @@ local function scan_dir_sync(context, path)
   end
 end
 
+--- async method
 local function scan_dir_async(context, path)
   log.debug("scan_dir_async - start " .. path)
 
@@ -234,7 +235,8 @@ local function scan_dir_async(context, path)
       if
         grandchild_nodes == nil
         or #grandchild_nodes == 0
-        or #grandchild_nodes == 1 and grandchild_nodes[1].type == "directory"
+        or (#grandchild_nodes == 1 and grandchild_nodes[1].type == "directory")
+        or context.recursive
       then
         scan_dir_async(context, child.path)
       end
@@ -520,7 +522,7 @@ M.get_items = function(state, parent_id, path_to_reveal, callback, async, recurs
 end
 
 -- async method
-M.get_dir_items_async = function(state, parent_id, recursive)
+M.get_dir_items_async = function(state, parent_id, recursive, expand)
   local context = file_items.create_context()
   context.state = state
   context.parent_id = parent_id

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -255,11 +255,9 @@ local function async_scan(context, path)
   if scan_mode == "deep" then
     local scan_tasks = {}
     for _, p in ipairs(context.paths_to_load) do
-      local scan_task = async.wrap(function(callback)
-        async.run(function ()
-            scan_dir_async(context, p)
-        end, callback)
-      end, 1)
+      local scan_task = function ()
+        scan_dir_async(context, p)
+      end
       table.insert(scan_tasks, scan_task)
     end
 

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -522,7 +522,7 @@ M.get_items = function(state, parent_id, path_to_reveal, callback, async, recurs
 end
 
 -- async method
-M.get_dir_items_async = function(state, parent_id, recursive, expand)
+M.get_dir_items_async = function(state, parent_id, recursive)
   local context = file_items.create_context()
   context.state = state
   context.parent_id = parent_id

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1198,7 +1198,7 @@ M.show_nodes = function(sourceItems, state, parentId, callback)
             if node.id == parent.id then
               item.name = parent.name .. utils.path_separator .. item.name
               item.level = level - 1
-              item.is_loaded = utils.truthy(item.children)
+              item.loaded = utils.truthy(item.children)
               siblings[i] = NuiTree.Node(item, item.children)
               break
             end


### PR DESCRIPTION
This relates to #701 

This is not a full fix for the builtin `expand_all_nodes` method but rather a fix that enables fixing it. It also enables fixing function from wiki to recursively expand nodes under the cursor (more important in my opinion).


List of changes broken down by commit:
1. Add callback to `toggle_directory` - this is the most important. Luckily it is not a breaking change because callback was previously `nil` anyway. 
    Justification:
   `fs.toggle_directory` calls `fs_scan.get_items` that calls `sync_scan` that for the 
   `scan_mode=="shallow"` calls `sync_scan` and then `job_complete`. 

   Here is where the problem starts - `job_complete` checks if `git_status_async` is set and 
   if so it registers a callback in `git.mark_ignored` method. That callback is important 
   because it eventually calls `render_context` that updates the nodes. That callback will be 
   called at some point later in time, but the execution continues in the meantime. Because 
   of that it is not guaranteed that we will have updated results by the time we start 
   expanding nodes. 
3. Small refactoring - method extraction. Can be removed from the list of changes if desired.
4. Small fix for the recursive traversals when `deep` strategy was used. 

I did not fix the `expand_all_nodes` because I didn't know how can I obtain the root element of the whole filesystem tree. The root element is needed so that we can start expanding from it rather than expanding from its children like it is now:
```lua
  for _, node in ipairs(state.tree:get_nodes()) do
    expand_node(node)
  end
```
This is important so that we can have a single callback that we pass to `toggle_directory`. Otherwise, this method will spawn as many processes as there are nodes on the top level. Tbh I would remove this method. 

And here is a fixed method to expand recursively nodes under the cursor `recursive_open`:
```lua
    local function expand_all(state, root)
        local toggle_directory = function(_, node)
            node:expand()
        end

        local expand_node
        expand_node = function(node)
            local id = node:get_id()
            if node.type == "directory" and not node:is_expanded() then
                toggle_directory(state, node)
                node = state.tree:get_node(id)
            end
            local children = state.tree:get_nodes(id)
            if children then
                for _, child in ipairs(children) do
                    if child.type == "directory" then
                        expand_node(child)
                    end
                end
            end
        end

        expand_node(root)
        renderer.redraw(state)
    end

    local function open_dir(state, dir_node, callback)
        local fs = require "neo-tree.sources.filesystem"
        fs.toggle_directory(state, dir_node, nil, true, true, callback)
    end

    -- Expand a node and all its children
    -- does not handle max_depth
    local function recursive_open(state, node, max_depth)
        open_dir(state, node, function()
            expand_all(state, node)
        end)
    end
```

Tested both with `deep` and `shallow` strategies. 