### PR TITLE
fix: reuse NuiTree and buffer if possible, fixes ghost tree problem

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -31,6 +31,10 @@ local tabid_to_tabnr = function(tabid)
   return vim.api.nvim_tabpage_is_valid(tabid) and vim.api.nvim_tabpage_get_number(tabid)
 end
 
+local buffer_is_usable = function(bufnr)
+  return vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr)
+end
+
 local cleaned_up = false
 ---Clean up invalid neotree buffers (e.g after a session restore)
 ---@param force boolean if true, force cleanup. Otherwise only cleanup once
@@ -738,11 +742,9 @@ end
 
 create_tree = function(state)
   if state.tree and state.tree.bufnr == state.bufnr then
-    if vim.api.nvim_buf_is_valid(state.bufnr) then
-      if vim.api.nvim_buf_is_loaded(state.bufnr) then
-        log.debug("Tree already exists and buffer is valid, skipping creation", state.name, state.id)
-        return
-      end
+    if buffer_is_usable(state.tree.bufnr) then
+      log.debug("Tree already exists and buffer is valid, skipping creation", state.name, state.id)
+      return
     end
   end
   state.tree = NuiTree({
@@ -881,18 +883,16 @@ local function create_floating_window(state, win_options, bufname)
     return win
 end
 
-local get_or_create_buffer = function(bufname)
+local get_existing_buffer = function(bufname)
   local bufnr = vim.fn.bufnr(bufname)
-  if bufnr < 1 then
-    bufnr = vim.api.nvim_create_buf(false, false)
-    vim.api.nvim_buf_set_name(bufnr, bufname)
-    vim.api.nvim_buf_set_option(bufnr, "buftype", "nofile")
-    vim.api.nvim_buf_set_option(bufnr, "swapfile", false)
-    vim.api.nvim_buf_set_option(bufnr, "filetype", "neo-tree")
-    vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
-    vim.api.nvim_buf_set_option(bufnr, "undolevels", -1)
+  if bufnr > 0 then
+    if buffer_is_usable(bufnr) then
+      return bufnr
+    else
+      pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+    end
   end
-  return bufnr
+  return 0
 end
 
 create_window = function(state)
@@ -944,7 +944,7 @@ create_window = function(state)
       log.warn("Window ", winid, "  is no longer valid!")
       return
     end
-    local bufnr = vim.fn.bufnr(bufname)
+    local bufnr = get_existing_buffer(bufname)
     if bufnr < 1 then
       bufnr = vim.api.nvim_create_buf(false, false)
       vim.api.nvim_buf_set_name(bufnr, bufname)
@@ -959,13 +959,14 @@ create_window = function(state)
     vim.api.nvim_win_set_buf(winid, bufnr)
   else
     win = NuiSplit(win_options)
-    local bufnr = vim.fn.bufnr(bufname)
+    local bufnr = get_existing_buffer(bufname)
     if bufnr > 0 then
       win.bufnr = bufnr
     end
     win:mount()
     state.winid = win.winid
     state.bufnr = win.bufnr
+    vim.api.nvim_buf_set_name(state.bufnr, bufname)
   end
   event_args.winid = state.winid
   events.fire_event(events.NEO_TREE_WINDOW_AFTER_OPEN, event_args)


### PR DESCRIPTION
fixes #1000

Alternate solution to #1007 proposed by @pysan3.

The problem was that we were creating a new NuiTree instance and attaching it to an existing buffer that already had a tree rendered in it. The solution here is to identify when the tree exists and the buffer it manages is still good, and in that case just reuse that tree instead of creating a new one.

Along the way I also made it so that a sidebar will reuse an existing buffer rather than creating a new one every time the window opens. This should just be a tiny bit more efficient and will help on another thing we are working on: reusing sidebar windows across sources instead of having to close them every time.
