### PR TITLE
feat(state): attach diagnostics_lookup on creation

### DIFF
--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -42,6 +42,7 @@ local function create_state(tabid, sd, winid)
   state.position = {
     is = { restorable = false },
   }
+  state.diagnostics_lookup = utils.get_diagnostic_counts()
   state.git_base = "HEAD"
   table.insert(all_states, state)
   return state


### PR DESCRIPTION
Closes #901.

## Fixes

The very first instantiation of a `state` always goes through this function.
So, I added the call to `utils.get_diagnostic_counts()` to add `diagnostics_lookup` field to state to lookup the diagnostics numbers even on the first launch of the tree.
Even before the first `DiagnosticChanged` event.

## Details

- https://github.com/nvim-neo-tree/neo-tree.nvim/issues/901#issuecomment-1560942607
- https://github.com/nvim-neo-tree/neo-tree.nvim/issues/901#issuecomment-1561123356