### PR TITLE
fix(fs_scan): ensure parents of all expanded nodes are also scanned

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -501,6 +501,20 @@ local handle_refresh_or_up = function (context, async)
         end)
         context.paths_to_load = utils.unique(context.paths_to_load)
       end
+      -- Ensure parents of all expanded nodes are also scanned
+      local seen = {}
+      for _, p in ipairs(context.paths_to_load) do
+        local current = p
+        while current do
+          if seen[current] then
+            break
+          end
+          seen[current] = true
+          local current_node = state.tree:get_node(current)
+          current = current_node and current_node:get_parent_id()
+        end
+      end
+      context.paths_to_load = vim.tbl_keys(seen)
     end
 
     local filtered_items = state.filtered_items or {}

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -481,6 +481,22 @@ local handle_refresh_or_up = function (context, async)
       elseif state.tree then
         context.paths_to_load = renderer.get_expanded_nodes(state.tree, state.path)
       end
+      -- Ensure parents of all expanded nodes are also scanned
+      if #context.paths_to_load > 0 and state.tree then
+        local seen = {}
+        for _, p in ipairs(context.paths_to_load) do
+          local current = p
+          while current do
+            if seen[current] then
+              break
+            end
+            seen[current] = true
+            local current_node = state.tree:get_node(current)
+            current = current_node and current_node:get_parent_id()
+          end
+        end
+        context.paths_to_load = vim.tbl_keys(seen)
+      end
       -- Ensure that there are no nested files in the list of folders to load
       context.paths_to_load = vim.tbl_filter(function(p)
         local stats = vim.loop.fs_stat(p)
@@ -501,20 +517,6 @@ local handle_refresh_or_up = function (context, async)
         end)
         context.paths_to_load = utils.unique(context.paths_to_load)
       end
-      -- Ensure parents of all expanded nodes are also scanned
-      local seen = {}
-      for _, p in ipairs(context.paths_to_load) do
-        local current = p
-        while current do
-          if seen[current] then
-            break
-          end
-          seen[current] = true
-          local current_node = state.tree:get_node(current)
-          current = current_node and current_node:get_parent_id()
-        end
-      end
-      context.paths_to_load = vim.tbl_keys(seen)
     end
 
     local filtered_items = state.filtered_items or {}


### PR DESCRIPTION
On refresh a list of expanded nodes is gathered to decide what paths to scan. However, when an expanded node lives inside a closed parent node, parent node's number of children will be wrong.
This results in unexpected behavior with `group_with_dirs`, so this fix ensures that all parent nodes are scanned.

For more detailed explanation with screenshots please read: https://github.com/nvim-neo-tree/neo-tree.nvim/issues/833.

Fixes: https://github.com/nvim-neo-tree/neo-tree.nvim/issues/833