### PR TITLE
feat(sources): add follow_current_file.leave_dirs_open option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ should you!
 - Neo-tree won't leave its window scrolled to the last line when there is
   plenty of room to display the whole tree.
 - Neo-tree does not need to be manually refreshed (set `use_libuv_file_watcher=true`)
-- Neo-tree can intelligently follow the current file (set `follow_current_file=true`)
+- Neo-tree can intelligently follow the current file (set `follow_current_file.enabled=true`)
 - Neo-tree is thoughtful about maintaining or setting focus on the right node
 - Neo-tree windows in different tabs are completely separate
 - `respect_gitignore` actually works!
@@ -273,8 +273,11 @@ use {
               --".null-ls_*",
             },
           },
-          follow_current_file = false, -- This will find and focus the file in the active buffer every
-                                       -- time the current file is changed while the tree is open.
+          follow_current_file = {
+            enabled = false, -- This will find and focus the file in the active buffer every time
+            --               -- the current file is changed while the tree is open.
+            leave_dirs_open = false, -- `false` closes auto expanded dirs, such as with `:Neotree reveal`
+          },
           group_empty_dirs = false, -- when true, empty folders will be grouped together
           hijack_netrw_behavior = "open_default", -- netrw disabled, opening a directory opens neo-tree
                                                   -- in whatever position is specified in window.position
