### PR TITLE
style: update some nerdfont symbols since they were deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ use {
       vim.fn.sign_define("DiagnosticSignInfo",
         {text = " ", texthl = "DiagnosticSignInfo"})
       vim.fn.sign_define("DiagnosticSignHint",
-        {text = "", texthl = "DiagnosticSignHint"})
+        {text = "󰌵", texthl = "DiagnosticSignHint"})
       -- NOTE: this is changed from v1.x, which used the old style of highlight groups
       -- in the form "LspDiagnosticsSignWarning"
 
@@ -154,7 +154,7 @@ use {
           icon = {
             folder_closed = "",
             folder_open = "",
-            folder_empty = "ﰊ",
+            folder_empty = "󰜌",
             -- The next two settings are only a fallback, if you use nvim-web-devicons and configure default icons there
             -- then these will never be used.
             default = "*",
@@ -175,12 +175,12 @@ use {
               added     = "", -- or "✚", but this is redundant info if you use git_status_colors on the name
               modified  = "", -- or "", but this is redundant info if you use git_status_colors on the name
               deleted   = "✖",-- this can only be used in the git_status source
-              renamed   = "",-- this can only be used in the git_status source
+              renamed   = "󰁕",-- this can only be used in the git_status source
               -- Status type
               untracked = "",
               ignored   = "",
-              unstaged  = "",
-              staged    = "",
+              unstaged  = "󰄱",
+              staged    = "󰱒",
               conflict  = "",
             }
           },

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -718,15 +718,15 @@ type notations.
         sources = {                                               -- table
           {
             source = "filesystem",                                -- string
-            display_name = "  Files "                            -- string | nil
+            display_name = " 󰉓 Files "                            -- string | nil
           },
           {
             source = "buffers",                                   -- string
-            display_name = "  Buffers "                          -- string | nil
+            display_name = " 󰈚 Buffers "                          -- string | nil
           },
           {
             source = "git_status",                                -- string
-            display_name = "  Git "                              -- string | nil
+            display_name = " 󰊢 Git "                              -- string | nil
           },
         },
         content_layout = "start",                                 -- string
@@ -773,9 +773,9 @@ then the `default_source` will be updated to be the first entry of
 effect when the tab width is greater than the length of label i.e.
 `tabs_layout = "equal", "focus"` or when `tabs_min_width` is large enough.
 Following options are available.
-    'start'  : left aligned                  / 裡 bufname     \/..
-    'end'    : right aligned                 /     裡 bufname \/...
-    'center' : centered with equal padding   /   裡 bufname   \/...
+    'start'  : left aligned                  / 󰓩 bufname     \/..
+    'end'    : right aligned                 /     󰓩 bufname \/...
+    'center' : centered with equal padding   /   󰓩 bufname   \/...
 
 `tabs_layout` defines how the tabs are aligned inside the window when there is
 more than enough space. The following options are available. `active` will
@@ -988,12 +988,12 @@ the following properties:
           added     = "✚",
           deleted   = "✖",
           modified  = "",
-          renamed   = "",
+          renamed   = "󰁕",
           -- Status type
           untracked = "",
           ignored   = "",
-          unstaged  = "",
-          staged    = "",
+          unstaged  = "󰄱",
+          staged    = "󰱒",
           conflict  = "",
         }
       }
@@ -1025,8 +1025,8 @@ The following config will remove those change type symbols:
           -- Status type
           untracked = "",
           ignored   = "",
-          unstaged  = "",
-          staged    = "",
+          unstaged  = "󰄱",
+          staged    = "󰱒",
           conflict  = "",
         }
       }
@@ -1063,7 +1063,7 @@ define those somewhere in your nvim configuration. Here is an example:
     vim.fn.sign_define("LspDiagnosticsSignInformation",
         {text = " ", texthl = "LspDiagnosticsSignInformation"})
     vim.fn.sign_define("LspDiagnosticsSignHint",
-        {text = "", texthl = "LspDiagnosticsSignHint"})
+        {text = "󰌵", texthl = "LspDiagnosticsSignHint"})
 <
 
 Alternatively, you can also specify the signs and/or highlights in the
@@ -1707,7 +1707,7 @@ If set to `true`, will automatically focus on the symbol under the cursor.
 kinds~
 A table specifying how LSP kinds should be rendered. Each entry should map the
 LSP kind name to an icon and a highlight group, for example 
-  `Class = { icon = "", hl = "Include" }`
+  `Class = { icon = "󰌗", hl = "Include" }`
 
 custom_kinds~
 A table mapping the LSP kind id (an integer) to the LSP kind name that is used

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -57,9 +57,9 @@ local config = {
       { source = "git_status" },
     },
     content_layout = "start", -- only with `tabs_layout` = "equal", "focus"
-    --                start  : |/ 裡 bufname     \/...
-    --                end    : |/     裡 bufname \/...
-    --                center : |/   裡 bufname   \/...
+    --                start  : |/ 󰓩 bufname     \/...
+    --                end    : |/     󰓩 bufname \/...
+    --                center : |/   󰓩 bufname   \/...
     tabs_layout = "equal", -- start, end, center, equal, focus
     --             start  : |/  a  \/  b  \/  c  \            |
     --             end    : |            /  a  \/  b  \/  c  \|
