### PR TITLE
fix(winfixbuf): avoid windows that have `winfixbuf` when opening buffers

### DIFF
--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -17,7 +17,7 @@ M.ensure_config = function()
   end
 end
 
-M.get_prior_window = function(ignore_filetypes)
+M.get_prior_window = function(ignore_filetypes, ignore_winfixbuf)
   ignore_filetypes = ignore_filetypes or {}
   local ignore = utils.list_to_dict(ignore_filetypes)
   ignore["neo-tree"] = true
@@ -32,7 +32,7 @@ M.get_prior_window = function(ignore_filetypes)
     local last_win = wins[win_index]
     if type(last_win) == "number" then
       local success, is_valid = pcall(vim.api.nvim_win_is_valid, last_win)
-      if success and is_valid and not utils.is_winfixbuf(last_win) then
+      if success and is_valid and not (ignore_winfixbuf and utils.is_winfixbuf(last_win)) then
         local buf = vim.api.nvim_win_get_buf(last_win)
         local ft = vim.api.nvim_buf_get_option(buf, "filetype")
         local bt = vim.api.nvim_buf_get_option(buf, "buftype") or "normal"

--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -32,7 +32,7 @@ M.get_prior_window = function(ignore_filetypes)
     local last_win = wins[win_index]
     if type(last_win) == "number" then
       local success, is_valid = pcall(vim.api.nvim_win_is_valid, last_win)
-      if success and is_valid then
+      if success and is_valid and not utils.is_winfixbuf(last_win) then
         local buf = vim.api.nvim_win_get_buf(last_win)
         local ft = vim.api.nvim_buf_get_option(buf, "filetype")
         local bt = vim.api.nvim_buf_get_option(buf, "buftype") or "normal"

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -197,8 +197,17 @@ M.buffer_enter_event = function()
   end
   last_buffer_enter_filetype = vim.bo.filetype
 
+  -- For all others, make sure another buffer is not hijacking our window
+  -- ..but not if the position is "current"
+  local prior_buf = vim.fn.bufnr("#")
+  if prior_buf < 1 then
+    return
+  end
+  local prior_type = vim.api.nvim_buf_get_option(prior_buf, "filetype")
+
   -- there is nothing more we want to do with floating windows
-  if utils.is_floating() then
+  -- but when prior_type is neo-tree we might need to redirect buffer somewhere else.
+  if utils.is_floating() and prior_type ~= "neo-tree" then
     return
   end
 
@@ -207,14 +216,6 @@ M.buffer_enter_event = function()
     return
   end
 
-  -- For all others, make sure another buffer is not hijacking our window
-  -- ..but not if the position is "current"
-  local prior_buf = vim.fn.bufnr("#")
-  if prior_buf < 1 then
-    return
-  end
-  local winid = vim.api.nvim_get_current_win()
-  local prior_type = vim.api.nvim_buf_get_option(prior_buf, "filetype")
   if prior_type == "neo-tree" then
     local success, position = pcall(vim.api.nvim_buf_get_var, prior_buf, "neo_tree_position")
     if not success then

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -164,15 +164,12 @@ M.close = function(state, focus_prior_window)
     state.winid = nil
   end
   local bufnr = utils.get_value(state, "bufnr", 0, true)
-  if bufnr > 0 and vim.api.nvim_buf_is_valid(bufnr) then
-    state.bufnr = nil
-    local success, err = pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
-    if not success and err:match("E523") then
-      vim.schedule_wrap(function()
-        vim.api.nvim_buf_delete(bufnr, { force = true })
-      end)()
+  state.bufnr = nil
+  vim.schedule(function()
+    if bufnr > 0 and vim.api.nvim_buf_is_valid(bufnr) then
+      vim.api.nvim_buf_delete(bufnr, { force = true })
     end
-  end
+  end)
   return window_existed
 end
 
@@ -1040,7 +1037,9 @@ M.acquire_window = function(state)
       M.position.save(state)
     end)
     win:on({ "BufDelete" }, function()
-      win:unmount()
+      vim.schedule(function ()
+        win:unmount()
+      end)
     end, { once = true })
   end
 

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -508,6 +508,14 @@ M.is_floating = function(win_id)
   return false
 end
 
