### PR TITLE
fix(ui): workaround #1197

### DIFF
--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -62,6 +62,11 @@ M.input = function(message, default_value, callback, options, completion)
       prompt = message .. "\n",
       default = default_value,
     }
+    if vim.opt.cmdheight:get() == 0 then
+      -- NOTE: I really don't know why but letters before the first '\n' is not rendered execpt in noice.nvim
+      --       when vim.opt.cmdheight = 0 <2023-10-24, pysan3>
+      opts.prompt = "Neo-tree Popup\n" .. opts.prompt
+    end
     if completion then
       opts.completion = completion
     end


### PR DESCRIPTION
NOTE: I really don't know why but letters before the first '\n' is not rendered execpt in `noice.nvim` when `vim.opt.cmdheight = 0` <2023-10-24, pysan3>

If you know any other solution to this problem, I am more than happy to revert this issue.