### PR TITLE
Return key mapping callback return value, so eval option works

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -842,7 +842,7 @@ local set_buffer_mappings = function(state)
         if type(func) == "function" then
           resolved_mappings[cmd].handler = function()
             state.config = config
-            func(state)
+            return func(state)
           end
           keymap.set(state.bufnr, "n", cmd, resolved_mappings[cmd].handler, map_options)
           if type(vfunc) == "function" then


### PR DESCRIPTION
This contains a small fix to make it so that the return value of key mapping callbacks get passed on to nvim.  This is needed so key mappings with the `expr=true` option work.   See issue #1192 for details.

Fixes #1192 