### PR TITLE
fix(filesystem): fix filesystem path on windows platform

### DIFF
--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -41,8 +41,6 @@ local follow_internal = function(callback, force_show, async)
   end
   if not state.path then
     return false
-  else
-    state.path = utils.normalize_path(state.path)
   end
   local window_exists = renderer.window_exists(state)
   if window_exists then
@@ -122,6 +120,8 @@ M._navigate_internal = function(state, path, path_to_reveal, callback, async)
     log.debug("navigate_internal: path is nil, using cwd")
     path = manager.get_cwd(state)
   end
+  path = utils.normalize_path(path)
+  state.path = utils.normalize_path(state.path)
   if path ~= state.path then
     log.debug("navigate_internal: path changed from ", state.path, " to ", path)
     state.path = path

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -30,7 +30,7 @@ local follow_internal = function(callback, force_show, async)
   if vim.bo.filetype == "neo-tree" or vim.bo.filetype == "neo-tree-popup" then
     return false
   end
-  local path_to_reveal = manager.get_path_to_reveal()
+  local path_to_reveal = utils.normalize_path(manager.get_path_to_reveal())
   if not utils.truthy(path_to_reveal) then
     return false
   end
@@ -41,6 +41,8 @@ local follow_internal = function(callback, force_show, async)
   end
   if not state.path then
     return false
+  else
+    state.path = utils.normalize_path(state.path)
   end
   local window_exists = renderer.window_exists(state)
   if window_exists then

--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -121,7 +121,6 @@ M._navigate_internal = function(state, path, path_to_reveal, callback, async)
     path = manager.get_cwd(state)
   end
   path = utils.normalize_path(path)
-  state.path = utils.normalize_path(state.path)
   if path ~= state.path then
     log.debug("navigate_internal: path changed from ", state.path, " to ", path)
     state.path = path


### PR DESCRIPTION
`\` and `/` both appears in the path, lead to string comparision problem on windows platform, user can not focus on the buffer file.