### PR TITLE
refactor!: remove `close_floats_on_esc_key` opt, replace with `cancel` mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ use {
             },
             ["<2-LeftMouse>"] = "open",
             ["<cr>"] = "open",
-            ["<esc>"] = "revert_preview",
+            ["<esc>"] = "cancel", -- close preview or floating neo-tree window
             ["P"] = { "toggle_preview", config = { use_float = true } },
             ["l"] = "focus_preview",
             ["S"] = "open_split",

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -15,7 +15,6 @@ local config = {
   -- popup_border_style is for input and confirmation dialogs.
   -- Configurtaion of floating window is done in the individual source sections.
   -- "NC" is a special style that works well with NormalNC set
-  close_floats_on_escape_key = true,
   default_source = "filesystem",
   enable_diagnostics = true,
   enable_git_status = true,
@@ -337,7 +336,7 @@ local config = {
       },
       ["<2-LeftMouse>"] = "open",
       ["<cr>"] = "open",
-      ["<esc>"] = "revert_preview",
+      ["<esc>"] = "cancel", -- close preview or floating neo-tree window
       ["P"] = { "toggle_preview", config = { use_float = true } },
       ["l"] = "focus_preview",
       ["S"] = "open_split",

--- a/lua/neo-tree/setup/deprecations.lua
+++ b/lua/neo-tree/setup/deprecations.lua
@@ -103,6 +103,9 @@ M.migrate = function(config)
   moved_inside("filesystem.follow_current_file", "enabled")
   moved_inside("buffers.follow_current_file", "enabled")
 
+  -- v3.x
+  removed("close_floats_on_escape_key")
+
   return migrations
 end
 

--- a/lua/neo-tree/ui/popups.lua
+++ b/lua/neo-tree/ui/popups.lua
@@ -1,5 +1,4 @@
 local vim = vim
-local Input = require("nui.input")
 local NuiText = require("nui.text")
 local NuiPopup = require("nui.popup")
 local highlights = require("neo-tree.ui.highlights")
@@ -8,7 +7,7 @@ local log = require("neo-tree.log")
 local M = {}
 
 M.popup_options = function(title, min_width, override_options)
-  local min_width = min_width or 30
+  min_width = min_width or 30
   local width = string.len(title) + 2
 
   local nt = require("neo-tree")

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -873,12 +873,6 @@ local function create_floating_window(state, win_options, bufname)
     win.original_options = state.window
     table.insert(floating_windows, win)
 
-    if require("neo-tree").config.close_floats_on_escape_key then
-      win:map("n", "<esc>", function(_)
-        win:unmount()
-      end, { noremap = true })
-    end
-
     win:on({ "BufHidden" }, function()
       vim.schedule(function()
         win:unmount()


### PR DESCRIPTION
closes #1028

In the end there is no change with the default options, but now it is controlled by a mapping which the user can set to any key that they want.
