### PR TITLE
Delete `enable_normal_mode_for_inputs` from `defaults.lua`

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -19,7 +19,6 @@ local config = {
   enable_opened_markers = true,   -- Enable tracking of opened files. Required for `components.name.highlight_opened_files`
   enable_refresh_on_write = true, -- Refresh the tree when a file is written. Only used if `use_libuv_file_watcher` is false.
   enable_cursor_hijack = false, -- If enabled neotree will keep the cursor on the first letter of the filename when moving in the tree.
-  enable_normal_mode_for_inputs = false, -- Enable normal mode for input dialogs.
   git_status_async = true,
   -- These options are for people with VERY large git repos
   git_status_async_options = {


### PR DESCRIPTION
Fixes the erroneous ``Some options have changed, please run `:Neotree migrations` to see the changes`` notification when neo-tree is opened. 

Follow up for bug introduced in PR #1372

See https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1372#issuecomment-1995921030 for discussion.

