### PR TITLE
fix(filesystem): ensure replacemnt for deleted buffer is a real file

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -16,12 +16,36 @@ local Path = require("plenary").path
 
 local M = {}
 
+local function find_replacement_buffer(for_buf)
+  local bufs = vim.api.nvim_list_bufs()
+
+  -- make sure the alternate buffer is at the top of the list
+  local alt = vim.fn.bufnr("#")
+  if alt ~= -1 and alt ~= for_buf then
+    table.insert(bufs, 1, alt)
+  end
+
+  -- find the first valid real file buffer
+  for _, buf in ipairs(bufs) do
+    if buf ~= for_buf then
+      local is_valid = vim.api.nvim_buf_is_valid(buf)
+      if is_valid then
+        local buftype = vim.api.nvim_buf_get_option(buf, "buftype")
+        if buftype == "" then
+          return buf
+        end
+      end
+    end
+  end
+  return -1
+end
+
 local function clear_buffer(path)
   local buf = utils.find_buffer_by_name(path)
   if buf < 1 then
     return
   end
-  local alt = vim.fn.bufnr("#")
+  local alt = find_replacement_buffer(buf)
   -- Check all windows to see if they are using the buffer
   for _, win in ipairs(vim.api.nvim_list_wins()) do
     if vim.api.nvim_win_is_valid(win) and vim.api.nvim_win_get_buf(win) == buf then


### PR DESCRIPTION
fixes #1174

When a file is deleted from neo-tree, neo-tree checks to see if it is open anywhere. If it is, neo-tree will replace this buffer with the "alternate" buffer before wiping out that buffer.

As detailed in #1174, if this is done from a floating window, this can lead to neo-tree itself becoming the replacement which then takes focus unexpectedly which can then lead to all sorts of shenanigans and bad results.

The solution is to make sure that the replacement file is a real file and not a special buffer type. This includes neo-tree which makes it a direct fix for this specific problem, but it also includes other plugin buffers and special buffers like quickfix and help. If there is no valid buffer to replace the deleted file with, then a new buffer will be created to as a placeholder.
