### PR TITLE
fix: Preventing removal of necessary root separator on Windows

### DIFF
--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -100,7 +100,9 @@ M.execute = function(args)
   -- Handle setting directory if requested
   local path_changed = false
   if utils.truthy(args.dir) then
-    if #args.dir > 1 and args.dir:sub(-1) == utils.path_separator then
+    -- Root paths on Windows have 3 characters ("C:\")
+    local root_len = vim.fn.has("win32") == 1 and 3 or 1
+    if #args.dir > root_len and args.dir:sub(-1) == utils.path_separator then
       args.dir = args.dir:sub(1, -2)
     end
     path_changed = state.path ~= args.dir


### PR DESCRIPTION
This fixes #985

When a root path was supplied as an argument to the Neotree command or to execute on Windows, the necessary separator was removed. ":Neotree C:\", for instance, would become "C:" and this resulted in an empty listing.

Instead of testing if the length of args.dir is greater than 1, this now compares it to 3 on Windows while remaining 1 on other operating systems, including WSL.
```lua
   -- Root paths on Windows have 3 characters ("C:\")
    local root_len = vim.fn.has("win32") == 1 and 3 or 1
    if #args.dir > root_len and args.dir:sub(-1) == utils.path_separator then
      args.dir = args.dir:sub(1, -2)
    end
```
I added a comment as well just to clarify what was going on. Though, maybe it'd be better to have a constant. In utils, there's an is_windows variable set (which includes WSL). Maybe a root_len should be set here as well? I'm going to leave it at this for now, though.
