### PR TITLE
chore(dockerfile): add nvim-web-devicons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN cd neovim && make CMAKE_BUILD_TYPE=RelWithDebInfo && make install
 ARG PLUG_DIR="root/.local/share/nvim/site/pack/packer/start"
 RUN git clone https://github.com/nvim-lua/plenary.nvim $PLUG_DIR/plenary.nvim
 RUN git clone https://github.com/MunifTanjim/nui.nvim $PLUG_DIR/nui.nvim
+RUN git clone https://github.com/nvim-tree/nvim-web-devicons.git $PLUG_DIR/nvim-web-devicons
 COPY . $PLUG_DIR/neo-tree.nvim
 
 WORKDIR $PLUG_DIR/neo-tree.nvim


### PR DESCRIPTION
`make test-docker` was failing for me.
I fixed it by adding nvim-web-devicons. Not sure if it was necessary.
