### PR TITLE
fix(commands)!: open nested files default to open instead of expand

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -365,7 +365,7 @@ local config = {
       },
       ["<2-LeftMouse>"] = "open",
       ["<cr>"] = "open",
-      -- ["<cr>"] = { "open", config = { no_expand_file = true } }, -- open top file instead of expanding when nested
+      -- ["<cr>"] = { "open", config = { expand_nested_files = true } }, -- expand nested file takes precedence
       ["<esc>"] = "cancel", -- close preview or floating neo-tree window
       ["P"] = { "toggle_preview", config = { use_float = true, use_image_nvim = false } },
       ["l"] = "focus_preview",


### PR DESCRIPTION
RETRY OF https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1219

- use `{ "open", config = { expand_nested_files = true } }` for old behavior
- `no_expand_file` options is deprecated, move to `expand_nested_files` (OPPOSITE)

I'm not really sure what is going on.

I'm so sorry to spam you with notifications...