@@ -198,8 +198,8 @@ local config = {
     icon = {
       folder_closed = "",
       folder_open = "",
-      folder_empty = "ﰊ",
-      folder_empty_open = "ﰊ",
+      folder_empty = "󰜌",
+      folder_empty_open = "󰜌",
       -- The next two settings are only a fallback, if you use nvim-web-devicons and configure default icons there
       -- then these will never be used.
       default = "*",
@@ -224,12 +224,12 @@ local config = {
         added     = "✚", -- NOTE: you can set any of these to an empty string to not show them
         deleted   = "✖",
         modified  = "",
-        renamed   = "",
+        renamed   = "󰁕",
         -- Status type
         untracked = "",
         ignored   = "",
-        unstaged  = "",
-        staged    = "",
+        unstaged  = "󰄱",
+        staged    = "󰱒",
         conflict  = "",
       },
       align = "right",
@@ -560,37 +560,37 @@ local config = {
     kinds = {
       Unknown = { icon = "?", hl = "" },
       Root = { icon = "", hl = "NeoTreeRootName" },
-      File = { icon = "", hl = "Tag" },
+      File = { icon = "󰈙", hl = "Tag" },
       Module = { icon = "", hl = "Exception" },
-      Namespace = { icon = "", hl = "Include" },
-      Package = { icon = "", hl = "Label" },
-      Class = { icon = "", hl = "Include" },
+      Namespace = { icon = "󰌗", hl = "Include" },
+      Package = { icon = "󰏖", hl = "Label" },
+      Class = { icon = "󰌗", hl = "Include" },
       Method = { icon = "", hl = "Function" },
-      Property = { icon = "", hl = "@property" },
+      Property = { icon = "󰆧", hl = "@property" },
       Field = { icon = "", hl = "@field" },
       Constructor = { icon = "", hl = "@constructor" },
-      Enum = { icon = "了", hl = "@number" },
+      Enum = { icon = "󰒻", hl = "@number" },
       Interface = { icon = "", hl = "Type" },
-      Function = { icon = "", hl = "Function" },
+      Function = { icon = "󰊕", hl = "Function" },
       Variable = { icon = "", hl = "@variable" },
       Constant = { icon = "", hl = "Constant" },
       String = { icon = "", hl = "String" },
-      Number = { icon = "", hl = "Number" },
+      Number = { icon = "󰎠", hl = "Number" },
       Boolean = { icon = "", hl = "Boolean" },
-      Array = { icon = "", hl = "Type" },
-      Object = { icon = "", hl = "Type" },
-      Key = { icon = "", hl = "" },
+      Array = { icon = "󰅪", hl = "Type" },
+      Object = { icon = "󰅩", hl = "Type" },
+      Key = { icon = "󰌋", hl = "" },
       Null = { icon = "", hl = "Constant" },
       EnumMember = { icon = "", hl = "Number" },
-      Struct = { icon = "", hl = "Type" },
+      Struct = { icon = "󰌗", hl = "Type" },
       Event = { icon = "", hl = "Constant" },
-      Operator = { icon = "", hl = "Operator" },
-      TypeParameter = { icon = "", hl = "Type" },
+      Operator = { icon = "󰆕", hl = "Operator" },
+      TypeParameter = { icon = "󰊄", hl = "Type" },
 
       -- ccls
       -- TypeAlias = { icon = ' ', hl = 'Type' },
       -- Parameter = { icon = ' ', hl = '@parameter' },
-      -- StaticMethod = { icon = 'ﴂ ', hl = 'Function' },
+      -- StaticMethod = { icon = '󰠄 ', hl = 'Function' },
       -- Macro = { icon = ' ', hl = 'Macro' },
     }
   },

--- a/lua/neo-tree/sources/buffers/init.lua
+++ b/lua/neo-tree/sources/buffers/init.lua
@@ -11,7 +11,7 @@ local git = require("neo-tree.git")
 
 local M = {
   name = "buffers",
-  display_name = "  Buffers "
+  display_name = " 󰈚 Buffers "
 }
 
 local wrap = function(func)

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -13,7 +13,7 @@ local glob = require("neo-tree.sources.filesystem.lib.globtopattern")
 
 local M = {
   name = "filesystem",
-  display_name = "  Files ",
+  display_name = " 󰉓 Files ",
 }
 
 local wrap = function(func)

--- a/lua/neo-tree/sources/git_status/init.lua
+++ b/lua/neo-tree/sources/git_status/init.lua
@@ -10,7 +10,7 @@ local manager = require("neo-tree.sources.manager")
 
 local M = {
   name = "git_status",
-  display_name = "  Git "
+  display_name = " 󰊢 Git "
 }
 
 local wrap = function(func)


### PR DESCRIPTION
Hi,

As some Nerd Font symbols used in this plugin have been updated and moved to new codepoints since v3.0.0 release of Material Design Icons, I did my best to find every deprecated symbols and manually updated them.

Please tell me if there's anything I missed.

Thank You!