### PR TITLE
fix: improve path escaping for commands on Windows

### DIFF
--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -115,7 +115,7 @@ end
 
 M.diagnostics = function(config, node, state)
   local diag = state.diagnostics_lookup or {}
-  local diag_state = diag[node:get_id()]
+  local diag_state = utils.index_by_path(diag, node:get_id())
   if config.hide_when_expanded and node.type == "directory" and node:is_expanded() then
     return {}
   end
@@ -322,7 +322,7 @@ end
 
 M.modified = function(config, node, state)
   local opened_buffers = state.opened_buffers or {}
-  local buf_info = opened_buffers[node.path]
+  local buf_info = utils.index_by_path(opened_buffers, node.path)
 
   if buf_info and buf_info.modified then
     return {

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -351,12 +351,13 @@ M.set_cwd = function(state)
 
   local _, cwd = pcall(vim.fn.getcwd, winid, tabnr)
   if state.path ~= cwd then
+    local path = utils.escape_path_for_cmd(state.path)
     if winid > 0 then
-      vim.cmd("lcd " .. state.path)
+      vim.cmd("lcd " .. path)
     elseif tabnr > 0 then
-      vim.cmd("tcd " .. state.path)
+      vim.cmd("tcd " .. path)
     else
-      vim.cmd("cd " .. state.path)
+      vim.cmd("cd " .. path)
     end
   end
 end

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1237,6 +1237,7 @@ M.index_by_path = function(tbl, key)
   end
 
   -- on windows, paths that differ only by case are considered equal
+  -- TODO: we should optimize this, see discussion in #1353
   if M.is_windows then
     local key_lower = key:lower()
     for k, v in pairs(tbl) do

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1220,4 +1220,33 @@ M.brace_expand = function(s)
   return result
 end
 
+---Indexes a table that uses paths as keys. Case-insensitive logic is used when
+---running on Windows.
+---
+---Consideration should be taken before using this function, because it is a
+---bit expensive on Windows. However, this function helps when trying to index
+---with absolute path keys, which can have inconsistent casing on Windows (such
+---as with drive letters).
+---@param tbl table
+---@param key string
+---@return unknown
+M.index_by_path = function(tbl, key)
+  local value = tbl[key]
+  if value ~= nil then
+    return value
+  end
+
+  -- on windows, paths that differ only by case are considered equal
+  if M.is_windows then
+    local key_lower = key:lower()
+    for k, v in pairs(tbl) do
+      if key_lower == k:lower() then
+        return v
+      end
+    end
+  end
+
+  return value
+end
+
 return M


### PR DESCRIPTION
This PR changes the handling of paths on Windows systems to address a few open issues. This builds on the work originally introduced in #1023 (to address #889). Realistically, this is another attempt to deal with a (neo)vim issue as mentioned in https://github.com/neovim/neovim/issues/3912 (no real update since 2015).

I've added some doc comments to help with maintainability, but if it's too verbose I'm happy to edit.

I've run tests locally and all pass, but I would really love to add regression tests for path escaping so we don't run into more problems in the future. However, I'm having trouble figuring out how to deal with platform-specific behavior of `vim.fn.fnameescape` (e.g., if you run tests on WSL or macOS, you won't get Windows path escaping). If anyone has any ideas for adding tests, I'm definitely all ears. Ideally, we would test both Windows and Unix-style path escaping regardless of the platform running the tests.

This PR fixes the following issues I could find:

- #1352 (opened by me when testing this fix)
- #1264

This also fixes the following external issues:
- https://github.com/nvim-lualine/lualine.nvim/issues/1183

The following issues *may* be fixed, but I have not confirmed:

- #1157

I think there are definitely more issues that could be addressed by this, but I'm reaching my issue-searching capability limits :)

I feel like I have a good grasp of how paths are being used in this limited capacity (such as with `set_cwd` and `open_file`) but I know this change could have cascading effects because it's modifying the input to commands like `:cd`, `:b`, `:vs`, etc. If anyone sees anything problematic with more context of the full codebase, I'm happy to discuss.