### PR TITLE
fix: make buffer command compatible with Windows paths (#1350)

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -307,7 +307,7 @@ M.win_enter_event = function()
               log.warn(message)
               vim.cmd("rightbelow vertical split")
               vim.api.nvim_win_set_width(win_id, state.window.width or 40)
-              vim.cmd("b" .. buf_name)
+              vim.cmd("b " .. buf_name)
             end)
             return
           end


### PR DESCRIPTION
This is an incredibly boring PR. It adds a space to the `b[uffer]` command so that buffer names that use absolute Windows paths can be used without causing errors. This is in line with usage described in [`:h :buffer`](https://neovim.io/doc/user/windows.html#%3Ab) and [`:h {bufname}`](https://neovim.io/doc/user/windows.html#%7Bbufname%7D).

I've manually tested this change on Windows and WSL with the following types of buffers to ensure no regressions as best I can:
- No name buffers
- Buffer names with no spaces
- Buffer names with spaces in the path but not filename
- Buffer names with spaces in the filename but not path
- Buffer names with spaces in both path and filename

All cases result in the correct behavior: a warning is issued and the unsaved buffer is focused, without causing errors. Unfortunately I don't have a macOS machine handy to test but I imagine paths and buffer names behave the same or nearly the same as on WSL.

**PS:** The current implementation of swapping to a buffer by name may be problematic for buffer names that are numbers (see: [`:h :buffer`](https://neovim.io/doc/user/windows.html#%3Ab)). This is outside the scope of this PR, but for reference this comes from the `utils.get_opened_buffers` function: https://github.com/nvim-neo-tree/neo-tree.nvim/blob/cfe1920c5dfb0524b3a13e827c35b6eb571143aa/lua/neo-tree/utils/init.lua#L314-L331
