### PR TITLE
feat: setup hooks for sources to provide custom `stat`s for nodes

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -270,6 +270,7 @@ create_nodes = function(source_items, state, level)
       skip_node = item.skip_node,
       is_empty_with_hidden_root = item.is_empty_with_hidden_root,
       stat = item.stat,
+      stat_provider = item.stat_provider,
       -- TODO: The below properties are not universal and should not be here.
       -- Maybe they should be moved to the "extra" field?
       is_link = item.is_link,

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -325,7 +325,9 @@ M.get_inner_win_width = function(winid)
 end
 
 local stat_providers = {
-  default = vim.loop.fs_stat,
+  default = function (node)
+    return vim.loop.fs_stat(node.path)
+  end,
 }
 
 --- Gets the statics for a node in the file system. The `stat` object will be cached 
@@ -344,7 +346,7 @@ local stat_providers = {
 M.get_stat = function (node)
   if node.stat == nil then
     local provider = stat_providers[node.stat_provider or "default"]
-    local success, stat = pcall(provider, node.path)
+    local success, stat = pcall(provider, node)
     node.stat = success and stat or {}
   end
   return node.stat


### PR DESCRIPTION
This tweaks how file stats are pulled so that sources (internal or external) can provide their own. This is only necessary if the node does not represent an object in the local filesystem.

See here for an example the API to fulfill:
https://github.com/nvim-neo-tree/example-source/blob/1be4d91d94875501cb4db1a61aa5155b6cd654bc/lua/example/init.lua#L19-L49
