### PR TITLE
feat(input): add newline when `use_popups_for_input = false`

### DIFF
--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -11,7 +11,7 @@ local should_use_popup_input = function()
 end
 
 M.show_input = function(input, callback)
- local config = require("neo-tree").config
+  local config = require("neo-tree").config
   input:mount()
 
   if config.enable_normal_mode_for_inputs and input.prompt_type ~= "confirm" then
@@ -59,7 +59,7 @@ M.input = function(message, default_value, callback, options, completion)
     M.show_input(input)
   else
     local opts = {
-      prompt = message .. " ",
+      prompt = message .. "\n",
       default = default_value,
     }
     if completion then


### PR DESCRIPTION
Closes: #1172

A very simple PR; inserts a `'\n'` between the popup message and default value instead of a space.