### PR TITLE
feat(commands): add option to open top file even when nested

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -365,6 +365,7 @@ local config = {
       },
       ["<2-LeftMouse>"] = "open",
       ["<cr>"] = "open",
+      -- ["<cr>"] = { "open", config = { no_expand_file = true } }, -- open top file instead of expanding when nested
       ["<esc>"] = "cancel", -- close preview or floating neo-tree window
       ["P"] = { "toggle_preview", config = { use_float = true, use_image_nvim = false } },
       ["l"] = "focus_preview",

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -713,7 +713,8 @@ local open_with_cmd = function(state, open_cmd, toggle_directory, open_file)
     if toggle_directory and node.type == "directory" then
       toggle_directory(node)
     elseif node:has_children() then
-      if node:is_expanded() and node.type ~= "directory" then
+      local no_expand_file = (state.config or {}).no_expand_file
+      if node.type ~= "directory" and (no_expand_file or node:is_expanded()) then
         return open()
       end
 


### PR DESCRIPTION
This feature was asked here: https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1165#issuecomment-1797935289

Basically to add a keybind to open the top level file of nested files without expanding it.

Could you review this as well? @@Teddytrombone 

---

I mean to have one command that does the following:

1. when run on a closed folder/directory -> expands it
2. when run on a file with other files nested under it -> opens the file without expanding it
3. when run on any other file -> opens the file

Number 2 is not possible right now as far as I know, because the built-in open command will always first expand files with nesting and then open it when you run it again on the same file.

_Originally posted by @kmoschcau in https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1165#issuecomment-1797935289_
