### PR TITLE
fix(utils): typo in open split command

### DIFF
--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -556,7 +556,7 @@ M.open_file = function(state, path, open_cmd, bufnr)
   if bufnr <= 0 then
     bufnr = nil
   else
-    local buf_cmd_lookup = { edit = "b", e = "b", split = "sb", sb = "sb", vsplit = "vert sb", vs = "vert sb" }
+    local buf_cmd_lookup = { edit = "b", e = "b", split = "sb", sp = "sb", vsplit = "vert sb", vs = "vert sb" }
     local cmd_for_buf = buf_cmd_lookup[open_cmd]
     if cmd_for_buf then
       open_cmd = cmd_for_buf


### PR DESCRIPTION
Related
- #898 
- #989 
- #1004 
- #1005 (Introduced here)