### PR TITLE
fix: prevent "too many open files" errors from git ignored check

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -22,8 +22,6 @@ local config = {
   enable_opened_markers = true,   -- Enable tracking of opened files. Required for `components.name.highlight_opened_files`
   enable_refresh_on_write = true, -- Refresh the tree when a file is written. Only used if `use_libuv_file_watcher` is false.
   enable_normal_mode_for_inputs = false, -- Enable normal mode for input dialogs.
-  git_ignore_max_folders = 200, -- Maximum number of folders before git ignore checks are skipped. If you increase this,
-                                -- you may need to increase the open files limit in your OS as well. i.e. `ulimit -n 4096`
   git_status_async = true,
   -- These options are for people with VERY large git repos
   git_status_async_options = {

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -22,6 +22,8 @@ local config = {
   enable_opened_markers = true,   -- Enable tracking of opened files. Required for `components.name.highlight_opened_files`
   enable_refresh_on_write = true, -- Refresh the tree when a file is written. Only used if `use_libuv_file_watcher` is false.
   enable_normal_mode_for_inputs = false, -- Enable normal mode for input dialogs.
+  git_ignore_max_folders = 200, -- Maximum number of folders before git ignore checks are skipped. If you increase this,
+                                -- you may need to increase the open files limit in your OS as well. i.e. `ulimit -n 4096`
   git_status_async = true,
   -- These options are for people with VERY large git repos
   git_status_async_options = {
@@ -444,6 +446,9 @@ local config = {
       sidebar = "tab",   -- sidebar is when position = left or right
       current = "window" -- current is when position = current
     },
+    check_gitignore_in_search = true, -- check gitignore status for files/directories when searching
+                                      -- setting this to false will speed up searches, but gitignored
+                                      -- items won't be marked if they are visible.
     -- The renderer section provides the renderers that will be used to render the tree.
     --   The first level is the node type.
     --   For each node type, you can specify a list of components to render.

--- a/lua/neo-tree/git/ignored.lua
+++ b/lua/neo-tree/git/ignored.lua
@@ -44,11 +44,21 @@ M.mark_ignored = function(state, items, callback)
   local folders = {}
   log.trace("================================================================================")
   log.trace("IGNORED: mark_ignore BEGIN...")
+  local folder_count = 0
+  local git_ignore_max_folders = require("neo-tree").config.git_ignore_max_folders or 200
 
   for _, item in ipairs(items) do
     local folder = utils.split_path(item.path)
     if folder then
       if not folders[folder] then
+        folder_count = folder_count + 1
+        if folder_count > git_ignore_max_folders then
+          log.info("Too many folders to check for git ignored files, skipping... you can change this with the `git_ignore_max_folders` option")
+          if type(callback) == "function" then
+            callback({})
+          end
+          return {}
+        end
         folders[folder] = {}
       end
       table.insert(folders[folder], item.path)

--- a/lua/neo-tree/git/ignored.lua
+++ b/lua/neo-tree/git/ignored.lua
@@ -44,21 +44,11 @@ M.mark_ignored = function(state, items, callback)
   local folders = {}
   log.trace("================================================================================")
   log.trace("IGNORED: mark_ignore BEGIN...")
-  local folder_count = 0
-  local git_ignore_max_folders = require("neo-tree").config.git_ignore_max_folders or 200
 
   for _, item in ipairs(items) do
     local folder = utils.split_path(item.path)
     if folder then
       if not folders[folder] then
-        folder_count = folder_count + 1
-        if folder_count > git_ignore_max_folders then
-          log.info("Too many folders to check for git ignored files, skipping... you can change this with the `git_ignore_max_folders` option")
-          if type(callback) == "function" then
-            callback({})
-          end
-          return {}
-        end
         folders[folder] = {}
       end
       table.insert(folders[folder], item.path)
@@ -114,7 +104,29 @@ M.mark_ignored = function(state, items, callback)
   local all_results = {}
   if type(callback) == "function" then
     local jobs = {}
-    local progress = 0
+    local running_jobs = 0
+    local job_count = 0
+    local completed_jobs = 0
+
+    -- This is called when a job completes, and starts the next job if there are any left
+    -- or calls the callback if all jobs are complete.
+    -- It is also called once at the start to start the first 50 jobs.
+    --
+    -- This is done to avoid running too many jobs at once, which can cause a crash from
+    -- having too many open files.
+    local run_more_jobs = function()
+      while #jobs > 0 and running_jobs < 50 and job_count > completed_jobs do
+        local next_job = table.remove(jobs, #jobs)
+        next_job:start()
+        running_jobs = running_jobs + 1
+      end
+
+      if completed_jobs == job_count then
+        finalize(all_results)
+        callback(all_results)
+      end
+    end
+
     for folder, folder_items in pairs(folders) do
       local args = { "-C", folder, "check-ignore", "--stdin" }
       local job = Job:new({
@@ -134,19 +146,17 @@ M.mark_ignored = function(state, items, callback)
             result = self:result()
           end
           vim.list_extend(all_results, process_result(result))
-          progress = progress + 1
-          if progress == #jobs then
-            finalize(all_results)
-            callback(all_results)
-          end
+
+          running_jobs = running_jobs - 1
+          completed_jobs = completed_jobs + 1
+          run_more_jobs()
         end,
       })
       table.insert(jobs, job)
+      job_count = job_count + 1
     end
 
-    for _, job in ipairs(jobs) do
-      job:start()
-    end
+    run_more_jobs()
   else
     for folder, folder_items in pairs(folders) do
       local cmd = { "git", "-C", folder, "check-ignore", unpack(folder_items) }


### PR DESCRIPTION
fixes #1125, fixes #997

The problem was actually cuased by calling out to git too many times when checking the git ignored status of files. This only happens when there are many folders being shown at once. The solution was to limit the number of concurrent running jobs to 50.

I also snuck in a config option to completely disable checking gitignore when searching, as this has a big performance impact on the "search as you type" mode. Personally, I'd rather it be fast than be able to mark gitignored items.

```
require("neo-tree").setup({
  filesystem = {
    check_gitignore_in_search = false, -- Check gitignore status for files/directories when searching.
                                       -- Setting this to false will speed up searches, but gitignored
                                       -- items won't be marked if they are visible.
  }
})
```

The default value is true so as not to change the existing behavior.
