### PR TITLE
feat: check explicitly opened directories in get_folder_node

### DIFF
--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -31,7 +31,12 @@ local function get_folder_node(state)
       use_parent = insert_as_global == "sibling"
     end
 
-    local is_open_dir = node.type == "directory" and (node:is_expanded() or node.empty_expanded)
+    local is_open_dir = node.type == "directory"
+      and (
+        node:is_expanded()
+        or node.empty_expanded
+        or state.explicitly_opened_directories[node:get_id()]
+      )
     if use_parent and not is_open_dir then
       return tree:get_node(node:get_parent_id())
     end


### PR DESCRIPTION
Fix issue when adding/pasting file with following config to an empty folder.

```lua
['a'] = { 'add', config = { insert_as = 'sibling' } },
['p'] = { 'paste_from_clipboard', config = { insert_as = 'sibling' } },
```

1. Expand folder `A`
2. press `a` and add file `a`
3. file `a` will be a sibling of `A` instead of child

![image](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/16000170/6362474c-fdec-4542-9c8b-71b8e221be24)
