### PR TITLE
feat(fs_actions): Add support for non-`/` path separator in `fs_actions.create_node`

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -356,6 +356,7 @@ M.create_node = function(in_directory, callback, using_root_directory)
           destination = vim.fn.fnamemodify(destination, ":p")
         end
 
+        if utils.is_windows then destination = utils.windowize_path(destination) end
         if loop.fs_stat(destination) then
           log.warn("File already exists")
           return

--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -331,8 +331,13 @@ M.create_node = function(in_directory, callback, using_root_directory)
     using_root_directory = false
   end
 
+  local dir_ending = '"/"'
+  if utils.path_separator ~= '/' then
+    dir_ending = dir_ending .. string.format(' or "%s"', utils.path_separator)
+  end
+  local msg = 'Enter name for new file or directory (dirs end with a ' .. dir_ending .. ')'
   inputs.input(
-    'Enter name for new file or directory (dirs end with a "/"):',
+    msg,
     base,
     function(destinations)
       if not destinations then
@@ -343,7 +348,7 @@ M.create_node = function(in_directory, callback, using_root_directory)
         if not destination or destination == base then
           return
         end
-        local is_dir = vim.endswith(destination, "/")
+        local is_dir = vim.endswith(destination, "/") or vim.endswith(destination, utils.path_separator)
 
         if using_root_directory then
           destination = utils.path_join(using_root_directory, destination)

--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -335,7 +335,7 @@ M.create_node = function(in_directory, callback, using_root_directory)
   if utils.path_separator ~= '/' then
     dir_ending = dir_ending .. string.format(' or "%s"', utils.path_separator)
   end
-  local msg = 'Enter name for new file or directory (dirs end with a ' .. dir_ending .. ')'
+  local msg = 'Enter name for new file or directory (dirs end with a ' .. dir_ending .. '):'
   inputs.input(
     msg,
     base,


### PR DESCRIPTION
Ironing out some quirks with `create_node()` when using Neovim in Windows 11:

1. Added an extra prompt + check to allow users to use either `/` or their native `path_separator` if they are different.
2. When creating nested directories, the command silently fails when using `/`, but works as intended when using `\`. Example in the demo video below. Might be a libuv issue? Seems like it can be worked around by sanitizing with `windowize_path`.

https://github.com/nvim-neo-tree/neo-tree.nvim/assets/43484729/6b556928-8eec-43b7-a2f1-367523e3851d

