### PR TITLE
fix: compatibility with 0.10 extmark sign

### DIFF
--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -74,19 +74,10 @@ M.current_filter = function(config, node, state)
   }
 end
 
-M.diagnostics = function(config, node, state)
-  local diag = state.diagnostics_lookup or {}
-  local diag_state = diag[node:get_id()]
-  if config.hide_when_expanded and node.type == "directory" and node:is_expanded() then
-    return {}
-  end
-  if not diag_state then
-    return {}
-  end
-  if config.errors_only and diag_state.severity_number > 1 then
-    return {}
-  end
-  local severity = diag_state.severity_string
+---`sign_getdefined` based wrapper with compatibility
+---@param severity string
+---@return vim.fn.sign_getdefined.ret.item
+local function get_defined_sign(severity)
   local defined = vim.fn.sign_getdefined("DiagnosticSign" .. severity)
   if not defined then
     -- backwards compatibility...
@@ -102,6 +93,23 @@ M.diagnostics = function(config, node, state)
   if type(defined) ~= "table" then
     defined = {}
   end
+  return defined
+end
+
+M.diagnostics = function(config, node, state)
+  local diag = state.diagnostics_lookup or {}
+  local diag_state = diag[node:get_id()]
+  if config.hide_when_expanded and node.type == "directory" and node:is_expanded() then
+    return {}
+  end
+  if not diag_state then
+    return {}
+  end
+  if config.errors_only and diag_state.severity_number > 1 then
+    return {}
+  end
+  local severity = diag_state.severity_string
+  local defined = get_defined_sign(severity)
 
   -- check for overrides in the component config
   local severity_lower = severity:lower()

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -78,18 +78,35 @@ end
 ---@param severity string
 ---@return vim.fn.sign_getdefined.ret.item
 local function get_defined_sign(severity)
-  local defined = vim.fn.sign_getdefined("DiagnosticSign" .. severity)
-  if not defined then
-    -- backwards compatibility...
-    local old_severity = severity
-    if severity == "Warning" then
-      old_severity = "Warn"
-    elseif severity == "Information" then
-      old_severity = "Info"
+  local defined
+
+  if vim.fn.has("nvim-0.10") then
+    local signs_config = vim.diagnostic.config().signs
+    if type(signs_config) == "table" then
+      local identifier = severity:sub(1, 1)
+      if identifier == "H" then
+        identifier = "N"
+      end
+      defined = {
+        text = signs_config.text[vim.diagnostic.severity[identifier]],
+        texthl = "DiagnosticSign" .. severity,
+      }
     end
-    defined = vim.fn.sign_getdefined("LspDiagnosticsSign" .. old_severity)
+  else -- before 0.10
+    defined = vim.fn.sign_getdefined("DiagnosticSign" .. severity)
+    if not defined then
+      -- backwards compatibility...
+      local old_severity = severity
+      if severity == "Warning" then
+        old_severity = "Warn"
+      elseif severity == "Information" then
+        old_severity = "Info"
+      end
+      defined = vim.fn.sign_getdefined("LspDiagnosticsSign" .. old_severity)
+    end
+    defined = defined and defined[1]
   end
-  defined = defined and defined[1]
+
   if type(defined) ~= "table" then
     defined = {}
   end

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -94,7 +94,7 @@ local function get_defined_sign(severity)
     end
   else -- before 0.10
     defined = vim.fn.sign_getdefined("DiagnosticSign" .. severity)
-    if not defined then
+    if vim.tbl_isempty(defined) then
       -- backwards compatibility...
       local old_severity = severity
       if severity == "Warning" then

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -80,7 +80,7 @@ end
 local function get_defined_sign(severity)
   local defined
 
-  if vim.fn.has("nvim-0.10") then
+  if vim.fn.has("nvim-0.10") > 0 then
     local signs_config = vim.diagnostic.config().signs
     if type(signs_config) == "table" then
       local identifier = severity:sub(1, 1)


### PR DESCRIPTION
After https://github.com/neovim/neovim/pull/26193 , the internal implementation of the diagnostic signs changed to the new extmark-based sign, `sign_getdefine` will no longer work.