### PR TITLE
Fix #960 wrap in `pcall` failing `closedir` call

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -160,7 +160,7 @@ local function get_children_sync(path)
       table.insert(children, { path = child_path, type = stat.type })
     end
   end
-  vim.loop.fs_closedir(dir)
+  pcall(vim.loop.fs_closedir, dir)
   return children
 end
 


### PR DESCRIPTION
To resolve issue #960, the PR wraps the code block with a `pcall` function, effectively preventing the error from being raised. 

Windows user can use `nvim` even if the folder contains subfolders with higher permissions, for example in the HOME directory the `Cookie` folder did mess with this plugin.