### PR TITLE
fix: use getftype to check symlink

### DIFF
--- a/lua/neo-tree/sources/common/file-items.lua
+++ b/lua/neo-tree/sources/common/file-items.lua
@@ -117,7 +117,7 @@ function create_item(context, path, _type, bufnr)
     path = path,
     type = _type,
   }
-  if item.type == "link" then
+  if vim.fn.getftype(path) == "link" then
     item.is_link = true
     item.link_to = vim.loop.fs_realpath(path)
     if item.link_to ~= nil then


### PR DESCRIPTION
This PR is simple fix to get correct 'link' file type for windows. Fot that it's seemed `fs_stat` can't work properly for windows' symlink.