### PR TITLE
feat(selector): add command option to toggle source selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,12 @@ want to change the current working directory. If you include this flag, it will
 automatically change the directory without prompting. This option implies
 "reveal", so you do not need to specify both.
 
+#### `selector`
+This is a boolean flag. When you specifically set this to false (`selector=false`)
+neo-tree will disable the [source selector](#source-selector) for that neo-tree
+instance. Otherwise, the source selector will depend on what you specified in
+the configuration (`config.source_selector.{winbar,statusline}`).
+
 See `:h neo-tree-commands` for details and a full listing of available arguments.
 
 ### File Nesting

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -129,10 +129,10 @@ automatically change the directory without prompting. This option implies
 "reveal", so you do not need to specify both.
 
 selector~
-This is a boolean flag. When you specifically set this to false (|selector=false|)
+This is a boolean flag. When you specifically set this to false (`selector=false`)
 neo-tree will disable the |neo-tree-source-selector| for that neo-tree
 instance. Otherwise, the source selector will depend on what you specified in
-the configuration (|config.source_selector.{winbar,statusline}|).
+the configuration (`config.source_selector.{winbar,statusline}`).
 
 CALLING_FROM_LUA
 

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -128,6 +128,12 @@ want to change the current working directory. If you include this flag, it will
 automatically change the directory without prompting. This option implies
 "reveal", so you do not need to specify both.
 
+selector~
+This is a boolean flag. When you specifically set this to false (|selector=false|)
+neo-tree will disable the |neo-tree-source-selector| for that neo-tree
+instance. Otherwise, the source selector will depend on what you specified in
+the configuration (|config.source_selector.{winbar,statusline}|).
+
 DEPRECATED_COMMANDS
 
 The following commands from Neotree v1.x will remain until v3.0 for backwards

--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -139,6 +139,9 @@ M.execute = function(args)
     state.git_base = args.git_base
   end
 
+  -- Handle source selector option
+  state.enable_source_selector = args.selector
+
   -- Handle reveal logic
   args.reveal = args.reveal or args.reveal_force_cwd
   local do_reveal = utils.truthy(args.reveal_file)

--- a/lua/neo-tree/command/parser.lua
+++ b/lua/neo-tree/command/parser.lua
@@ -45,6 +45,7 @@ M.setup = function(all_source_names)
     toggle = { type = M.FLAG },
     reveal = { type = M.FLAG },
     reveal_force_cwd = { type = M.FLAG },
+    selector = { type = M.FLAG },
   }
 
   local arg_type_lookup = {}

--- a/lua/neo-tree/ui/selector.lua
+++ b/lua/neo-tree/ui/selector.lua
@@ -400,6 +400,9 @@ end
 ---@param state table: state
 ---@return nil
 M.set_source_selector = function(state)
+  if state.enable_source_selector == false then
+    return
+  end
   local sel_config = utils.resolve_config_option(require("neo-tree").config, "source_selector", {})
   if sel_config and sel_config.winbar then
     vim.wo[state.winid].winbar = "%{%v:lua.require'neo-tree.ui.selector'.get()%}"


### PR DESCRIPTION
Closes: #1170, #895

Add command option `:Neotree selector=true / false` to toggle source selector on command.

Note: @cseickel 
This adds a new field `state.enable_source_selector` which I'm not sure if you are a fan of.

If you don't want to introduce a new field to `state`, I believe it would be pretty much impossible to implement this feature tho.

If you are OK with this PR, I'll add some documentation and change this from _draft_ to a PR.