### PR TITLE
fix(filesystem): fixed call to debounce with wrong arguments

### DIFF
--- a/lua/neo-tree/git/status.lua
+++ b/lua/neo-tree/git/status.lua
@@ -237,7 +237,6 @@ M.status_async = function(path, base, opts)
     end
 
     local job_complete_callback = function()
-      utils.debounce(event_id, nil, nil, nil, utils.debounce_action.COMPLETE_ASYNC_JOB)
       vim.schedule(function()
         events.fire_event(events.GIT_STATUS_CHANGED, {
           git_root = context.git_root,

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -13,7 +13,7 @@ local glob = require("neo-tree.sources.filesystem.lib.globtopattern")
 
 local M = {
   name = "filesystem",
-  display_name = " 󰉓 Files "
+  display_name = " 󰉓 Files ",
 }
 
 local wrap = function(func)
@@ -423,13 +423,13 @@ M.toggle_directory = function(state, node, path_to_reveal, skip_redraw, recursiv
 end
 
 M.prefetcher = {
-  prefetch = function (state, node)
+  prefetch = function(state, node)
     log.debug("Running fs prefetch for: " .. node:get_id())
     fs_scan.get_dir_items_async(state, node:get_id(), true)
   end,
-  should_prefetch = function (node)
+  should_prefetch = function(node)
     return not node.loaded
-  end
+  end,
 }
 
 return M

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -174,7 +174,7 @@ M.navigate = function(state, path, path_to_reveal, callback, async)
   log.trace("navigate", path, path_to_reveal, async)
   utils.debounce("filesystem_navigate", function()
     M._navigate_internal(state, path, path_to_reveal, callback, async)
-  end, utils.debounce_strategy.CALL_FIRST_AND_LAST, 100)
+  end, 100, utils.debounce_strategy.CALL_FIRST_AND_LAST)
 end
 
 M.reset_search = function(state, refresh, open_current_node)

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -75,7 +75,7 @@ end
 
 ---Call fn, but not more than once every x milliseconds.
 ---@param id string Identifier for the debounce group, such as the function name.
----@param fn function? Function to be executed.
+---@param fn function Function to be executed.
 ---@param frequency_in_ms number Miniumum amount of time between invocations of fn.
 ---@param strategy NeotreeDebounceStrategy The debounce_strategy to use, determines which calls to fn are not dropped.
 ---@param action NeotreeDebounceAction? The debounce_action to use, determines how the function is invoked


### PR DESCRIPTION
closes: #1214

Please read [my comments](https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1214#issuecomment-1807104855) for the explanation.

But ultimately, this is a failure of an untyped scripting language lol.

We definitely need to introduce type notations at some point. I'm too sick of these kind of errors.