### PR TITLE
fix: ignore errors from failed redraw due to window being closed

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -677,8 +677,15 @@ M.position = {
 M.redraw = function(state)
   if state.tree and M.tree_is_visible(state) then
     log.trace("Redrawing tree", state.name, state.id)
-    render_tree(state)
-    log.trace("  Redrawing tree done", state.name, state.id)
+    -- every now and then this will fail because the window was closed in 
+    -- betweeen the start of an async refresh and the redraw call.
+    -- This is not a problem, so we just ignore the error.
+    local success = pcall(render_tree, state)
+    if success then
+      log.trace("  Redrawing tree done", state.name, state.id)
+    else
+      log.trace("  Redrawing tree failed, maybe it was closed?", state.name, state.id)
+    end
   end
 end
 ---Visit all nodes ina tree recursively and reduce to a single value.


### PR DESCRIPTION
This is to fix errors like this:

```
[Neo-tree ERROR] Error in event handler for event vim_diagnostic_changed[filesystem.vim_diagnostic_changed]: ...r/.local/share/nvim/lazy/nui.nvim/lua/nui/utils/init.lua:130: Invalid buffer id: 42
```

They mostly happen when quickly open and closing the tree, such as with position=current. They are not really a problem but the error messaage is a nuisance. This change just ignores the errors.
