### PR TITLE
fix(fuzzy): delay `open_file` after search to navigate first

### DIFF
--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -218,13 +218,16 @@ M.reset_search = function(state, refresh, open_current_node)
           pcall(renderer.focus_node, state, path, false)
         end)
       else
-        utils.open_file(state, path)
         if
           refresh
           and state.current_position ~= "current"
           and state.current_position ~= "float"
         then
-          M.navigate(state, nil, path)
+          M.navigate(state, nil, path, function()
+            utils.open_file(state, path)
+          end)
+        else
+          utils.open_file(state, path)
         end
       end
     end

--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -547,7 +547,7 @@ end
 ---Open file in the appropriate window.
 ---@param state table The state of the source
 ---@param path string The file to open
----@param open_cmd string The vimcommand to use to open the file
+---@param open_cmd string? The vimcommand to use to open the file
 ---@param bufnr number|nil The buffer number to open
 M.open_file = function(state, path, open_cmd, bufnr)
   open_cmd = open_cmd or "edit"


### PR DESCRIPTION
Closes #948.

### Details

`M.navigate` calls debounce and therefore is async. So `utils.open_file` finishes before it resulting to neo-tree opening itself again after closing with event handler.

Passing `utils.open_file` as a callback solves the problem.

### Notes

I've also updated type notation of `utils.open_file` since parameter `open_cmd` can be `nil`.