### PR TITLE
fix: fix buffer_changed event, fix diagnostics final severity

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -54,6 +54,7 @@ local define_events = function()
 
   events.define_autocmd_event(events.VIM_AFTER_SESSION_LOAD, { "SessionLoadPost" }, 200)
   events.define_autocmd_event(events.VIM_BUFFER_ADDED, { "BufAdd" }, 200, update_opened_buffers)
+  events.define_autocmd_event(events.VIM_BUFFER_CHANGED, { "BufWritePost" }, 200)
   events.define_autocmd_event(
     events.VIM_BUFFER_DELETED,
     { "BufDelete" },

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -248,14 +248,25 @@ M.get_diagnostic_counts = function()
 
           if #diagnostics > 0 then
             local severity_string = diag_severity_to_string(severity)
-            if lookup[file_name] == nil then
-              lookup[file_name] = {
+            -- Get or create the entry for this file
+            local entry = lookup[file_name]
+            if entry == nil then
+              entry = {
                 severity_number = severity,
                 severity_string = severity_string,
               }
+              lookup[file_name] = entry
             end
+            -- Set the count for this diagnostic type
             if severity_string ~= nil then
-              lookup[file_name][severity_string] = #diagnostics
+              entry[severity_string] = #diagnostics
+            end
+
+            -- Set the overall severity to the most severe so far
+            -- Error = 1, Warn = 2, Info = 3, Hint = 4
+            if severity < entry.severity_number then
+              entry.severity_number = severity
+              entry.severity_string = severity_string
             end
           end
         end

--- a/tests/neo-tree/sources/filesystem/filesystem_netrw_hijack_spec.lua
+++ b/tests/neo-tree/sources/filesystem/filesystem_netrw_hijack_spec.lua
@@ -73,13 +73,6 @@ describe("Filesystem netrw hijack", function()
 
     assert(#vim.api.nvim_list_wins() == 1, "Test should start with one window")
 
-    vim.cmd("edit .")
-
-    verify.eventually(200, function()
-      assert(#vim.api.nvim_list_wins() == 1, "`edit .` should not open a new window")
-      return vim.api.nvim_buf_get_option(0, "filetype") == "neo-tree"
-    end, "neotree is not the only window")
-
     vim.cmd("split .")
 
     verify.eventually(200, function()


### PR DESCRIPTION
fixes #1225, fixes issues form discussion #1234

Somehow the buffer_changed event was not connected to an autocmd, it was probably lost along the way. 

I also discovered that the diagnostics was no longer setting the most severe as the final level. This was also something that was broken recently.

Finally, I think I fixed the glitchy test issue from #1225. It had an extra test that was not related to what should have been tested. I'm not sure why it sometimes worked...
