### PR TITLE
fix(prompt): confirm `cwd` changing using `vim.fn.comfirm`

### DIFF
--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -91,12 +91,7 @@ M.confirm = function(message, callback)
     input.prompt_type = "confirm"
     M.show_input(input)
   else
-    local opts = {
-      prompt = message .. " y/n: ",
-    }
-    vim.ui.input(opts, function(value)
-      callback(value == "y" or value == "Y")
-    end)
+    callback(vim.fn.confirm(message, "&y[Y]\n&n[N]"))
   end
 end
 

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -91,7 +91,7 @@ M.confirm = function(message, callback)
     input.prompt_type = "confirm"
     M.show_input(input)
   else
-    callback(vim.fn.confirm(message, "&y[Y]\n&n[N]"))
+    callback(vim.fn.confirm(message, "&Yes\n&No") == 1)
   end
 end
 


### PR DESCRIPTION
It is kind of cumbersome to input "y or n", and press <kbd>enter</kbd> for the confirm process, why not just press <kbd>y</kbd> or <kbd>n</kbd> instead.

![new prompt](https://github.com/konosubakonoakua/neo-tree.nvim/releases/download/images/reveal.prompt.png)

