### PR TITLE
fix: skip normalizing empty file paths

### DIFF
--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -30,7 +30,7 @@ local follow_internal = function(callback, force_show, async)
   if vim.bo.filetype == "neo-tree" or vim.bo.filetype == "neo-tree-popup" then
     return false
   end
-  local path_to_reveal = utils.normalize_path(manager.get_path_to_reveal())
+  local path_to_reveal = utils.normalize_path(manager.get_path_to_reveal() or "")
   if not utils.truthy(path_to_reveal) then
     return false
   end

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -759,9 +759,6 @@ end
 ---@return string string The normalized path.
 M.normalize_path = function(path)
   if M.is_windows then
-    if not M.truthy(path) then
-      return path
-    end
     -- normalize the drive letter to uppercase
     path = path:sub(1, 1):upper() .. path:sub(2)
     -- Turn mixed forward and back slashes into all forward slashes

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -759,6 +759,9 @@ end
 ---@return string string The normalized path.
 M.normalize_path = function(path)
   if M.is_windows then
+    if not M.truthy(path) then
+      return path
+    end
     -- normalize the drive letter to uppercase
     path = path:sub(1, 1):upper() .. path:sub(2)
     -- Turn mixed forward and back slashes into all forward slashes


### PR DESCRIPTION
This PR fixes a quite niche Windows bug where quickly changing popup windows could cause Neo-tree to try and follow (and thus normalize) an `nil` file path. This causes an error message to be printed, despite not actually being an issue for Neo-tree.

Essentially the problem is:
- Some form of popup window (like `NuiInput`) closes, changing the active buffer
- This causes the "follow" event to be fired from Neo-tree, but it is debounced: https://github.com/nvim-neo-tree/neo-tree.nvim/blob/7d3b02073e59ed9ef271795787de76d0de8f5294/lua/neo-tree/sources/filesystem/init.lua#L105
- A `toggleterm` floating window is opened (triggered from the previous `NuiInput` by `on_submit`) and changes the active buffer to be a `term://` path before the debounce timer finishes
- The `follow_internal` function does not include `term://` paths when calling `manager.get_path_to_reveal()` so it returns `nil` and passes that directly into `normalize_path`: https://github.com/nvim-neo-tree/neo-tree.nvim/blob/7d3b02073e59ed9ef271795787de76d0de8f5294/lua/neo-tree/sources/filesystem/init.lua#L33
- On Windows, this `path` value is indexed here, but the function does not check for `nil` (note the doc comment states the argument is a `string` not `string?`): https://github.com/nvim-neo-tree/neo-tree.nvim/blob/7d3b02073e59ed9ef271795787de76d0de8f5294/lua/neo-tree/utils/init.lua#L763
- Thus an error occurs before the `follow_internal` can gracefully exit early from an empty path here: https://github.com/nvim-neo-tree/neo-tree.nvim/blob/7d3b02073e59ed9ef271795787de76d0de8f5294/lua/neo-tree/sources/filesystem/init.lua#L34

~~The check is only added after the `M.is_windows` branch, so this will not change behavior for any non-Windows users. Windows users will have the exact same behavior (no file will be followed), just without the error message.~~

See below comment.