### PR TITLE
fix(renderer): check if current buffer is loaded

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -778,6 +778,7 @@ create_tree = function(state)
   state.tree = NuiTree({
     ns_id = highlights.ns_id,
     winid = state.winid,
+    bufnr = state.bufnr,
     get_node_id = function(node)
       return node.id
     end,

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -163,13 +163,15 @@ M.close = function(state, focus_prior_window)
     end
     state.winid = nil
   end
-  local bufnr = utils.get_value(state, "bufnr", 0, true)
-  state.bufnr = nil
-  vim.schedule(function()
-    if bufnr > 0 and vim.api.nvim_buf_is_valid(bufnr) then
-      vim.api.nvim_buf_delete(bufnr, { force = true })
-    end
-  end)
+  if window_existed then
+    local bufnr = utils.get_value(state, "bufnr", 0, true)
+    state.bufnr = nil
+    vim.schedule(function()
+      if bufnr > 0 and vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end)
+  end
   return window_existed
 end
 

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1087,7 +1087,7 @@ M.window_exists = function(state)
     window_exists = false
   elseif position == "current" then
     window_exists = vim.api.nvim_win_is_valid(winid)
-      and vim.api.nvim_buf_is_valid(bufnr)
+      and vim.api.nvim_buf_is_loaded(bufnr)
       and vim.api.nvim_win_get_buf(winid) == bufnr
   else
     local isvalid = M.is_window_valid(winid)


### PR DESCRIPTION
              Somehow this commit has caused a bug with `:Neotree current toggle`. 

1. If you have more than one split, 
2. and you use `:Neotree current toggle`
3. then open a file
4. then `:Neotree current toggle`
5. you'll get an error (see below)
6. then your current window will be closed

Error from step 5:
```
Error executing vim.schedule lua callback: ...is/.local/share/nvim/lazy/nui.nvim/lua/nui/tree/init.lua:188: missing bufnr                                                     
stack traceback:                                                                                                                                                              
        [C]: in function 'error'                                                                                                                                              
        ...is/.local/share/nvim/lazy/nui.nvim/lua/nui/tree/init.lua:188: in function 'init'                                                                                   
        .../.local/share/nvim/lazy/nui.nvim/lua/nui/object/init.lua:132: in function 'NuiTree'                                                                                
        ...e/chris/repos/neo-tree.nvim/lua/neo-tree/ui/renderer.lua:778: in function 'create_tree'                                                                            
        ...e/chris/repos/neo-tree.nvim/lua/neo-tree/ui/renderer.lua:1190: in function 'draw'                                                                                  
        ...e/chris/repos/neo-tree.nvim/lua/neo-tree/ui/renderer.lua:1326: in function 'show_nodes'                                                                            
        ...ree.nvim/lua/neo-tree/sources/filesystem/lib/fs_scan.lua:96: in function 'render_context'                                                                          
        ...ree.nvim/lua/neo-tree/sources/filesystem/lib/fs_scan.lua:165: in function <...ree.nvim/lua/neo-tree/sources/filesystem/lib/fs_scan.lua:164> 
```

@pysan3 I'm not sure I am going to be able to debug so I was thinking about reverting it for now. Do you want to look into it before I do?

_Originally posted by @cseickel in https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1390#issuecomment-2008589757_
            