### PR TITLE
feat(sources): fix and test all `source.navigate` to have same nparams

### DIFF
--- a/lua/neo-tree/sources/buffers/init.lua
+++ b/lua/neo-tree/sources/buffers/init.lua
@@ -82,7 +82,7 @@ end
 
 ---Navigate to the given path.
 ---@param path string Path to navigate to. If empty, will navigate to the cwd.
-M.navigate = function(state, path, path_to_reveal)
+M.navigate = function(state, path, path_to_reveal, callback, async)
   state.dirty = false
   local path_changed = false
   if path == nil then
@@ -100,6 +100,10 @@ M.navigate = function(state, path, path_to_reveal)
 
   if path_changed and state.bind_to_cwd then
     vim.api.nvim_command("tcd " .. path)
+  end
+
+  if type(callback) == "function" then
+    vim.schedule(callback)
   end
 end
 

--- a/lua/neo-tree/sources/document_symbols/init.lua
+++ b/lua/neo-tree/sources/document_symbols/init.lua
@@ -59,12 +59,16 @@ local follow_debounced = function(args)
 end
 
 ---Navigate to the given path.
-M.navigate = function(state)
+M.navigate = function(state, path, path_to_reveal, callback, async)
   state.lsp_winid, _ = utils.get_appropriate_window(state)
   state.lsp_bufnr = vim.api.nvim_win_get_buf(state.lsp_winid)
   state.path = vim.api.nvim_buf_get_name(state.lsp_bufnr)
 
   symbols.render_symbols(state)
+
+  if type(callback) == "function" then
+    vim.schedule(callback)
+  end
 end
 
 ---Configures the plugin, should be called before the plugin is used.

--- a/lua/neo-tree/sources/git_status/init.lua
+++ b/lua/neo-tree/sources/git_status/init.lua
@@ -23,12 +23,16 @@ end
 
 ---Navigate to the given path.
 ---@param path string Path to navigate to. If empty, will navigate to the cwd.
-M.navigate = function(state, path, path_to_reveal)
+M.navigate = function(state, path, path_to_reveal, callback, async)
   state.dirty = false
   if path_to_reveal then
     renderer.position.set(state, path_to_reveal)
   end
   items.get_git_status(state)
+
+  if type(callback) == "function" then
+    vim.schedule(callback)
+  end
 end
 
 M.refresh = function()

--- a/tests/neo-tree/sources/navigate_spec.lua
+++ b/tests/neo-tree/sources/navigate_spec.lua
@@ -23,7 +23,7 @@ local function find_all_sources()
   return result
 end
 
-describe("Manager.navigate(...)", function()
+describe("sources.navigate(...: #<nparams>)", function()
   it("neo-tree.sources.filesystem.navigate exists", function()
     local ok, mod = pcall(require, "neo-tree.sources.filesystem")
     assert.is_true(ok)
@@ -31,7 +31,7 @@ describe("Manager.navigate(...)", function()
   end)
   local filesystem_navigate_nparams =
     debug.getinfo(require("neo-tree.sources.filesystem").navigate).nparams
-  it("neo-tree.sources.filesystem.navigate is_func and has args", function()
+  it("neo-tree.sources.filesystem.navigate is a func and has args", function()
     assert.is_not_nil(filesystem_navigate_nparams)
     assert.is_true(filesystem_navigate_nparams > 0)
   end)
@@ -43,7 +43,7 @@ describe("Manager.navigate(...)", function()
         assert.is_not_nil(mod.navigate)
       end)
       it(source .. ".navigate has same num of args as filesystem", function()
-        local nparams = debug.getinfo(require("neo-tree.sources.filesystem").navigate).nparams
+        local nparams = debug.getinfo(require("neo-tree.sources." .. source).navigate).nparams
         assert.are.equal(filesystem_navigate_nparams, nparams)
       end)
     end)

--- a/tests/neo-tree/sources/navigate_spec.lua
+++ b/tests/neo-tree/sources/navigate_spec.lua
@@ -1,0 +1,51 @@
+pcall(require, "luacov")
+
+local uv = vim.loop
+
+---Return all sources inside "lua/neo-tree/sources"
+---@return string[] # name of sources found
+local function find_all_sources()
+  local base_dir = "lua/neo-tree/sources"
+  local result = {}
+  local fd = uv.fs_scandir(base_dir)
+  while fd do
+    local name, typ = uv.fs_scandir_next(fd)
+    if not name then
+      break
+    end
+    if typ == "directory" then
+      local ok, mod = pcall(require, "neo-tree.sources." .. name)
+      if ok and mod.name then
+        result[#result + 1] = name
+      end
+    end
+  end
+  return result
+end
+
+describe("Manager.navigate(...)", function()
+  it("neo-tree.sources.filesystem.navigate exists", function()
+    local ok, mod = pcall(require, "neo-tree.sources.filesystem")
+    assert.is_true(ok)
+    assert.is_not_nil(mod.navigate)
+  end)
+  local filesystem_navigate_nparams =
+    debug.getinfo(require("neo-tree.sources.filesystem").navigate).nparams
+  it("neo-tree.sources.filesystem.navigate is_func and has args", function()
+    assert.is_not_nil(filesystem_navigate_nparams)
+    assert.is_true(filesystem_navigate_nparams > 0)
+  end)
+  for _, source in ipairs(find_all_sources()) do
+    describe(string.format("Test: %s.navigate", source), function()
+      it(source .. ".navigate is able to require and exists", function()
+        local ok, mod = pcall(require, "neo-tree.sources." .. source)
+        assert.is_true(ok)
+        assert.is_not_nil(mod.navigate)
+      end)
+      it(source .. ".navigate has same num of args as filesystem", function()
+        local nparams = debug.getinfo(require("neo-tree.sources.filesystem").navigate).nparams
+        assert.are.equal(filesystem_navigate_nparams, nparams)
+      end)
+    end)
+  end
+end)


### PR DESCRIPTION
Closes #1151.

As @cseickel mentioned in [this comment](https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1151#issuecomment-1773838523), we should have the same number of arguments for all `M.navigate` functions found in the sources.

I've also added a `busted` test to ensure that all of the sources have the same number of args.

#### Failed Example

This was **before** I made the [last commit](https://github.com/pysan3/neo-tree.nvim/pull/1/commits/bda666ffe7ce248ad9b3754c4b699fa78b47d09e).

https://github.com/pysan3/neo-tree.nvim/actions/runs/6604075269/job/17937819320

#### Success Example

After the last commit.

https://github.com/pysan3/neo-tree.nvim/actions/runs/6604154767/job/17937988093