### PR TITLE
fix: Leading slashes of spaces in paths on Windows when opening files

### DIFF
--- a/lua/neo-tree/utils.lua
+++ b/lua/neo-tree/utils.lua
@@ -903,7 +903,7 @@ end
 M.escape_path = function(path)
   local escaped_path = vim.fn.fnameescape(path)
   if M.is_windows then
-    escaped_path = escaped_path:gsub("\\", "/")
+    escaped_path = escaped_path:gsub("\\", "/"):gsub("/ ", " ")
   end
   return escaped_path
 end


### PR DESCRIPTION
Closes #1076

@miversen33 Could you please take a look at this fix? It's a subsequent fix of the Windows path adaption since PR #1023.

I've tested on my side for these test cases and all of them have passed:

- `d:\test path\test.txt`
- `d:\test\nested dir\test.txt`
- `d:\test\(inner)\test.txt` _<-- regression test for #1023_
- `d:\test\ leading\test.txt`
- `d:\test\trailing \test.txt`

![image](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/2867434/576beb58-b919-41b3-a222-374a894b5d62)

