### PR TITLE
feat(nui): allow callbacks in nui input with option

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1431,6 +1431,21 @@ have.
 "neo_tree_popup_buffer_leave"~
 Fired after leaving a neo-tree popup buffer.
 
+"neo_tree_popup_input_ready"~
+Fired after NuiInput is ready. Use this event to default to normal mode etc.
+This is fired inside a vim.schedule.
+
+>lua
+    {
+      event = "neo_tree_popup_input_ready",
+      ---@param input NuiInput
+      handler = function(input)
+        -- enter input popup with normal mode by default.
+        vim.cmd("stopinsert")
+      end,
+    }
+<
+
 "neo_tree_window_before_open"~
 Fired before opening a new Neo-tree window. Called with the following arg:
                                                      *neo-tree-window-event-args*

--- a/lua/neo-tree/events/init.lua
+++ b/lua/neo-tree/events/init.lua
@@ -24,6 +24,7 @@ local M = {
   NEO_TREE_LSP_UPDATE = "neo_tree_lsp_update",
   NEO_TREE_POPUP_BUFFER_ENTER = "neo_tree_popup_buffer_enter",
   NEO_TREE_POPUP_BUFFER_LEAVE = "neo_tree_popup_buffer_leave",
+  NEO_TREE_POPUP_INPUT_READY = "neo_tree_popup_input_ready",
   NEO_TREE_WINDOW_AFTER_CLOSE = "neo_tree_window_after_close",
   NEO_TREE_WINDOW_AFTER_OPEN = "neo_tree_window_after_open",
   NEO_TREE_WINDOW_BEFORE_CLOSE = "neo_tree_window_before_close",

--- a/lua/neo-tree/setup/deprecations.lua
+++ b/lua/neo-tree/setup/deprecations.lua
@@ -6,17 +6,16 @@ local migrations = {}
 
 M.show_migrations = function()
   if #migrations > 0 then
-    for i, message in ipairs(migrations) do
-      migrations[i] = "  * " .. message
+    local content = {}
+    for _, message in ipairs(migrations) do
+      vim.list_extend(content, vim.split("\n## " .. message, "\n", { trimempty = false }))
     end
-    table.insert(
-      migrations,
-      1,
-      "# Neo-tree configuration has been updated. Please review the changes below."
-    )
+    local header = "# Neo-tree configuration has been updated. Please review the changes below."
+    table.insert(content, 1, header)
     local buf = vim.api.nvim_create_buf(false, true)
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, migrations)
+    vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
     vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
+    vim.api.nvim_buf_set_option(buf, "wrap", true)
     vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
     vim.api.nvim_buf_set_option(buf, "buflisted", false)
     vim.api.nvim_buf_set_option(buf, "swapfile", false)
@@ -24,7 +23,7 @@ M.show_migrations = function()
     vim.api.nvim_buf_set_option(buf, "filetype", "markdown")
     vim.api.nvim_buf_set_name(buf, "Neo-tree migrations")
     vim.defer_fn(function()
-      vim.cmd(string.format("%ssplit", #migrations))
+      vim.cmd(string.format("%ssplit", #content))
       vim.api.nvim_win_set_buf(0, buf)
     end, 100)
   end
@@ -60,11 +59,12 @@ M.migrate = function(config)
     end
   end
 
-  local removed = function(key)
+  local removed = function(key, desc)
     local value = utils.get_value(config, key)
     if type(value) ~= "nil" then
       utils.set_value(config, key, nil)
-      migrations[#migrations + 1] = string.format("The `%s` option has been removed.", key)
+      migrations[#migrations + 1] =
+        string.format("The `%s` option has been removed.\n%s", key, desc or "")
     end
   end
 
@@ -105,6 +105,28 @@ M.migrate = function(config)
 
   -- v3.x
   removed("close_floats_on_escape_key")
+
+  -- v4.x
+  removed(
+    "enable_normal_mode_for_inputs",
+    [[
+Please use `neo_tree_popup_input_ready` event instead and call `stopinsert` inside the handler.
+See instructions in `:h neo-tree-events` for more details.
+
+```lua
+event_handlers = {
+  {
+    event = "neo_tree_popup_input_ready",
+    ---@param input NuiInput
+    handler = function(input)
+      -- enter input popup with normal mode by default.
+      vim.cmd("stopinsert")
+    end,
+  }
+}
+```
+]]
+  )
 
   return migrations
 end

--- a/lua/neo-tree/setup/deprecations.lua
+++ b/lua/neo-tree/setup/deprecations.lua
@@ -111,6 +111,8 @@ M.migrate = function(config)
     "enable_normal_mode_for_inputs",
     [[
 Please use `neo_tree_popup_input_ready` event instead and call `stopinsert` inside the handler.
+<https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1372>
+
 See instructions in `:h neo-tree-events` for more details.
 
 ```lua

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -2,6 +2,7 @@ local vim = vim
 local Input = require("nui.input")
 local popups = require("neo-tree.ui.popups")
 local utils = require("neo-tree.utils")
+local events = require("neo-tree.events")
 
 local M = {}
 
@@ -14,16 +15,13 @@ M.show_input = function(input, callback)
   local config = require("neo-tree").config
   input:mount()
 
-  if config.enable_normal_mode_for_inputs and input.prompt_type ~= "confirm" then
+  if input.prompt_type ~= "confirm" then
     vim.schedule(function()
-      vim.cmd("stopinsert")
-      if type(config.enable_normal_mode_for_inputs) == "function" then
-        config.enable_normal_mode_for_inputs(input)
-      elseif type(config.enable_normal_mode_for_inputs) == "string" then
-        vim.cmd(config.enable_normal_mode_for_inputs)
-      elseif type(config.enable_normal_mode_for_inputs) == "table" then
-        vim.cmd(config.enable_normal_mode_for_inputs)
+      -- deprecate this option in next version
+      if config.enable_normal_mode_for_inputs then
+        vim.cmd("stopinsert")
       end
+      events.fire_event(events.NEO_TREE_POPUP_INPUT_READY)
     end)
   end
 

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -17,6 +17,13 @@ M.show_input = function(input, callback)
   if config.enable_normal_mode_for_inputs and input.prompt_type ~= "confirm" then
     vim.schedule(function()
       vim.cmd("stopinsert")
+      if type(config.enable_normal_mode_for_inputs) == "function" then
+        config.enable_normal_mode_for_inputs(input)
+      elseif type(config.enable_normal_mode_for_inputs) == "string" then
+        vim.cmd(config.enable_normal_mode_for_inputs)
+      elseif type(config.enable_normal_mode_for_inputs) == "table" then
+        vim.cmd(config.enable_normal_mode_for_inputs)
+      end
     end)
   end
 


### PR DESCRIPTION
We already have an option to default to normal mode in nui inputs.
`config.enable_normal_mode_for_inputs`

However, it looks like users want more power of customization to the details. (https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1371)

So why not just let users do whatever they want with absolute power?

All `function/string/table` are considered true-thy so this will cover backwards compatibility.