### PR TITLE
feat(state): attach diagnostics_lookup on creation

### DIFF
--- a/lua/neo-tree/events/init.lua
+++ b/lua/neo-tree/events/init.lua
@@ -5,6 +5,7 @@ local utils = require("neo-tree.utils")
 
 local M = {
   -- Well known event names, you can make up your own
+  STATE_CREATED = "state_created",
   BEFORE_RENDER = "before_render",
   AFTER_RENDER = "after_render",
   FILE_ADDED = "file_added",

--- a/lua/neo-tree/sources/buffers/init.lua
+++ b/lua/neo-tree/sources/buffers/init.lua
@@ -162,6 +162,12 @@ M.setup = function(config, global_config)
 
   if global_config.enable_diagnostics then
     manager.subscribe(M.name, {
+      event = events.STATE_CREATED,
+      handler = function(state)
+        state.diagnostics_lookup = utils.get_diagnostic_counts()
+      end,
+    })
+    manager.subscribe(M.name, {
       event = events.VIM_DIAGNOSTIC_CHANGED,
       handler = wrap(manager.diagnostics_changed),
     })

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -357,6 +357,12 @@ M.setup = function(config, global_config)
   --Configure event handlers for lsp diagnostic updates
   if global_config.enable_diagnostics then
     manager.subscribe(M.name, {
+      event = events.STATE_CREATED,
+      handler = function(state)
+        state.diagnostics_lookup = utils.get_diagnostic_counts()
+      end,
+    })
+    manager.subscribe(M.name, {
       event = events.VIM_DIAGNOSTIC_CHANGED,
       handler = wrap(manager.diagnostics_changed),
     })

--- a/lua/neo-tree/sources/git_status/init.lua
+++ b/lua/neo-tree/sources/git_status/init.lua
@@ -72,6 +72,12 @@ M.setup = function(config, global_config)
 
   if global_config.enable_diagnostics then
     manager.subscribe(M.name, {
+      event = events.STATE_CREATED,
+      handler = function(state)
+        state.diagnostics_lookup = utils.get_diagnostic_counts()
+      end,
+    })
+    manager.subscribe(M.name, {
       event = events.VIM_DIAGNOSTIC_CHANGED,
       handler = wrap(manager.diagnostics_changed),
     })

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -43,6 +43,7 @@ local function create_state(tabid, sd, winid)
     is = { restorable = false },
   }
   state.git_base = "HEAD"
+  events.fire_event(events.STATE_CREATED, state)
   table.insert(all_states, state)
   return state
 end


### PR DESCRIPTION
Basically a duplicate of #959 but with a different approach.

As @cseickel pointed in the comment linked below, it is not possible to update `state.diagnositics_lookup` on state creation while referring to `config.enable_diagnostics`. https://github.com/nvim-neo-tree/neo-tree.nvim/pull/959#discussion_r1209276814

So instead, this PR adds a `STATE_CREATED` event that can be subscribed to, and is called on state creation (`sources/manager.lua > create_state()`).

Closes #901.

## Details

- https://github.com/nvim-neo-tree/neo-tree.nvim/issues/901#issuecomment-1560942607
- https://github.com/nvim-neo-tree/neo-tree.nvim/issues/901#issuecomment-1561123356