@@ -308,8 +311,11 @@ use {
           commands = {} -- Add a custom command or override a global one using the same function name
         },
         buffers = {
-          follow_current_file = true, -- This will find and focus the file in the active buffer every
-                                       -- time the current file is changed while the tree is open.
+          follow_current_file = {
+            enabled = true, -- This will find and focus the file in the active buffer every time
+            --              -- the current file is changed while the tree is open.
+            leave_dirs_open = false, -- `false` closes auto expanded dirs, such as with `:Neotree reveal`
+          },
           group_empty_dirs = true, -- when true, empty folders will be grouped together
           show_unloaded = true,
           window = {

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -475,8 +475,11 @@ local config = {
     --end,
     group_empty_dirs = false, -- when true, empty folders will be grouped together
     search_limit = 50, -- max number of search results when using filters
-    follow_current_file = false, -- This will find and focus the file in the active buffer every time
-                                 -- the current file is changed while the tree is open.
+    follow_current_file = {
+      enabled = false, -- This will find and focus the file in the active buffer every time
+      --               -- the current file is changed while the tree is open.
+      leave_dirs_open = false, -- `false` closes auto expanded dirs, such as with `:Neotree reveal`
+    },
     hijack_netrw_behavior = "open_default", -- netrw disabled, opening a directory opens neo-tree
                                             -- in whatever position is specified in window.position
                           -- "open_current",-- netrw disabled, opening a directory opens within the
@@ -487,8 +490,11 @@ local config = {
   },
   buffers = {
     bind_to_cwd = true,
-    follow_current_file = true, -- This will find and focus the file in the active buffer every time
-                                -- the current file is changed while the tree is open.
+    follow_current_file = {
+      enabled = true, -- This will find and focus the file in the active buffer every time
+      --              -- the current file is changed while the tree is open.
+      leave_dirs_open = false, -- `false` closes auto expanded dirs, such as with `:Neotree reveal`
+    },
     group_empty_dirs = true,  -- when true, empty directories will be grouped together
     show_unloaded = false,    -- When working with sessions, for example, restored but unfocused buffers
                               -- are mark as "unloaded". Turn this on to view these unloaded buffer.

--- a/lua/neo-tree/setup/deprecations.lua
+++ b/lua/neo-tree/setup/deprecations.lua
@@ -40,7 +40,7 @@ M.migrate = function(config)
         existing = converter(existing)
       end
       utils.set_value(config, old, nil)
-      utils.set_value(config, new, existing, true)
+      utils.set_value(config, new, existing)
       migrations[#migrations + 1] =
         string.format("The `%s` option has been deprecated, please use `%s` instead.", old, new)
     end
@@ -54,7 +54,7 @@ M.migrate = function(config)
       end
       utils.set_value(config, old, {})
       local new = old .. "." .. new_inside
-      utils.set_value(config, new, existing, true)
+      utils.set_value(config, new, existing)
       migrations[#migrations + 1] =
         string.format("The `%s` option is replaced with a table, please move to `%s`.", old, new)
     end

--- a/lua/neo-tree/sources/buffers/init.lua
+++ b/lua/neo-tree/sources/buffers/init.lua
@@ -63,7 +63,7 @@ local buffers_changed_internal = function()
     local state = manager.get_state(M.name, tabid)
     if state.path and renderer.window_exists(state) then
       items.get_opened_buffers(state)
-      if state.follow_current_file then
+      if state.follow_current_file.enabled then
         follow_internal()
       end
     end
@@ -182,7 +182,7 @@ M.setup = function(config, global_config)
   end
 
   -- Configure event handler for follow_current_file option
-  if config.follow_current_file then
+  if config.follow_current_file.enabled then
     manager.subscribe(M.name, {
       event = events.VIM_BUFFER_ENTER,
       handler = M.follow,

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -114,7 +114,6 @@ M.expand_all_nodes = function(state, toggle_directory)
       node:expand()
     end
   end
-  --state.explicitly_opened_directories = state.explicitly_opened_directories or {}
 
   local expand_node
   expand_node = function(node)

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -34,10 +34,10 @@ end
 local follow_internal = function(callback, force_show, async)
   log.trace("follow called")
   if vim.bo.filetype == "neo-tree" or vim.bo.filetype == "neo-tree-popup" then
-    return
+    return false
   end
   local path_to_reveal = manager.get_path_to_reveal()
-  if not utils.truthy(path_to_reveal) then
+  if not path_to_reveal or not utils.truthy(path_to_reveal) then
     return false
   end
 

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -37,9 +37,10 @@ local follow_internal = function(callback, force_show, async)
     return false
   end
   local path_to_reveal = manager.get_path_to_reveal()
-  if not path_to_reveal or not utils.truthy(path_to_reveal) then
+  if not utils.truthy(path_to_reveal) then
     return false
   end
+  ---@cast path_to_reveal string
 
   local state = get_state()
   if state.current_position == "float" then

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -433,7 +433,7 @@ M.get_items = function(state, parent_id, path_to_reveal, callback, async, recurs
       -- Ensure that there are no nested files in the list of folders to load
       context.paths_to_load = vim.tbl_filter(function(p)
         local stats = vim.loop.fs_stat(p)
-        return stats and stats.type == "directory"
+        return stats and stats.type == "directory" or false
       end, context.paths_to_load)
       if path_to_reveal then
         -- be sure to load all of the folders leading up to the path to reveal

--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -349,15 +349,14 @@ end
 ---@param sourceObject table The table to set a value in.
 ---@param valuePath string The path to the value to set.
 ---@param value any The value to set.
----@param force_tabulize boolean? Overwrite existing non-table parents with a table along the way.
-M.set_value = function(sourceObject, valuePath, value, force_tabulize)
+M.set_value = function(sourceObject, valuePath, value)
   local pathParts = M.split(valuePath, ".")
   local currentTable = sourceObject
   for i, part in ipairs(pathParts) do
     if i == #pathParts then
       currentTable[part] = value
     else
-      if force_tabulize and type(currentTable[part]) ~= "table" then
+      if type(currentTable[part]) ~= "table" then
         currentTable[part] = {}
       end
       currentTable = currentTable[part]

--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -315,10 +315,10 @@ end
 ---Handles null coalescing into a table at any depth.
 ---@param sourceObject table The table to get a vlue from.
 ---@param valuePath string The path to the value to get.
----@param defaultValue any The default value to return if the value is nil.
----@param strict_type_check boolean Whether to require the type of the value is
+---@param defaultValue any|nil The default value to return if the value is nil.
+---@param strict_type_check boolean? Whether to require the type of the value is
 ---the same as the default value.
----@return table|nil table The value at the path or the default value.
+---@return any value The value at the path or the default value.
 M.get_value = function(sourceObject, valuePath, defaultValue, strict_type_check)
   if sourceObject == nil then
     return defaultValue
@@ -349,13 +349,17 @@ end
 ---@param sourceObject table The table to set a value in.
 ---@param valuePath string The path to the value to set.
 ---@param value any The value to set.
-M.set_value = function(sourceObject, valuePath, value)
+---@param force_tabulize boolean? Overwrite existing non-table parents with a table along the way.
+M.set_value = function(sourceObject, valuePath, value, force_tabulize)
   local pathParts = M.split(valuePath, ".")
   local currentTable = sourceObject
   for i, part in ipairs(pathParts) do
     if i == #pathParts then
       currentTable[part] = value
     else
+      if force_tabulize and type(currentTable[part]) ~= "table" then
+        currentTable[part] = {}
+      end
       currentTable = currentTable[part]
     end
   end

--- a/tests/neo-tree/command/command_spec.lua
+++ b/tests/neo-tree/command/command_spec.lua
@@ -129,11 +129,13 @@ describe("Command", function()
   for _, follow_current_file in ipairs({ true, false }) do
     require("neo-tree").setup({
       filesystem = {
-        follow_current_file = follow_current_file,
+        follow_current_file = {
+          enabled = follow_current_file,
+        },
       },
     })
 
-    describe(string.format("w/ follow_current_file=%s", follow_current_file), function()
+    describe(string.format("w/ follow_current_file.enabled=%s", follow_current_file), function()
       describe("with show  :", function()
         it("`:Neotree show` should show the window without focusing", function()
           local cmd = "Neotree show"

--- a/tests/neo-tree/sources/filesystem/filesystem_command_spec.lua
+++ b/tests/neo-tree/sources/filesystem/filesystem_command_spec.lua
@@ -127,11 +127,13 @@ describe("Filesystem", function()
   for _, follow_current_file in ipairs({ true, false }) do
     require("neo-tree").setup({
       filesystem = {
-        follow_current_file = follow_current_file,
+        follow_current_file = {
+          enabled =  follow_current_file,
+        }
       },
     })
 
-    describe(string.format("w/ follow_current_file=%s", follow_current_file), function()
+    describe(string.format("w/ follow_current_file.enabled=%s", follow_current_file), function()
       describe("show command", function()
         it("should show the window without focusing", function()
           local cmd = "NeoTreeShow"


### PR DESCRIPTION
## Details

https://github.com/nvim-neo-tree/neo-tree.nvim/issues/999#issuecomment-1601887559

Closes: #999
Related: #903

## Changes

- `filesystem.follow_current_file` -> `filesystem.follow_current_file.enabled`
  - Added in `deprecations.lua`

## Notes

- `filesystem.follow_current_file.leave_dirs_open` defaults to `false`, which does not change the default behavior.
- Although `:Neotree reveal` automatically opens dirs to focus the current file, `filesystem.follow_current_file.enabled == false` && `:Neotree reveal` => does not respect `leave_dirs_open` nor remember dirs opened by `reveal`. This option only works when `enabled == true` is explicitly set.
- Changed `buffers.follow_current_file.enabled` as well for compatibility, but `buffers.follow_current_file.leave_dirs_open` is never referenced since in buffers source, all dirs are expanded by default. https://github.com/nvim-neo-tree/neo-tree.nvim/blob/70d3daa22bf24de9e3e284ac659506b1374e3ae2/lua/neo-tree/sources/buffers/lib/items.lua#L100-L102