### PR TITLE
feat(preview): use image.nvim to load images into preview window

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ so we can fix it.
       "nvim-lua/plenary.nvim",
       "nvim-tree/nvim-web-devicons", -- not strictly required, but recommended
       "MunifTanjim/nui.nvim",
+      -- "3rd/image.nvim", -- Optional image support in preview window: See `# Preview Mode` for more information
     }
 }
 ```
@@ -78,6 +79,7 @@ use {
       "nvim-lua/plenary.nvim",
       "nvim-tree/nvim-web-devicons", -- not strictly required, but recommended
       "MunifTanjim/nui.nvim",
+      -- "3rd/image.nvim", -- Optional image support in preview window: See `# Preview Mode` for more information
     }
   }
 ```
@@ -102,6 +104,7 @@ use {
       "nvim-lua/plenary.nvim",
       "nvim-tree/nvim-web-devicons", -- not strictly required, but recommended
       "MunifTanjim/nui.nvim",
+      -- "3rd/image.nvim", -- Optional image support in preview window: See `# Preview Mode` for more information
       {
         's1n7ax/nvim-window-picker',
         version = '2.*',
@@ -240,7 +243,8 @@ use {
             ["<2-LeftMouse>"] = "open",
             ["<cr>"] = "open",
             ["<esc>"] = "cancel", -- close preview or floating neo-tree window
-            ["P"] = { "toggle_preview", config = { use_float = true } },
+            ["P"] = { "toggle_preview", config = { use_float = true, use_image_nvim = true } },
+            -- Read `# Preview Mode` for more information
             ["l"] = "focus_preview",
             ["S"] = "open_split",
             ["s"] = "open_vsplit",
@@ -664,6 +668,7 @@ There are more sources available as extensions that are managed outside of this 
 [wiki](https://github.com/nvim-neo-tree/neo-tree.nvim/wiki/External-Sources) for me information.
 
 ### Source Selector
+
 ![Neo-tree source selector](https://github.com/nvim-neo-tree/resources/raw/main/images/Neo-tree-source-selector.png)
 
 You can enable a clickable source selector in either the winbar (requires neovim 0.8+) or the statusline.
@@ -681,6 +686,44 @@ To do so, set one of these options to `true`:
 There are many configuration options to change the style of these tabs. 
 See [lua/neo-tree/defaults.lua](lua/neo-tree/defaults.lua) for details.
 
+### Preview Mode
+
+`:h neo-tree-preview-mode`
+
+Preview mode will temporarily show whatever file the cursor is on without
+switching focus from the Neo-tree window. By default, files will be previewed
+in a new floating window. This can also be configured to automatically choose
+an existing split by configuring the command like this:
+
+```lua
+require("neo-tree").setup({
+  window = {
+    mappings = {
+      ["P"] = { "toggle_preview", config = { use_float = false, use_image_nvim = true } },
+    }
+  }
+})
+```
+
+Anything that causes Neo-tree to lose focus will end preview mode. When
+`use_float = false`, the window that was taken over by preview mode will revert
+back to whatever was shown in that window before preview mode began.
+
+If you want to work with the floating preview mode window in autocmds or other
+custom code, the window will have the `neo-tree-preview` filetype.
+
+When preview mode is not using floats, the window will have the window local
+variable `neo_tree_preview` set to `1` to indicate that it is being used as a
+preview window. You can refer to this in statusline and winbar configs to mark a
+window as being used as a preview.
+
+#### Image Support in Preview Mode
+
+If you have [3rd/image.nvim](https://github.com/3rd/image.nvim) installed, preview
+mode supports image rendering by default using kitty graphics protocol or ueberzug
+([Video](https://user-images.githubusercontent.com/41065736/277180763-b7152637-f310-43a5-b8c3-4bcba135629d.mp4)).
+However, if you do not want this feature, you can disable it by changing the option
+`use_image_nvim = false` in the mappings config mentioned above.
 
 ## Configuration and Customization
 
@@ -807,6 +850,9 @@ This project relies upon these two excellent libraries:
 The design is heavily inspired by these excellent plugins:
 - [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim)
 - [nvim-cokeline](https://github.com/noib3/nvim-cokeline)
+
+This plugin enables image support inside preview windows.
+- [image.nvim](https://github.com/3rd/image.nvim)
 
 Everything I know about writing a tree control in lua, I learned from:
 - [nvim-tree.lua](https://github.com/nvim-tree/nvim-tree.lua)

--- a/README.md
+++ b/README.md
@@ -851,8 +851,5 @@ The design is heavily inspired by these excellent plugins:
 - [lualine.nvim](https://github.com/nvim-lualine/lualine.nvim)
 - [nvim-cokeline](https://github.com/noib3/nvim-cokeline)
 
-This plugin enables image support inside preview windows.
-- [image.nvim](https://github.com/3rd/image.nvim)
-
 Everything I know about writing a tree control in lua, I learned from:
 - [nvim-tree.lua](https://github.com/nvim-tree/nvim-tree.lua)

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -397,7 +397,7 @@ an existing split by configuring the command like this:
     require("neo-tree").setup({
       window = {
         mappings = {
-          ["P"] = { "toggle_preview", config = { use_float = false } },
+          ["P"] = { "toggle_preview", config = { use_float = false, use_image_nvim = true } },
         }
       }
     })
@@ -414,6 +414,10 @@ variable `neo_tree_preview` set to `1` to indicate that it is being used as a
 preview window. You can refer to this in statusline and winbar configs to mark a
 window as being used as a preview.
 
+If you have [3rd/image.nvim](https://github.com/3rd/image.nvim) installed, preview
+mode supports image rendering by default using kitty graphics protocol or ueberzug.
+However, if you do not want this feature, you can disable it by changing the option
+`use_image_nvim = false` in the mappings config mentioned above.
 
 CUSTOM MAPPINGS                                       *neo-tree-custom-mappings*
 

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -366,7 +366,7 @@ local config = {
       ["<2-LeftMouse>"] = "open",
       ["<cr>"] = "open",
       ["<esc>"] = "cancel", -- close preview or floating neo-tree window
-      ["P"] = { "toggle_preview", config = { use_float = true, use_image_nvim = true } },
+      ["P"] = { "toggle_preview", config = { use_float = true, use_image_nvim = false } },
       ["l"] = "focus_preview",
       ["S"] = "open_split",
       -- ["S"] = "split_with_window_picker",

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -366,7 +366,7 @@ local config = {
       ["<2-LeftMouse>"] = "open",
       ["<cr>"] = "open",
       ["<esc>"] = "cancel", -- close preview or floating neo-tree window
-      ["P"] = { "toggle_preview", config = { use_float = true } },
+      ["P"] = { "toggle_preview", config = { use_float = true, use_image_nvim = true } },
       ["l"] = "focus_preview",
       ["S"] = "open_split",
       -- ["S"] = "split_with_window_picker",

--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -272,7 +272,7 @@ end
 
 ---@param winid number
 ---@param bufnr number
-local function load_image_nvim_buf(winid, bufnr)
+local function try_load_image_nvim_buf(winid, bufnr)
   if vim.bo[bufnr].filetype ~= "image_nvim" then
     return false
   end
@@ -292,7 +292,7 @@ function Preview:setBuffer(bufnr)
   vim.opt.eventignore:append("BufEnter,BufWinEnter")
   vim.api.nvim_win_set_buf(self.winid, bufnr)
   if self.config.use_image_nvim then
-    load_image_nvim_buf(self.winid, bufnr)
+    try_load_image_nvim_buf(self.winid, bufnr)
   end
   if self.config.use_float then
     -- I'm not sufe why float windows won;t show numbers without this

--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -270,12 +270,30 @@ function Preview:activate()
   vim.api.nvim_win_set_var(self.winid, "neo_tree_preview", 1)
 end
 
+---@param winid number
+---@param bufnr number
+local function load_image_nvim_buf(winid, bufnr)
+  if vim.bo[bufnr].filetype ~= "image_nvim" then
+    return false
+  end
+  local success, mod = pcall(require, "image")
+  if not success or not mod.hijack_buffer then
+    local image_nvim_url = "https://github.com/3rd/image.nvim"
+    log.debug("You'll need to install image.nvim to use this command: " .. image_nvim_url)
+    return false
+  end
+  return mod.hijack_buffer(vim.api.nvim_buf_get_name(bufnr), winid, bufnr)
+end
+
 ---Set the buffer in the preview window without executing BufEnter or BufWinEnter autocommands.
 --@param bufnr number The buffer number of the buffer to set.
 function Preview:setBuffer(bufnr)
   local eventignore = vim.opt.eventignore
   vim.opt.eventignore:append("BufEnter,BufWinEnter")
   vim.api.nvim_win_set_buf(self.winid, bufnr)
+  if self.config.use_image_nvim then
+    load_image_nvim_buf(self.winid, bufnr)
+  end
   if self.config.use_float then
     -- I'm not sufe why float windows won;t show numbers without this
     vim.api.nvim_win_set_option(self.winid, "number", true)


### PR DESCRIPTION
Closes #1196

- [x] Added docs in README and help page as well.
- [x] Checking `vim.bo[bufnr].filetype == "image_nvim"` is enough to decide if we need 3rd/image.nvim.

Tagging some people that might be relevant. (Please ignore if you are not interested)
@SlimShadyIAm @cseickel 