### PR TITLE
[WIP] feat(manager): allow window-specific state 

### DIFF
--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -551,13 +551,14 @@ end
 ---@param bufnr number|nil The buffer number to open
 M.open_file = function(state, path, open_cmd, bufnr)
   open_cmd = open_cmd or "edit"
-  if open_cmd == "edit" or open_cmd == "e" then
+  local cmd_for_buf = { edit = "b", e = "b", split = "sb", sp = "sb" }
+  if open_cmd[cmd_for_buf] ~= nil then
     -- If the file is already open, switch to it.
     bufnr = bufnr or M.find_buffer_by_name(path)
     if bufnr <= 0 then
       bufnr = nil
     else
-      open_cmd = "b"
+      open_cmd = cmd_for_buf[open_cmd]
     end
   end
 

--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -551,14 +551,17 @@ end
 ---@param bufnr number|nil The buffer number to open
 M.open_file = function(state, path, open_cmd, bufnr)
   open_cmd = open_cmd or "edit"
-  local cmd_for_buf = { edit = "b", e = "b", split = "sb", sp = "sb" }
-  if open_cmd[cmd_for_buf] ~= nil then
     -- If the file is already open, switch to it.
-    bufnr = bufnr or M.find_buffer_by_name(path)
-    if bufnr <= 0 then
-      bufnr = nil
+  bufnr = bufnr or M.find_buffer_by_name(path)
+  if bufnr <= 0 then
+    bufnr = nil
+  else
+    local buf_cmd_lookup = { edit = "b", e = "b", split = "sb", sb = "sb", vsplit = "vert sb", vs = "vert sb" }
+    local cmd_for_buf = buf_cmd_lookup[open_cmd]
+    if cmd_for_buf then
+      open_cmd = cmd_for_buf
     else
-      open_cmd = cmd_for_buf[open_cmd]
+      bufnr = nil
     end
   end
 


### PR DESCRIPTION
Following up on the conversation in #752, the goal is to prevent the flickering caused by the closing and reopening of the `Neotree` window when we change the source. Here are my current thoughts:
- Add a table to `manager` to keep track of the states by position. Whenever the source is created, the manager will use the old (if exists) window. This avoids the flickering window and also allow window-specific settings such as width (in #928)
- I am also thinking about the idea of having multiple state at the same time, instead of just one. This allows more flexible layouts, for example, `filesystem` on the left, `document_symbol` on the right, and `diagnostics` at the bottom. This might, however, come with some complexity especially when two of the same source coexist (e.g. the user uses the source selector to cycle through the sources).

I want to get some suggestions before doing the implementation, as this might requires many changes. What do you think @cseickel, @pysan3?

PS: I set the `v2.x` as the base branch as it does not allow me to set `main` since there is no commits yet. I will switch back afterwards.