### PR TITLE
fix(input): pass bufnr and winid to event instead

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1440,11 +1440,13 @@ This is fired inside a vim.schedule.
       event = "neo_tree_popup_input_ready",
       ---@param args { input: NuiInput }
       handler = function(args)
-        -- enter input popup with normal mode by default.
+        -- Example Usages:
+
+        -- 1. enter input popup with normal mode by default.
         vim.cmd("stopinsert")
-        -- map <esc> to enter normal mode (closes prompt by default)
+        -- 2. map <esc> to enter normal mode (closes prompt by default)
         args.input:map("i", "<esc>", vim.cmd.stopinsert, { noremap = true })
-        -- unmap <esc> in normal mode to do nothing (closes prompt by default) (`q` still works)
+        -- 3. unmap <esc> in normal mode to do nothing (closes prompt by default) (`q` still works)
         args.input:map("n", "<esc>", function() end, { noremap = true })
       end,
     }

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1438,16 +1438,18 @@ This is fired inside a vim.schedule.
 >lua
     {
       event = "neo_tree_popup_input_ready",
-      ---@param args { input: NuiInput }
-      handler = function(args)
-        -- Example Usages:
-
-        -- 1. enter input popup with normal mode by default.
+      handler = function()
+        -- enter input popup with normal mode by default.
         vim.cmd("stopinsert")
-        -- 2. map <esc> to enter normal mode (closes prompt by default)
-        args.input:map("i", "<esc>", vim.cmd.stopinsert, { noremap = true })
-        -- 3. unmap <esc> in normal mode to do nothing (closes prompt by default) (`q` still works)
-        args.input:map("n", "<esc>", function() end, { noremap = true })
+      end,
+    },
+    {
+      event = "neo_tree_popup_input_ready",
+      ---@param args { bufnr: integer, winid: integer }
+      handler = function(args)
+        -- map <esc> to enter normal mode (by default closes prompt)
+        -- don't forget `opts.buffer` to specify the buffer of the popup.
+        vim.keymap.set("i", "<esc>", vim.cmd.stopinsert, { noremap = true, buffer = args.bufnr })
       end,
     }
 <

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1438,10 +1438,14 @@ This is fired inside a vim.schedule.
 >lua
     {
       event = "neo_tree_popup_input_ready",
-      ---@param input NuiInput
-      handler = function(input)
+      ---@param args { input: NuiInput }
+      handler = function(args)
         -- enter input popup with normal mode by default.
         vim.cmd("stopinsert")
+        -- map <esc> to enter normal mode (closes prompt by default)
+        args.input:map("i", "<esc>", vim.cmd.stopinsert, { noremap = true })
+        -- unmap <esc> in normal mode to do nothing (closes prompt by default) (`q` still works)
+        args.input:map("n", "<esc>", function() end, { noremap = true })
       end,
     }
 <

--- a/lua/neo-tree/setup/deprecations.lua
+++ b/lua/neo-tree/setup/deprecations.lua
@@ -118,8 +118,8 @@ See instructions in `:h neo-tree-events` for more details.
 event_handlers = {
   {
     event = "neo_tree_popup_input_ready",
-    ---@param input NuiInput
-    handler = function(input)
+    ---@param args { bufnr: integer, winid: integer }
+    handler = function(args)
       -- enter input popup with normal mode by default.
       vim.cmd("stopinsert")
     end,

--- a/lua/neo-tree/setup/deprecations.lua
+++ b/lua/neo-tree/setup/deprecations.lua
@@ -120,8 +120,8 @@ event_handlers = {
     event = "neo_tree_popup_input_ready",
     ---@param args { bufnr: integer, winid: integer }
     handler = function(args)
-      -- enter input popup with normal mode by default.
       vim.cmd("stopinsert")
+      vim.keymap.set("i", "<esc>", vim.cmd.stopinsert, { noremap = true, buffer = args.bufnr })
     end,
   }
 }

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -39,7 +39,10 @@ M.show_input = function(input, callback)
 
   if input.prompt_type ~= "confirm" then
     vim.schedule(function()
-      events.fire_event(events.NEO_TREE_POPUP_INPUT_READY, { input = input })
+      events.fire_event(events.NEO_TREE_POPUP_INPUT_READY, {
+        bufnr = input.bufnr,
+        winid = input.winid,
+      })
     end)
   end
 end

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -12,24 +12,11 @@ local should_use_popup_input = function()
 end
 
 M.show_input = function(input, callback)
-  local config = require("neo-tree").config
   input:mount()
-
-  if input.prompt_type ~= "confirm" then
-    vim.schedule(function()
-      -- deprecate this option in next version
-      if config.enable_normal_mode_for_inputs then
-        vim.cmd("stopinsert")
-      end
-      events.fire_event(events.NEO_TREE_POPUP_INPUT_READY)
-    end)
-  end
 
   input:map("i", "<esc>", function()
     vim.cmd("stopinsert")
-    if not config.enable_normal_mode_for_inputs or input.prompt_type == "confirm" then
-      input:unmount()
-    end
+    input:unmount()
   end, { noremap = true })
 
   input:map("n", "<esc>", function()
@@ -49,6 +36,12 @@ M.show_input = function(input, callback)
       callback()
     end
   end, { once = true })
+
+  if input.prompt_type ~= "confirm" then
+    vim.schedule(function()
+      events.fire_event(events.NEO_TREE_POPUP_INPUT_READY, { input = input })
+    end)
+  end
 end
 
 M.input = function(message, default_value, callback, options, completion)


### PR DESCRIPTION
Closes: #1396

> [!WARNING]
> 
> Breaking change.
> I've deprecated `config.enable_normal_mode_for_inputs` entirely and it does absolutely nothing now.

I've also added examples to the help page.

```lua
    {
      event = "neo_tree_popup_input_ready",
      ---@param args { input: NuiInput }
      handler = function(args)
        -- enter input popup with normal mode by default.
        vim.cmd("stopinsert")
        -- map <esc> to enter normal mode (closes prompt by default)
        args.input:map("i", "<esc>", vim.cmd.stopinsert, { noremap = true })
        -- unmap <esc> in normal mode to do nothing (closes prompt by default) (`q` still works)
        args.input:map("n", "<esc>", function() end, { noremap = true })
      end,
    }
```