### PR TITLE
fix(filesystem): always show gitignored status unless `enable_git_status` is false

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -115,10 +115,10 @@ local should_check_gitignore = function (context)
   if state.filtered_items.hide_gitignored then
     return true
   end
-  if not state.enable_git_status then
-    return true
+  if state.enable_git_status == false then
+    return false
   end
-  return false
+  return true
 end
 
 local job_complete_async = function(context)


### PR DESCRIPTION
fixes #1152

With this change, the gitignored status will always be loaded unless:

- `filtered_items.hide_gitignored` is false AND `enabled_git_status` is false
- you are doing a search and `check_gitignore_in_search` is false
- there are no items to show

Note that this does not affect dotfiles, which will show as normal files when `filtered_items.hide_dotfiles` is false.
