### PR TITLE
doc: typo fix (duplicated `om`)

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -309,7 +309,7 @@ og = ...git_status:  Sort by git status.
 
 om = ...modified:    Sort by last modified date.
 
-om = ...name:        Sort by name (default sort).
+on = ...name:        Sort by name (default sort).
 
 os = ...size:        Sort by size.
 


### PR DESCRIPTION
Sort by **n**ame should be `on`, i guess.