### PR TITLE
refactor!: setup the `symlink_target` component using default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,9 @@ use {
             enabled = true,
             required_width = 110, -- min width of window required to show this column
           },
+          symlink_target = {
+            enabled = false,
+          },
         },
         -- A list of functions, each representing a global custom command
         -- that will be available in all sources (if not overridden in `opts[source_name].commands`)

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -251,6 +251,9 @@ local config = {
       enabled = false,
       required_width = 120, -- min width of window required to show this column
     },
+    symlink_target = {
+      enabled = false,
+    },
   },
   renderers = {
     directory = {
@@ -261,11 +264,11 @@ local config = {
         "container",
         content = {
           { "name", zindex = 10 },
-          -- {
-          --   "symlink_target",
-          --   zindex = 10,
-          --   highlight = "NeoTreeSymbolicLinkTarget",
-          -- },
+          {
+            "symlink_target",
+            zindex = 10,
+            highlight = "NeoTreeSymbolicLinkTarget",
+          },
           { "clipboard", zindex = 10 },
           { "diagnostics", errors_only = true, zindex = 20, align = "right", hide_when_expanded = true },
           { "git_status", zindex = 10, align = "right", hide_when_expanded = true },
@@ -286,11 +289,11 @@ local config = {
             "name",
             zindex = 10
           },
-          -- {
-          --   "symlink_target",
-          --   zindex = 10,
-          --   highlight = "NeoTreeSymbolicLinkTarget",
-          -- },
+          {
+            "symlink_target",
+            zindex = 10,
+            highlight = "NeoTreeSymbolicLinkTarget",
+          },
           { "clipboard", zindex = 10 },
           { "bufnr", zindex = 10 },
           { "modified", zindex = 20, align = "right" },


### PR DESCRIPTION
Currently the only ways to enable the `symlink_target` component is copying the entire the directory and file renderer configs or defining a custom config that includes them. This can be annoying to maintain if the default rendered configuration changes.

This PR uncomments the component in the default config and disables it by default as mentioned in [this comment](https://github.com/nvim-neo-tree/neo-tree.nvim/issues/746#issuecomment-1429090271). 