### PR TITLE
fix: restore deprecated `close_all` command, but remove from docs

### DIFF
--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -3,6 +3,14 @@ local utils = require("neo-tree.utils")
 local log = require("neo-tree.log")
 local M = {}
 
+-- DEPRECATED: to be removed in a future release, use this instead:
+-- ```
+-- require("neo-tree.command").execute({ action = "close" }) 
+-- ```
+M.close_all = function()
+  require("neo-tree.command").execute({ action = "close" })
+end
+
 M.ensure_config = function()
   if not M.config then
     M.setup({ log_to_file = false }, true)

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -100,7 +100,7 @@ local config = {
   --    event = "file_opened",
   --    handler = function(file_path)
   --      --auto close
-  --      require("neo-tree").close_all()
+  --      require("neo-tree.command").execute({ action = "close" })
   --    end
   --  },
   --  {


### PR DESCRIPTION
fixes #1080
