### PR TITLE
fix: set max height for popup help window

### DIFF
--- a/lua/neo-tree/sources/common/help.lua
+++ b/lua/neo-tree/sources/common/help.lua
@@ -89,6 +89,35 @@ M.show = function(state, title, prefix_key)
     zindex = 50,
     relative = "editor",
   }
+
+  local popup_max_height = function()
+    local lines = vim.o.lines
+    local cmdheight = vim.o.cmdheight
+    -- statuscolumn
+    local statuscolumn_lines = 0
+    local laststatus = vim.o.laststatus
+    if laststatus ~= 0 then
+      local windows = vim.api.nvim_tabpage_list_wins(0)
+      if (laststatus == 1 and #windows > 1) or laststatus > 1 then
+        statuscolumn_lines = 1
+      end
+    end
+    -- tabs
+    local tab_lines = 0
+    local showtabline = vim.o.showtabline
+    if showtabline ~= 0 then
+      local tabs = vim.api.nvim_list_tabpages()
+      if (showtabline == 1 and #tabs > 1) or showtabline == 2 then
+        tab_lines = 1
+      end
+    end
+    return lines - cmdheight - statuscolumn_lines - tab_lines - 1
+  end
+  local max_height = popup_max_height()
+  if options.size.height > max_height then
+    options.size.height = max_height
+  end
+
   local title = title or "Neotree Help"
   local options = popups.popup_options(title, width, options)
   local popup = Popup(options)


### PR DESCRIPTION
When the list of keymaps is too long, the borders of the popup help window are not displayed properly.

Before
![before](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/70215835/a05e633b-ca97-4654-a88f-c648b481b008)

After
![after](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/70215835/b95f990d-ec6e-48fe-8ea7-f1b278e7c0e3)
