### PR TITLE
fix: do not restore bad state for top line when opening neotree

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -619,14 +619,14 @@ M.position = {
       local success, node = pcall(state.tree.get_node, state.tree)
       if success and node then
         _, state.position.node_id = pcall(node.get_id, node)
+        local win_state = vim.fn.winsaveview()
+        state.position.topline = win_state.topline
       end
+      -- Only need to restore the cursor state once per save, comes
+      -- into play when some actions fire multiple times per "iteration"
+      -- within the scope of where we need to perform the restore operation
+      state.position.is.restorable = true
     end
-    local win_state = vim.fn.winsaveview()
-    state.position.topline = win_state.topline
-    -- Only need to restore the cursor state once per save, comes
-    -- into play when some actions fire multiple times per "iteration"
-    -- within the scope of where we need to perform the restore operation
-    state.position.is.restorable = true
   end,
   set = function(state, node_id)
     if not type(node_id) == "string" and node_id > "" then
@@ -643,11 +643,11 @@ M.position = {
     if state.position.is.restorable then
       log.debug("Restoring position to node_id: " .. state.position.node_id)
       M.focus_node(state, state.position.node_id, true)
+      if state.position.topline then
+         vim.fn.winrestview({ topline = state.position.topline })
+      end
     else
       log.debug("Position is not restorable")
-    end
-    if state.position.topline then
-        vim.fn.winrestview({ topline = state.position.topline })
     end
     state.position.is.restorable = false
   end,


### PR DESCRIPTION
this is a follow up to #953, which was a fix for #781

This fixes the problem where if you open `:Neotree current` in a window that has a terminal that has a lot of lines, then the tree will be scrolled down as far as it can go. I didn't really trace the execution, I just moved the save and restore of the window top line within the same conditionals as the saving of the currently focused node. It make sense that whatever situation would prevent a save/restore of the current node would also apply to the window scroll position.

FYI: @ghostbuster91 
