### PR TITLE
feat!: rename `label` to `desc` for mapping descriptions

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -412,7 +412,7 @@ For example:
              local node = state.tree:get_node()
              print(node.path)
            end,
-           label = "print path",
+           desc = "print path",
          },
        }
      },
@@ -428,7 +428,7 @@ For example:
 The above config will map `A` to command_a for all sources except for
 filesystem, which will use command_b instead.
 
-The label is used to display in the help popup.
+The desc is used to display in the help popup.
 
 If you don't want to use *any* default mappings, you can set
 `use_default_mappings = false` in your config.
@@ -509,7 +509,7 @@ assigning it to the `command` key:
                local node = state.tree:get_node()
                print(node.name)
              end,
-             label = "print name",
+             desc = "print name",
              nowait = true
            },
            ["i"] = {
@@ -517,7 +517,7 @@ assigning it to the `command` key:
                local node = state.tree:get_node()
                print(node.name)
              end,
-             label = "print name",
+             desc = "print name",
              nowait = true,
            },
            ["o"] = {

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -821,14 +821,14 @@ local set_buffer_mappings = function(state)
         log.trace("Skipping mapping for %s", cmd)
       else
         local map_options = vim.deepcopy(mapping_options)
-        local label
+        local desc
         if type(func) == "table" then
           for key, value in pairs(func) do
-            if key ~= "command" and key ~= 1 and key ~= "config" and key ~= "label" then
+            if key ~= "command" and key ~= 1 and key ~= "config" and key ~= "desc" then
               map_options[key] = value
             end
           end
-          label = func.label
+          desc = func.desc
           config = func.config or {}
           func = func.command or func[1]
         end
@@ -837,7 +837,7 @@ local set_buffer_mappings = function(state)
           vfunc = state.commands[func .. "_visual"]
           func = state.commands[func]
         elseif type(func) == "function" then
-          resolved_mappings[cmd] = { text = label or "<function>" }
+          resolved_mappings[cmd] = { text = desc or "<function>" }
         end
         if type(func) == "function" then
           resolved_mappings[cmd].handler = function()


### PR DESCRIPTION
This aligns the mapping API closer with the core `keymap.set` lua API in Neovim

This is a continuation on #1186 