### PR TITLE
fix(renderer): fix jumping to the top when opening files.

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -641,7 +641,6 @@ M.position = {
   save = function(state)
     if state.tree and M.window_exists(state) then
       local win_state = vim.api.nvim_win_call(state.winid, vim.fn.winsaveview)
-      log.trace("win_state: " .. vim.inspect(win_state))
       state.position.topline = win_state.topline
       state.position.lnum = win_state.lnum
       log.debug("Saved cursor position with lnum: " .. state.position.lnum)

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -640,15 +640,12 @@ end
 M.position = {
   save = function(state)
     if state.tree and M.window_exists(state) then
-      local success, node = pcall(state.tree.get_node, state.tree)
-      if success and node then
-        _, state.position.node_id = pcall(node.get_id, node)
-        local win_state = vim.api.nvim_win_call(state.winid, vim.fn.winsaveview)
-        log.trace("win_state: " .. vim.inspect(win_state))
-        state.position.topline = win_state.topline
-        log.debug("Saved cursor position with node_id: " .. state.position.node_id)
-        log.debug("Saved window position with topline: " .. state.position.topline)
-      end
+      local win_state = vim.api.nvim_win_call(state.winid, vim.fn.winsaveview)
+      log.trace("win_state: " .. vim.inspect(win_state))
+      state.position.topline = win_state.topline
+      state.position.lnum = win_state.lnum
+      log.debug("Saved cursor position with lnum: " .. state.position.lnum)
+      log.debug("Saved window position with topline: " .. state.position.topline)
       -- Only need to restore the cursor state once per save, comes
       -- into play when some actions fire multiple times per "iteration"
       -- within the scope of where we need to perform the restore operation
@@ -663,18 +660,16 @@ M.position = {
     state.position.is.restorable = true
   end,
   restore = function(state)
-    if not state.position.node_id then
-      log.debug("No node_id to restore to")
-      return
-    end
     if state.position.is.restorable then
-      log.debug("Restoring cursor position to node_id: " .. state.position.node_id)
-      M.focus_node(state, state.position.node_id, true)
-      if state.position.topline then
+      if state.position.topline and state.position.lnum then
         log.debug("Restoring window position to topline: " .. state.position.topline)
+        log.debug("Restoring cursor position to lnum: " .. state.position.lnum)
         vim.api.nvim_win_call(state.winid, function()
-          vim.fn.winrestview({ topline = state.position.topline })
+          vim.fn.winrestview({ topline = state.position.topline, lnum = state.position.lnum })
         end)
+      end
+      if state.position.node_id then
+        M.focus_node(state, state.position.node_id, true)
       end
     else
       log.debug("Position is not restorable")


### PR DESCRIPTION
When opening files you had to scroll down to find, the neo-tree window jumped to the top (see #1025).

This is because Neovim changed the way `nvim_buf_set_lines` works in https://github.com/neovim/neovim/commit/008154954791001efcc46c28146e21403f3a698b (https://github.com/neovim/neovim/pull/24824) and later in https://github.com/neovim/neovim/pull/24889

This change in Neovim caused some problems in plugins:
- https://github.com/nvim-telescope/telescope.nvim/issues/2667
- https://github.com/folke/which-key.nvim/pull/516

To ensure the window stays fixed, we have to use `winsaveview` and `winrestview` (wrapped in `M.position`) inside `render_tree`.

Fixes #1025 
Fixes #996 


