### PR TITLE
fix(diagnostics): fix diagnostics component mechanism

### DIFF
--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -99,19 +99,22 @@ M.diagnostics = function(config, node, state)
     defined = vim.fn.sign_getdefined("LspDiagnosticsSign" .. old_severity)
   end
   defined = defined and defined[1]
+  if type(defined) ~= "table" then
+    defined = {}
+  end
 
   -- check for overrides in the component config
   local severity_lower = severity:lower()
   if config.symbols and config.symbols[severity_lower] then
-    defined = defined or { texthl = "Diagnostic" .. severity }
+    defined.texthl = defined.texthl or ("Diagnostic" .. severity)
     defined.text = config.symbols[severity_lower]
   end
   if config.highlights and config.highlights[severity_lower] then
-    defined = defined or { text = severity:sub(1, 1) }
+    defined.text = defined.text or severity:sub(1, 1)
     defined.texthl = config.highlights[severity_lower]
   end
 
-  if defined and defined.text and defined.texthl then
+  if defined.text and defined.texthl then
     return {
       text = make_two_char(defined.text),
       highlight = defined.texthl,


### PR DESCRIPTION
Closes #774.

The old code goes wrong at line 106 when `defined = { other_keys = "foo" }` since it does not set `texthl` key although it is required to pass the if-check at line 114.

This PR changed the algorithm to specifically set `texthl` when not found.

Same for `text` in `texthl`.