### PR TITLE
fix!: fix and deprecate old `reveal_current_file` methods

### DIFF
--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -24,13 +24,6 @@ local get_state = function(tabid)
   return manager.get_state(M.name, tabid)
 end
 
--- TODO: DEPRECATED in 1.19, remove in 2.0
--- Leaving this here for now because it was mentioned in the help file.
-M.reveal_current_file = function()
-  log.warn("DEPRECATED: use `neotree.sources.manager.reveal_current_file('filesystem')` instead")
-  return manager.reveal_current_file(M.name)
-end
-
 local follow_internal = function(callback, force_show, async)
   log.trace("follow called")
   local state = get_state()

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -517,65 +517,14 @@ M.refresh = function(source_name, callback)
   end
 end
 
+--- DEPRECATED: Keeping this here as a warning for a few releases...
 M.reveal_current_file = function(source_name, callback, force_cwd)
-  log.trace("Revealing current file")
-  local state = M.get_state(source_name)
-  state.current_position = nil
-
-  -- When events trigger that try to restore the position of the cursor in the tree window,
-  -- we want them to ignore this "iteration" as the user is trying to explicitly focus a
-  -- (potentially) different position/node
-  state.position.is.restorable = false
-
-  require("neo-tree").close_all_except(source_name)
-  local path = M.get_path_to_reveal()
-  if not path then
-    M.focus(source_name)
-    return
-  end
-  local cwd = state.path
-  if cwd == nil then
-    cwd = M.get_cwd(state)
-  end
-  if force_cwd then
-    if not utils.is_subpath(cwd, path) then
-      state.path, _ = utils.split_path(path)
-    end
-  elseif not utils.is_subpath(cwd, path) then
-    cwd, _ = utils.split_path(path)
-    inputs.confirm("File not in cwd. Change cwd to " .. cwd .. "?", function(response)
-      if response == true then
-        state.path = cwd
-        M.focus(source_name, path, callback)
-      else
-        M.focus(source_name, nil, callback)
-      end
-    end)
-    return
-  end
-  if path then
-    if not renderer.focus_node(state, path) then
-      M.focus(source_name, path, callback)
-    end
-  end
+  log.warn([[DEPRECATED: use `require("neo-tree.command").execute({ source_name = source_name, action = "focus", reveal = true })` instead]])
 end
 
+--- DEPRECATED: Keeping this here as a warning for a few releases...
 M.reveal_in_split = function(source_name, callback)
-  local state = M.get_state(source_name, nil, vim.api.nvim_get_current_win())
-  state.current_position = "current"
-  local path_to_reveal = M.get_path_to_reveal()
-  if not path_to_reveal then
-    M.navigate(state, nil, nil, callback)
-    return
-  end
-  local cwd = state.path
-  if cwd == nil then
-    cwd = M.get_cwd(state)
-  end
-  if cwd and not utils.is_subpath(cwd, path_to_reveal) then
-    state.path, _ = utils.split_path(path_to_reveal)
-  end
-  M.navigate(state, state.path, path_to_reveal, callback)
+  log.warn([[DEPRECATED: use `require("neo-tree.command").execute({ source_name = source_name, action = "focus", reveal = true, position = "current" })` instead]])
 end
 
 ---Opens the tree and displays the current path or cwd, without focusing it.


### PR DESCRIPTION
BREAKING CHANGE: deprecated `neo-tree.sources.manager.reveal_current_file()` and `...reveal_in_split()`, removed `neo-tree.reveal_current_file`

Since `neo-tree.reveal_current_file` has actually been broken since 3.0 was released and should bhave been removed in 2.0, I don't so much harm in just deleting it now. These were all leftovers from the old `NeoTree*` commands.

see #1098 for more info
