### PR TITLE
Update state.explicitly_opened_directories when collapsing by action close_all

### DIFF
--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -153,6 +153,12 @@ M.close_node = function(state, callback)
     target_node:collapse()
     renderer.redraw(state)
     renderer.focus_node(state, target_node:get_id())
+    if
+      state.explicitly_opened_directories
+      and state.explicitly_opened_directories[target_node:get_id()]
+    then
+      state.explicitly_opened_directories[target_node:get_id()] = false
+    end
   end
 end
 
@@ -171,9 +177,16 @@ M.close_all_subnodes = function(state)
   renderer.collapse_all_nodes(tree, target_node:get_id())
   renderer.redraw(state)
   renderer.focus_node(state, target_node:get_id())
+  if
+    state.explicitly_opened_directories
+    and state.explicitly_opened_directories[target_node:get_id()]
+  then
+    state.explicitly_opened_directories[target_node:get_id()] = false
+  end
 end
 
 M.close_all_nodes = function(state)
+  state.explicitly_opened_directories = {}
   renderer.collapse_all_nodes(state.tree)
   renderer.redraw(state)
 end


### PR DESCRIPTION
This purpose of this change is to keep `state.explicitly_opened_directories` up to date not only when you open Nodes, but also when you close them. 
Specifically, this applies to actions `close_all_nodes` and `close_all_subnodes`.

Not sure if this change is fixing some bugs in the neo-tree itself. The reason why I need this: one of my plugins uses `state.explicitly_opened_directories` to save and restore Neo-tree when switching projects, and in above cases, 'explicitly_opened_directories' variable does not correspond to the real state. This change will fix [the bug.](https://github.com/coffebar/neovim-project/issues/12)