### PR TITLE
docs: Fix lazy.nvim instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ so we can fix it.
 {
     "nvim-neo-tree/neo-tree.nvim",
     branch = "v3.x",
-    requires = { 
+    dependencies = {
       "nvim-lua/plenary.nvim",
       "nvim-tree/nvim-web-devicons", -- not strictly required, but recommended
       "MunifTanjim/nui.nvim",


### PR DESCRIPTION
Lazy uses `dependencies` instead of `requires` 😄

Source: [Lazy.nvim migration guide](https://github.com/folke/lazy.nvim#packernvim)