### PR TITLE
fix(filesystem): Mixed path separators in Windows

### DIFF
--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -761,6 +761,11 @@ M.normalize_path = function(path)
   if M.is_windows then
     -- normalize the drive letter to uppercase
     path = path:sub(1, 1):upper() .. path:sub(2)
+    -- Turn mixed forward and back slashes into all forward slashes
+    -- using NeoVim's logic
+    path = vim.fs.normalize(path)
+    -- Now use backslashes, as expected by the rest of Neo-Tree's code
+    path = path:gsub("/", M.path_separator)
   end
   return path
 end


### PR DESCRIPTION
Fixes #1256 . One thing to note, NeoVim normalizes paths differently on Windows than a lot of plugins do, so I did this in a way that keeps it consistent with Neo-tree's code, which is to use backslashes on Windows.