### PR TITLE
Fix: replace the usage of `get_icon` function to support the `overrid…

### DIFF
--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -281,7 +281,7 @@ M.icon = function(config, node, state)
     local success, web_devicons = pcall(require, "nvim-web-devicons")
     if success then
       local ext = node.ext and node.ext:lower() or nil
-      local devicon, hl = web_devicons.get_icon(node.name, ext)
+      local devicon, hl = web_devicons.get_icon(node.name)
       icon = devicon or icon
       highlight = hl or highlight
     end


### PR DESCRIPTION
…e_by_extension`

To support the `override_by_extension` items inside the icons, and complex extensions of files, try to use the `get_icon` function without force the extension