### PR TITLE
fix: normalize file paths (#993)

### DIFF
--- a/lua/neo-tree/command/parser.lua
+++ b/lua/neo-tree/command/parser.lua
@@ -79,6 +79,7 @@ M.setup = function(all_source_names)
 end
 
 M.resolve_path = function(path, validate_type)
+  path = vim.fs.normalize(path)
   local expanded = vim.fn.expand(path)
   local abs_path = vim.fn.fnamemodify(expanded, ":p")
   if validate_type then


### PR DESCRIPTION
![image](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/2640668/fb8f4648-4709-4895-adff-90471f0f314f)

Pretty simple fix but appears to resolve this. Tagging @emilgedda for testing and @cseickel / @pysan3  for review :)