### PR TITLE
docs: add Buffers entry to Nerd Fonts v3  source selector example

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ require("neo-tree").setup({
   source_selector = {
     sources = {
       { source = "filesystem", display_name = " 󰉓 Files " },
+      { source = "buffers", display_name = " 󰈚 Buffers " },
       { source = "git_status", display_name = " 󰊢 Git " },
     },
   },


### PR DESCRIPTION
I recently reconfigured my terminal and editor, so I'm using v3 nerd fonts. Using the winbar source selector, I noticed icons were broken, so I applied the config suggested in the readme. I realized that the buffers entry was missing, so I determined that the existing code point was 0xf719, `nf-mdi-file_document_box`:

https://github.com/nvim-neo-tree/neo-tree.nvim/blob/7f6fa04dbd8e8c79d1af33bc90e856b65d8641da/lua/neo-tree/sources/buffers/init.lua#L14

The equivalent glyph in v3 has a different name, `nf-md-text_box`, and is at 0xf021a.

This PR adds a line to the readme config example to fix the buffer icon for V3 nerd fonts.