### PR TITLE
feat(ui/inputs): enable normal mode in rename popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ use {
         popup_border_style = "rounded",
         enable_git_status = true,
         enable_diagnostics = true,
+        enable_normal_mode_for_inputs = false, -- Enable normal mode for input dialogs.
         open_files_do_not_replace_types = { "terminal", "trouble", "qf" }, -- when opening files, do not use windows containing these filetypes or buftypes
         sort_case_insensitive = false, -- used when sorting files and directories in the tree
         sort_function = nil , -- use a custom function for sorting files and directories in the tree 

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -22,7 +22,7 @@ local config = {
   enable_modified_markers = true, -- Show markers for files with unsaved changes.
   enable_opened_markers = true,   -- Enable tracking of opened files. Required for `components.name.highlight_opened_files`
   enable_refresh_on_write = true, -- Refresh the tree when a file is written. Only used if `use_libuv_file_watcher` is false.
-  enable_normal_mode_for_inputs = true, -- Enable normal mode for input dialogs when <esc> is pressed.
+  enable_normal_mode_for_inputs = true, -- Enable normal mode for input dialogs.
   git_status_async = true,
   -- These options are for people with VERY large git repos
   git_status_async_options = {

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -22,6 +22,7 @@ local config = {
   enable_modified_markers = true, -- Show markers for files with unsaved changes.
   enable_opened_markers = true,   -- Enable tracking of opened files. Required for `components.name.highlight_opened_files`
   enable_refresh_on_write = true, -- Refresh the tree when a file is written. Only used if `use_libuv_file_watcher` is false.
+  enable_normal_mode_for_inputs = true, -- Enable normal mode for input dialogs when <esc> is pressed.
   git_status_async = true,
   -- These options are for people with VERY large git repos
   git_status_async_options = {

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -22,7 +22,7 @@ local config = {
   enable_modified_markers = true, -- Show markers for files with unsaved changes.
   enable_opened_markers = true,   -- Enable tracking of opened files. Required for `components.name.highlight_opened_files`
   enable_refresh_on_write = true, -- Refresh the tree when a file is written. Only used if `use_libuv_file_watcher` is false.
-  enable_normal_mode_for_inputs = true, -- Enable normal mode for input dialogs.
+  enable_normal_mode_for_inputs = false, -- Enable normal mode for input dialogs.
   git_status_async = true,
   -- These options are for people with VERY large git repos
   git_status_async_options = {

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -14,6 +14,12 @@ M.show_input = function(input, callback)
  local config = require("neo-tree").config
   input:mount()
 
+  if config.enable_normal_mode_for_inputs then
+    vim.schedule(function()
+      vim.cmd("stopinsert")
+    end)
+  end
+
   input:map("i", "<esc>", function()
     vim.cmd("stopinsert")
     if not config.enable_normal_mode_for_inputs then

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -11,10 +11,14 @@ local should_use_popup_input = function()
 end
 
 M.show_input = function(input, callback)
+ local config = require("neo-tree").config
   input:mount()
 
   input:map("i", "<esc>", function()
     vim.cmd("stopinsert")
+    if not config.enable_normal_mode_for_inputs then
+      input:unmount()
+    end
   end, { noremap = true })
 
   input:map("n", "<esc>", function()
@@ -33,7 +37,7 @@ M.show_input = function(input, callback)
     if callback then
       callback()
     end
-  end, { once = true })
+  end, { once = true }) 
 end
 
 M.input = function(message, default_value, callback, options, completion)

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -14,7 +14,7 @@ M.show_input = function(input, callback)
  local config = require("neo-tree").config
   input:mount()
 
-  if config.enable_normal_mode_for_inputs then
+  if config.enable_normal_mode_for_inputs and input.prompt_type ~= "confirm" then
     vim.schedule(function()
       vim.cmd("stopinsert")
     end)
@@ -22,7 +22,7 @@ M.show_input = function(input, callback)
 
   input:map("i", "<esc>", function()
     vim.cmd("stopinsert")
-    if not config.enable_normal_mode_for_inputs then
+    if not config.enable_normal_mode_for_inputs or input.prompt_type == "confirm" then
       input:unmount()
     end
   end, { noremap = true })
@@ -83,6 +83,7 @@ M.confirm = function(message, callback)
       end,
     })
 
+    input.prompt_type = "confirm"
     M.show_input(input)
   else
     local opts = {

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -15,6 +15,13 @@ M.show_input = function(input, callback)
 
   input:map("i", "<esc>", function()
     vim.cmd("stopinsert")
+  end, { noremap = true })
+
+  input:map("n", "<esc>", function()
+    input:unmount()
+  end, { noremap = true })
+
+  input:map("n", "q", function()
     input:unmount()
   end, { noremap = true })
 

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -37,7 +37,7 @@ M.show_input = function(input, callback)
     if callback then
       callback()
     end
-  end, { once = true }) 
+  end, { once = true })
 end
 
 M.input = function(message, default_value, callback, options, completion)


### PR DESCRIPTION
This PR addresses the issue discussed in [#1039](https://github.com/nvim-neo-tree/neo-tree.nvim/discussions/1039), where users were unable to switch to normal mode in the NeoTree rename popup by pressing the escape key.

**Benefits:**

This change significantly improves the user experience by allowing users to switch to normal mode without closing the popup, and provides a way to close the popup from normal mode.

Moreover, it offers additional benefits when dealing with long file names. Users can now leverage normal mode commands such as `dw` (delete word), `dt`. (delete until dot), or `dd` (delete line) to edit file names more efficiently. This makes the renaming process faster and more intuitive, especially for those who are accustomed to Vim's normal mode operations.

Please let me know if you want me to change anything or if you would like this to be an option in the plugin.