### PR TITLE
fix(preview): revert when jumping to preview window if it is not floating

### DIFF
--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -393,7 +393,8 @@ Preview.toggle = function(state)
     local preview_event = {
       event = events.VIM_CURSOR_MOVED,
       handler = function()
-        if not toggle_state or vim.api.nvim_get_current_win() == instance.winid then
+        local did_enter_preview = vim.api.nvim_get_current_win() == instance.winid
+        if not toggle_state or (did_enter_preview and instance.config.use_float) then
           return
         end
         if vim.api.nvim_get_current_win() == winid then


### PR DESCRIPTION
There is a check in place which prevents closing the preview if the user jumps into the preview window. This makes sense if the preview is floating, but causes problems otherwise by not properly reverting the preview, for example when closing the neo-tree source.

This should be fixed simply by also checking if the preview window is floating.