### PR TITLE
feat: custom text for mappings in help window

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -406,7 +406,14 @@ For example:
    require("neo-tree").setup({
      window = {
        mappings = {
-         ["A"] = "command_a"
+         ["A"] = "command_a",
+         ["i"] = {
+           function(state)
+             local node = state.tree:get_node()
+             print(node.path)
+           end,
+           label = "print path",
+         },
        }
      },
      filesystem = {
@@ -420,6 +427,8 @@ For example:
 <
 The above config will map `A` to command_a for all sources except for
 filesystem, which will use command_b instead.
+
+The label is used to display in the help popup.
 
 If you don't want to use *any* default mappings, you can set
 `use_default_mappings = false` in your config.
@@ -500,6 +509,7 @@ assigning it to the `command` key:
                local node = state.tree:get_node()
                print(node.name)
              end,
+             label = "print name",
              nowait = true
            },
            ["i"] = {
@@ -507,7 +517,8 @@ assigning it to the `command` key:
                local node = state.tree:get_node()
                print(node.name)
              end,
-             nowait = true
+             label = "print name",
+             nowait = true,
            },
            ["o"] = {
              command = "open",

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -821,12 +821,14 @@ local set_buffer_mappings = function(state)
         log.trace("Skipping mapping for %s", cmd)
       else
         local map_options = vim.deepcopy(mapping_options)
+        local label
         if type(func) == "table" then
           for key, value in pairs(func) do
-            if key ~= "command" and key ~= 1 and key ~= "config" then
+            if key ~= "command" and key ~= 1 and key ~= "config" and key ~= "label" then
               map_options[key] = value
             end
           end
+          label = func.label
           config = func.config or {}
           func = func.command or func[1]
         end
@@ -835,7 +837,7 @@ local set_buffer_mappings = function(state)
           vfunc = state.commands[func .. "_visual"]
           func = state.commands[func]
         elseif type(func) == "function" then
-          resolved_mappings[cmd] = { text = config.label or "<function>" }
+          resolved_mappings[cmd] = { text = label or "<function>" }
         end
         if type(func) == "function" then
           resolved_mappings[cmd].handler = function()

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -835,7 +835,7 @@ local set_buffer_mappings = function(state)
           vfunc = state.commands[func .. "_visual"]
           func = state.commands[func]
         elseif type(func) == "function" then
-          resolved_mappings[cmd] = { text = config.text or "<function>" }
+          resolved_mappings[cmd] = { text = config.label or "<function>" }
         end
         if type(func) == "function" then
           resolved_mappings[cmd].handler = function()

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -835,7 +835,7 @@ local set_buffer_mappings = function(state)
           vfunc = state.commands[func .. "_visual"]
           func = state.commands[func]
         elseif type(func) == "function" then
-          resolved_mappings[cmd] = { text = "<function>" }
+          resolved_mappings[cmd] = { text = config.text or "<function>" }
         end
         if type(func) == "function" then
           resolved_mappings[cmd].handler = function()


### PR DESCRIPTION
With this feature, you can add labels for custom mappings (lua functions).

### Example mapping with text:

```lua
["<c-f>"] = {
  function(state)
     require("telescope.builtin").live_grep({ cwd = context_dir(state) })
  end,
  config = { text = "live grep" }, -- text here
},
```

### Demo

Before

![before](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/3100053/37961018-8c00-42dd-8729-7c0a7236f85a)

After

![after](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/3100053/05617eb0-8ce9-4835-ac93-0cd67f6488f4)