+M.is_winfixbuf = function(win_id)
+  if vim.fn.exists("&winfixbuf") == 1 then
+    win_id = win_id or vim.api.nvim_get_current_win()
+    return vim.api.nvim_get_option_value("winfixbuf", { win = win_id })
+  end
+  return false
+end
+
 ---Evaluates the value of <afile>, which comes from an autocmd event, and determines if it
 ---is a valid file or some sort of utility buffer like quickfix or neo-tree itself.
 ---@param afile string The path or relative path to the file.
@@ -598,7 +606,7 @@ M.get_appropriate_window = function(state)
   local attempts = 0
   while attempts < 5 and not suitable_window_found do
     local bt = vim.bo.buftype or "normal"
-    if ignore[vim.bo.filetype] or ignore[bt] or M.is_floating() then
+    if ignore[vim.bo.filetype] or ignore[bt] or M.is_floating() or M.is_winfixbuf() then
       attempts = attempts + 1
       vim.cmd("wincmd w")
     else
@@ -654,7 +662,8 @@ M.open_file = function(state, path, open_cmd, bufnr)
   if bufnr <= 0 then
     bufnr = nil
   else
-    local buf_cmd_lookup = { edit = "b", e = "b", split = "sb", sp = "sb", vsplit = "vert sb", vs = "vert sb" }
+    local buf_cmd_lookup =
+      { edit = "b", e = "b", split = "sb", sp = "sb", vsplit = "vert sb", vs = "vert sb" }
     local cmd_for_buf = buf_cmd_lookup[open_cmd]
     if cmd_for_buf then
       open_cmd = cmd_for_buf

--- a/tests/neo-tree/command/command_current_spec.lua
+++ b/tests/neo-tree/command/command_current_spec.lua
@@ -15,6 +15,11 @@ local run_in_current_command = function(command, expected_tree_node)
   end
 end
 
+local run_close_command = function(command)
+  vim.cmd(command)
+  u.wait_for(function() end, { interval = 200, timeout = 200 })
+end
+
 describe("Command", function()
   local test = u.fs.init_test({
     items = {
@@ -71,7 +76,7 @@ describe("Command", function()
       run_in_current_command(cmd, testfile)
 
       -- toggle CLOSE
-      vim.cmd(cmd)
+      run_close_command(cmd)
       verify.window_handle_is(tree_winid)
       verify.buf_name_is(testfile)
     end)

--- a/tests/neo-tree/command/command_spec.lua
+++ b/tests/neo-tree/command/command_spec.lua
@@ -39,6 +39,11 @@ local run_show_command = function(command, expected_tree_node)
   end, "Expected to see a new window without focusing it.")
 end
 
+local run_close_command = function(command)
+  vim.cmd(command)
+  u.wait_for(function() end, { interval = 200, timeout = 200 })
+end
+
 describe("Command", function()
   local test = u.fs.init_test({
     items = {
@@ -87,7 +92,7 @@ describe("Command", function()
       local tree_winid = vim.api.nvim_get_current_win()
 
       -- toggle CLOSE
-      vim.cmd(cmd)
+      run_close_command(cmd)
       verify.window_handle_is_not(tree_winid)
       verify.buf_name_is(testfile)
 
@@ -109,7 +114,7 @@ describe("Command", function()
         local tree_winid = vim.api.nvim_get_current_win()
 
         -- toggle CLOSE
-        vim.cmd("Neotree float reveal toggle")
+        run_close_command("Neotree float reveal toggle")
         verify.window_handle_is_not(tree_winid)
         verify.buf_name_is(testfile)
 
@@ -158,7 +163,7 @@ describe("Command", function()
 
           verify.after(500, function()
             -- toggle CLOSE
-            vim.cmd(cmd)
+            run_close_command(cmd)
 
             -- toggle OPEN
             u.editfile(topfile)
@@ -189,7 +194,7 @@ describe("Command", function()
           run_focus_command("Neotree reveal", baz)
           local expected_tree_node = baz
           -- toggle CLOSE
-          vim.cmd(cmd)
+          run_close_command(cmd)
 
           verify.after(500, function()
             -- toggle OPEN


### PR DESCRIPTION
Ref: https://github.com/neovim/neovim/issues/12517

First challenge to workaround new `winfixbuf` option added to nvim-nightly.

Please read the long discussion about this new feature here: https://github.com/vim/vim/pull/13903.