### PR TITLE
fix(renderer): clean out edge cases of cursor.position.restore

### DIFF
--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -85,7 +85,6 @@ local follow_internal = function(callback, force_show, async)
     end
   end
 
-  state.position.is.restorable = false -- we will handle setting cursor position here
   fs_scan.get_items(state, nil, path_to_reveal, function()
     show_only_explicitly_opened()
     renderer.focus_node(state, path_to_reveal, true)
@@ -129,12 +128,7 @@ M._navigate_internal = function(state, path, path_to_reveal, callback, async)
 
   if path_to_reveal then
     renderer.position.set(state, path_to_reveal)
-    log.debug(
-      "navigate_internal: in path_to_reveal, state.position is ",
-      state.position.node_id,
-      ", restorable = ",
-      state.position.is.restorable
-    )
+    log.debug("navigate_internal: in path_to_reveal, state.position=", state.position.node_id)
     fs_scan.get_items(state, nil, path_to_reveal, callback)
   else
     local is_current = state.current_position == "current"

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -526,11 +526,6 @@ M.reveal_current_file = function(source_name, callback, force_cwd)
   local state = M.get_state(source_name)
   state.current_position = nil
 
-  -- When events trigger that try to restore the position of the cursor in the tree window,
-  -- we want them to ignore this "iteration" as the user is trying to explicitly focus a
-  -- (potentially) different position/node
-  state.position.is.restorable = false
-
   local path = M.get_path_to_reveal()
   if not path then
     M.focus(source_name)

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -39,9 +39,7 @@ local function create_state(tabid, sd, winid)
   state.tabid = tabid
   state.id = winid or tabid
   state.dirty = true
-  state.position = {
-    is = { restorable = false },
-  }
+  state.position = {}
   state.git_base = "HEAD"
   events.fire_event(events.STATE_CREATED, state)
   table.insert(all_states, state)

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -699,7 +699,7 @@ M.position = {
 M.redraw = function(state)
   if state.tree and M.tree_is_visible(state) then
     log.trace("Redrawing tree", state.name, state.id)
-    -- every now and then this will fail because the window was closed in 
+    -- every now and then this will fail because the window was closed in
     -- betweeen the start of an async refresh and the redraw call.
     -- This is not a problem, so we just ignore the error.
     local success = pcall(render_tree, state)
@@ -938,6 +938,9 @@ local get_buffer = function(bufname, state)
     vim.api.nvim_buf_set_option(bufnr, "filetype", "neo-tree")
     vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
     vim.api.nvim_buf_set_option(bufnr, "undolevels", -1)
+    autocmd.buf.define(bufnr, "BufDelete", function()
+      M.position.save(state)
+    end)
   end
   return bufnr
 end
@@ -1036,6 +1039,10 @@ M.acquire_window = function(state)
     vim.api.nvim_buf_set_var(state.bufnr, "neo_tree_tabid", state.tabid)
     vim.api.nvim_buf_set_var(state.bufnr, "neo_tree_position", state.current_position)
     vim.api.nvim_buf_set_var(state.bufnr, "neo_tree_winid", state.winid)
+    -- Used to track the position of the cursor within the tree as it gains and loses focus
+    win:on({ "BufDelete" }, function()
+      M.position.save(state)
+    end)
   end
 
   if win ~= nil then

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -938,9 +938,6 @@ local get_buffer = function(bufname, state)
     vim.api.nvim_buf_set_option(bufnr, "filetype", "neo-tree")
     vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
     vim.api.nvim_buf_set_option(bufnr, "undolevels", -1)
-    autocmd.buf.define(bufnr, "WinLeave", function()
-      M.position.save(state)
-    end)
   end
   return bufnr
 end
@@ -1044,16 +1041,6 @@ M.acquire_window = function(state)
   if win ~= nil then
     vim.api.nvim_buf_set_name(state.bufnr, bufname)
     vim.api.nvim_set_current_win(state.winid)
-    -- Used to track the position of the cursor within the tree as it gains and loses focus
-    --
-    -- Note `WinEnter` is often too early to restore the cursor position so we do not set
-    -- that up here, and instead trigger those events manually after drawing the tree (not
-    -- to mention that it would be too late to register `WinEnter` here for the first
-    -- iteration of that event on the tree window)
-    win:on({ "WinLeave" }, function()
-      M.position.save(state)
-    end)
-
     win:on({ "BufDelete" }, function()
       win:unmount()
     end, { once = true })

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1039,15 +1039,15 @@ M.acquire_window = function(state)
     vim.api.nvim_buf_set_var(state.bufnr, "neo_tree_tabid", state.tabid)
     vim.api.nvim_buf_set_var(state.bufnr, "neo_tree_position", state.current_position)
     vim.api.nvim_buf_set_var(state.bufnr, "neo_tree_winid", state.winid)
-    -- Used to track the position of the cursor within the tree as it gains and loses focus
-    win:on({ "BufDelete" }, function()
-      M.position.save(state)
-    end)
   end
 
   if win ~= nil then
     vim.api.nvim_buf_set_name(state.bufnr, bufname)
     vim.api.nvim_set_current_win(state.winid)
+    -- Used to track the position of the cursor within the tree as it gains and loses focus
+    win:on({ "BufDelete" }, function()
+      M.position.save(state)
+    end)
     win:on({ "BufDelete" }, function()
       win:unmount()
     end, { once = true })


### PR DESCRIPTION
We need to be more careful when to save and restore the cursor position as we cannot overwrite the position anymore with https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1288.

closes #1310

Please read the LONG discussion from https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1354#issuecomment-1946307225 as it describes the issue and the reason thoroughly.

I will keep this as draft until I get some people to test this code as I might have missed some more edge cases.

Would you mind testing this code? @georgeguimaraes @mehalter @XavierChanth

```lua
{ 
  "pysan3/neo-tree.nvim",
  branch = "update-curpos-before-expand",
  version = false,
```