### PR TITLE
fix(renderer): delete content of buffer before rendering

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1086,6 +1086,7 @@ draw = function(nodes, state, parent_id)
 
   -- Create the tree if it doesn't exist.
   if not parent_id and not M.window_exists(state) then
+    M.close(state)
     create_window(state)
     create_tree(state)
   end


### PR DESCRIPTION
After thinking of it for a while I think this is the best way to fix the issue.

With the old code, the content, or even the entire buffer was deleted with `close_all`, so this change would not create much overhead theoretically.

I've tested it with edge-cases I could think of but I'd be glad if you could test the change.

closes #1000
details https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1000#issuecomment-1601258265

Best,
pysan3