### PR TITLE
fix(filesystem): Add error handler for `get_children_async()`

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -207,6 +207,13 @@ end
 
 local function get_children_async(path, callback)
   uv.fs_opendir(path, function(_, dir)
+    if err then
+      if dir then
+        uv.fs_closedir(dir)
+      end
+      callback({})
+      return
+    end
     uv.fs_readdir(dir, function(_, stats)
       local children = {}
       if stats then

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -208,9 +208,6 @@ end
 local function get_children_async(path, callback)
   uv.fs_opendir(path, function(_, dir)
     if err then
-      if dir then
-        uv.fs_closedir(dir)
-      end
       callback({})
       return
     end


### PR DESCRIPTION
Similar to #960 but for `get_children_async`.

Sometimes, `get_children_async` may try to read from folders with restrictive permissions and libuv will error out. For example, I use `scan_mode = "deep"`, and opening neo-tree in the Windows $HOME results in a lot of errors because Windows puts a lot of folders with restrictive permissions there (for some reason). This PR will just callback with an empty list of children in that case.

On a tangential note, I think the fs_scan file could use a run of `stylua`, some code seems to have extra indentation and there's `function (...)` (note the space) instead of `function(...)`. I didn't want to make the diff too big for a small bugfix though.