### PR TITLE
doc: correct table for git symbols to be within git_status table

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1040,18 +1040,20 @@ the following properties:
 >lua
     require("neo-tree").setup({
       default_component_configs = {
-        symbols = {
-          -- Change type
-          added     = "✚",
-          deleted   = "✖",
-          modified  = "",
-          renamed   = "󰁕",
-          -- Status type
-          untracked = "",
-          ignored   = "",
-          unstaged  = "󰄱",
-          staged    = "",
-          conflict  = "",
+        git_status = {
+          symbols = {
+            -- Change type
+            added     = "✚",
+            deleted   = "✖",
+            modified  = "",
+            renamed   = "󰁕",
+            -- Status type
+            untracked = "",
+            ignored   = "",
+            unstaged  = "󰄱",
+            staged    = "",
+            conflict  = "",
+          }
         }
       }
     })
@@ -1073,18 +1075,20 @@ The following config will remove those change type symbols:
 >lua
     require("neo-tree").setup({
       default_component_configs = {
-        symbols = {
-          -- Change type
-          added     = "",
-          deleted   = "",
-          modified  = "",
-          renamed   = "",
-          -- Status type
-          untracked = "",
-          ignored   = "",
-          unstaged  = "󰄱",
-          staged    = "",
-          conflict  = "",
+        git_status = {
+          symbols = {
+            -- Change type
+            added     = "",
+            deleted   = "",
+            modified  = "",
+            renamed   = "",
+            -- Status type
+            untracked = "",
+            ignored   = "",
+            unstaged  = "󰄱",
+            staged    = "",
+            conflict  = "",
+          }
         }
       }
     })


### PR DESCRIPTION
For my system the symbols-table needs to be within a git_status-table. 
My system has the versions below installed:
"lazy.nvim": { "branch": "main", "commit": "96584866b9c5e998cbae300594d0ccfd0c464627" } 
"neo-tree.nvim": { "branch": "v3.x", "commit": "77d9f484b88fd380386b46ed9206e5374d69d9d8" }