### PR TITLE
fix(command): normalize reveal_file path argument

### DIFF
--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -150,14 +150,13 @@ M.execute = function(args)
     do_reveal = utils.truthy(args.reveal_file)
   end
 
-  args.reveal_file = utils.normalize_path(args.reveal_file)
-
   -- All set, now show or focus the window
   local force_navigate = path_changed or do_reveal or git_base_changed or state.dirty
   --if position_changed and args.position ~= "current" and current_position ~= "current" then
   --  manager.close(args.source)
   --end
   if do_reveal then
+    args.reveal_file = utils.normalize_path(args.reveal_file)
     handle_reveal(args, state)
   else
     do_show_or_focus(args, state, force_navigate)

--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -150,6 +150,8 @@ M.execute = function(args)
     do_reveal = utils.truthy(args.reveal_file)
   end
 
+  args.reveal_file = utils.normalize_path(args.reveal_file)
+
   -- All set, now show or focus the window
   local force_navigate = path_changed or do_reveal or git_base_changed or state.dirty
   --if position_changed and args.position ~= "current" and current_position ~= "current" then


### PR DESCRIPTION
I found that when using neo-tree with project.nvim, when changing cwd via project selector, `reveal` argument doesn't work, the file is not focused upon opening the tree. Turns out, project.nvim normalizes disk names on Windows to **lower** case

https://github.com/ahmedkhalf/project.nvim/blob/8c6bad7d22eef1b71144b401c9f74ed01526a4fb/lua/project_nvim/utils/history.lua#L32-L34

As a result, switching directories via project.nvim on Windows results in all file paths having lower case drive letter

![image](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/20725046/f00d3838-d6a1-4b50-9874-14feb28beedf)

Meanwhile, neo-tree normalizes drive names to **upper** case

https://github.com/nvim-neo-tree/neo-tree.nvim/blob/120a83eb7c3c240d5298122111e9f65f0ee5bc8f/lua/neo-tree/utils/init.lua#L792-L793

But it doesn't do so for `reveal_file` argument. Since normalized file names are used as case sensitive ids, neo-tree is unable to find file to reveal and just does nothing. 

The issue can be trivially reproduced by running `:cd c:\[directory]` with drive letter in lower case and trying to open neo-tree with `reveal` argument (or relative path in `reveal_file` argument).

This fix applies same normalization process to the input parameter, eliminating possible discrepancies.