### PR TITLE
feat(buffers): add `terminals_first` option

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -538,6 +538,7 @@ local config = {
     group_empty_dirs = true,  -- when true, empty directories will be grouped together
     show_unloaded = false,    -- When working with sessions, for example, restored but unfocused buffers
                               -- are mark as "unloaded". Turn this on to view these unloaded buffer.
+    terminals_first = false,  -- when true, terminals will be listed before file buffers
     window = {
       mappings = {
         ["<bs>"] = "navigate_up",

--- a/lua/neo-tree/sources/buffers/lib/items.lua
+++ b/lua/neo-tree/sources/buffers/lib/items.lua
@@ -94,7 +94,11 @@ M.get_opened_buffers = function(state)
       search_pattern = state.search_pattern,
     }
     context.folders["Terminals"] = terminal_root
-    root_folders[2] = terminal_root
+    if state.terminals_first then
+      table.insert(root_folders, 1, terminal_root)
+    else
+      table.insert(root_folders, terminal_root)
+    end
   end
   state.default_expanded_nodes = {}
   for id, _ in pairs(context.folders) do

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -279,8 +279,9 @@ M.icon = function(config, node, state)
     end
   elseif node.type == "file" or node.type == "terminal" then
     local success, web_devicons = pcall(require, "nvim-web-devicons")
+    local name = node.type == "terminal" and "terminal" or node.name
     if success then
-      local devicon, hl = web_devicons.get_icon(node.name)
+      local devicon, hl = web_devicons.get_icon(name)
       icon = devicon or icon
       highlight = hl or highlight
     end


### PR DESCRIPTION
This adds an option, which is disabled by default, to sort terminals at the top of the buffers list instead of the bottom. It also fixes the ternminal icon.

The new option is:

```lua
require("neo-tree").setup({
  buffers = {
    terminals_first = false
  }
})
```
