### PR TITLE
feat: improve default empty folder icons

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -198,8 +198,8 @@ local config = {
     icon = {
       folder_closed = "",
       folder_open = "",
-      folder_empty = "󰜌",
-      folder_empty_open = "󰜌",
+      folder_empty = "󰉖",
+      folder_empty_open = "󰷏",
       -- The next two settings are only a fallback, if you use nvim-web-devicons and configure default icons there
       -- then these will never be used.
       default = "*",

--- a/tests/neo-tree/ui/icons_spec.lua
+++ b/tests/neo-tree/ui/icons_spec.lua
@@ -71,7 +71,7 @@ describe("ui/icons", function()
 
       u.assert_buf_lines(bufnr, {
         string.format("  %s", fs_tree.abspath):sub(1, 42),
-        "   󰜌 baz",
+        "   󰉖 baz",
         "    foo",
         "   │  bar",
         "   └ * foo1.lua",
@@ -79,7 +79,7 @@ describe("ui/icons", function()
       })
 
       u.assert_highlight(bufnr, ns_id, 1, " ", "NeoTreeDirectoryIcon")
-      u.assert_highlight(bufnr, ns_id, 2, "󰜌 ", "NeoTreeDirectoryIcon")
+      u.assert_highlight(bufnr, ns_id, 2, "󰉖 ", "NeoTreeDirectoryIcon")
       u.assert_highlight(bufnr, ns_id, 4, " ", "NeoTreeDirectoryIcon")
       u.assert_highlight(bufnr, ns_id, 5, "* ", "NeoTreeFileIcon")
     end)
@@ -108,7 +108,7 @@ describe("ui/icons", function()
 
       u.assert_buf_lines(bufnr, {
         vim.fn.strcharpart(string.format("  %s", fs_tree.abspath), 0, 40),
-        "   󰜌 baz",
+        "   󰉖 baz",
         "    foo",
         "   │  bar",
         "   └  foo1.lua",
@@ -116,7 +116,7 @@ describe("ui/icons", function()
       })
 
       u.assert_highlight(bufnr, ns_id, 1, " ", "NeoTreeDirectoryIcon")
-      u.assert_highlight(bufnr, ns_id, 2, "󰜌 ", "NeoTreeDirectoryIcon")
+      u.assert_highlight(bufnr, ns_id, 2, "󰉖 ", "NeoTreeDirectoryIcon")
       u.assert_highlight(bufnr, ns_id, 4, " ", "NeoTreeDirectoryIcon")
 
       local extmarks = u.get_text_extmarks(bufnr, ns_id, 5, " ")


### PR DESCRIPTION
The original icon was chosen before we had the feature to distingiush between an empty folder and an empty folder that was "open". It was intentionally different as as not to lead to confusion, it was meant to indicate that the folder was neither open nor closed, just empty.

Now that we do actually track the open state of a closed folder and there are some situations where the behavior is different based on whether an empty folder is open or closed, it's important to show which state it is in.

The new icons I hope make it obvious that the folder is empty while still displaying separate open and closed states.

![image](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/5160605/9f78a3ce-b7fe-4188-a519-c6c71b30044e)

