### PR TITLE
fix: reuse windows and buffers when possible, prevents flashing when switching

### DIFF
--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -126,9 +126,9 @@ M.execute = function(args)
 
   -- All set, now show or focus the window
   local force_navigate = path_changed or do_reveal or git_base_changed or state.dirty
-  if position_changed and args.position ~= "current" and current_position ~= "current" then
-    manager.close(args.source)
-  end
+  --if position_changed and args.position ~= "current" and current_position ~= "current" then
+  --  manager.close(args.source)
+  --end
   if do_reveal then
     handle_reveal(args, state)
   else
@@ -161,7 +161,7 @@ do_show_or_focus = function(args, state, force_navigate)
       -- There's nothing to do here, we are already at the target state
       return
     end
-    close_other_sources()
+    -- close_other_sources()
     local current_win = vim.api.nvim_get_current_win()
     manager.navigate(state, args.dir, args.reveal_file, function()
       -- navigate changes the window to neo-tree, so just quickly hop back to the original window
@@ -173,7 +173,7 @@ do_show_or_focus = function(args, state, force_navigate)
       vim.api.nvim_set_current_win(state.winid)
     end
     if force_navigate or not window_exists then
-      close_other_sources()
+      -- close_other_sources()
       manager.navigate(state, args.dir, args.reveal_file, nil, false)
     end
   end

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -992,6 +992,7 @@ create_window = function(state)
       state.bufnr = win.bufnr
       state.winid = win.winid
       location.winid = state.winid
+      vim.api.nvim_buf_set_name(state.bufnr, bufname)
       vim.api.nvim_set_current_win(state.winid)
     end
     location.source = state.name
@@ -1079,7 +1080,6 @@ M.window_exists = function(state)
       end
       local buf_position = vim.api.nvim_buf_get_var(bufnr, "neo_tree_position")
       if buf_position ~= position then
-        log.warn("window exists but at wrong position")
         window_exists = false
       end
     end

--- a/lua/neo-tree/ui/windows.lua
+++ b/lua/neo-tree/ui/windows.lua
@@ -1,0 +1,24 @@
+local locations = {}
+
+local get_location = function(location)
+  local loc = locations[location]
+  if loc then
+    if loc.winid ~= 0 then
+      -- verify the window before we return it
+      if not vim.api.nvim_win_is_valid(loc.winid) then
+        loc.winid = 0
+      end
+    end
+    return loc
+  end
+  loc = {
+    source = nil,
+    name = location,
+    winid = 0,
+  }
+  locations[location] = loc
+  return loc
+end
+
+local M = { get_location = get_location }
+return M


### PR DESCRIPTION
fixes #713

This adds logic to reuse Neotree windows between sources instead of always closing the window when opening a new source. It also improves upon the concept of reusing the buffer when possible instead of recreating it from scratch each time. These are primarily optimizations for quickly switching between sources when they are shown as sidebars.
