### PR TITLE
fix(manager): reveal_current_file attemp to call nil field

### DIFF
--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -527,7 +527,7 @@ M.reveal_current_file = function(source_name, callback, force_cwd)
   -- (potentially) different position/node
   state.position.is.restorable = false
 
-  require("neo-tree").close_all_except(source_name)
+  M.close_all()
   local path = M.get_path_to_reveal()
   if not path then
     M.focus(source_name)


### PR DESCRIPTION
`reveal_current_file` still tries calling `require("neo-tree").close_all_except(source_name)` which is removed by 78d26168e0b4c7c06a0c59b26c2cd305e64f3d12 and causes this error.

![image](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/16000170/c2327eb7-baf9-40ff-8cc1-86054d9ac2e6)

Here's my usage:

```
mappings = {
  ['gc'] = function()
    local manager = require('neo-tree.sources.manager')
    manager.reveal_current_file('filesystem')
  end,
},
```

From my understanding, it needs to close all neo-tree window to bring focus to 'current file' and after that `M.get_path_to_reveal()` can find the path.

I tried using `M.close_all_except(source_name)` but since the neo-tree window is not closed `M.get_path_to_reveal()` can't find the path to reveal. So I think `M.close_all()` is the proper choice.