### PR TITLE
fix: prevent expand(<afile>) from raising errors when verbose is set

### DIFF
--- a/lua/neo-tree/events/init.lua
+++ b/lua/neo-tree/events/init.lua
@@ -53,7 +53,7 @@ M.define_autocmd_event = function(event_name, autocmds, debounce_frequency, seed
   local opts = {
     setup = function()
       local tpl =
-        ":lua require('neo-tree.events').fire_event('%s', { afile = vim.fn.expand('<afile>') })"
+        ":lua require('neo-tree.events').fire_event('%s', { afile = vim.F.npcall(vim.fn.expand, '<afile>') or '' })"
       local callback = string.format(tpl, event_name)
       if nested then
         callback = "++nested " .. callback


### PR DESCRIPTION
When verbose mode is used (`nvim -V1` or `:verbose ...`),
`vim.fn.expand('<afile>')` throws an error upon any WinEnter autocmds.

To avoid such errors, we can protect the call and suppress any E495
errors. See #1145 for more details and analysis.

Fixes #1145.
