### PR TITLE
feat(filesystem): move to new dst after copy / move in filesystem

### DIFF
--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -29,7 +29,7 @@ M.clear_filter = function(state)
 end
 
 M.copy = function(state)
-  cc.copy(state, utils.wrap(fs.focus_dst_children, state))
+  cc.copy(state, utils.wrap(fs.focus_destination_children, state))
 end
 
 ---Marks node as copied, so that it can be pasted somewhere else.
@@ -51,7 +51,7 @@ M.cut_to_clipboard_visual = function(state, selected_nodes)
 end
 
 M.move = function(state)
-  cc.move(state, utils.wrap(fs.focus_dst_children, state))
+  cc.move(state, utils.wrap(fs.focus_destination_children, state))
 end
 
 ---Pastes all items from the clipboard to the current directory.

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -29,7 +29,7 @@ M.clear_filter = function(state)
 end
 
 M.copy = function(state)
-  cc.copy(state, utils.wrap(refresh, state))
+  cc.copy(state, utils.wrap(fs.focus_dst_children, state))
 end
 
 ---Marks node as copied, so that it can be pasted somewhere else.
@@ -51,7 +51,7 @@ M.cut_to_clipboard_visual = function(state, selected_nodes)
 end
 
 M.move = function(state)
-  cc.move(state, utils.wrap(refresh, state))
+  cc.move(state, utils.wrap(fs.focus_dst_children, state))
 end
 
 ---Pastes all items from the clipboard to the current directory.

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -254,6 +254,10 @@ M.show_new_children = function(state, node_or_path)
   M.navigate(state, nil, node_or_path)
 end
 
+M.move_from_children = function (state, src, dst)
+  return M.show_new_children(state, dst)
+end
+
 ---Configures the plugin, should be called before the plugin is used.
 ---@param config table Configuration table containing any keys that the user
 --wants to change from the defaults. May be empty to accept default values.

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -13,7 +13,7 @@ local glob = require("neo-tree.sources.filesystem.lib.globtopattern")
 
 local M = {
   name = "filesystem",
-  display_name = " 󰉓 Files "
+  display_name = " 󰉓 Files ",
 }
 
 local wrap = function(func)
@@ -254,7 +254,7 @@ M.show_new_children = function(state, node_or_path)
   M.navigate(state, nil, node_or_path)
 end
 
-M.move_from_children = function (state, src, dst)
+M.focus_dst_children = function(state, src, dst)
   return M.show_new_children(state, dst)
 end
 
@@ -427,13 +427,13 @@ M.toggle_directory = function(state, node, path_to_reveal, skip_redraw, recursiv
 end
 
 M.prefetcher = {
-  prefetch = function (state, node)
+  prefetch = function(state, node)
     log.debug("Running fs prefetch for: " .. node:get_id())
     fs_scan.get_dir_items_async(state, node:get_id(), true)
   end,
-  should_prefetch = function (node)
+  should_prefetch = function(node)
     return not node.loaded
-  end
+  end,
 }
 
 return M

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -254,8 +254,8 @@ M.show_new_children = function(state, node_or_path)
   M.navigate(state, nil, node_or_path)
 end
 
-M.focus_dst_children = function(state, src, dst)
-  return M.show_new_children(state, dst)
+M.focus_destination_children = function(state, move_from, destination)
+  return M.show_new_children(state, destination)
 end
 
 ---Configures the plugin, should be called before the plugin is used.


### PR DESCRIPTION
Requested [here](https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1214#issuecomment-1807130056), this PR changes the cursor position to the newly created file after `copy` command instead of focusing the src file.

https://github.com/nvim-neo-tree/neo-tree.nvim/assets/41065736/47daf22d-2e66-45e4-bce5-ccf5464b32cf

