### PR TITLE
fix(devicons): let `nvim-web-devicons` decide the extension

### DIFF
--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -280,8 +280,7 @@ M.icon = function(config, node, state)
   elseif node.type == "file" or node.type == "terminal" then
     local success, web_devicons = pcall(require, "nvim-web-devicons")
     if success then
-      local ext = node.ext and node.ext:lower() or nil
-      local devicon, hl = web_devicons.get_icon(node.name, ext)
+      local devicon, hl = web_devicons.get_icon(node.name)
       icon = devicon or icon
       highlight = hl or highlight
     end


### PR DESCRIPTION
Closes: #1034

`require'nvim-web-devicons'.get_icon(filename, extension, options)` has the ability to guess the file extension on its own and does not require the `extension` argument.

This PR simply deletes that argument, and passes everything to them to decide the icon.

Docs: https://github.com/nvim-tree/nvim-web-devicons#get-icon

### Examples

(The browser might not be able to display the icons tho...)

```txt
require("nvim-web-devicons").get_icon("something.spec.ts")  DevIconSpecTs
require("nvim-web-devicons").get_icon("hoge.PNG")  DevIconPng
require("nvim-web-devicons").get_icon("hoge.png")  DevIconPng
require("nvim-web-devicons").get_icon(".zshrc")  DevIconZshrc
require("nvim-web-devicons").get_icon("hoge.zsh")  DevIconZsh
require("nvim-web-devicons").get_icon(".bashrc")  DevIconBashrc
require("nvim-web-devicons").get_icon("components.lua")  DevIconLua
```

![image](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/41065736/ca062f7e-4691-4771-9202-93a5b505534b)
