### PR TITLE
feat: support desc for string command keymaps

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -840,7 +840,7 @@ local set_buffer_mappings = function(state)
           func = func.command or func[1]
         end
         if type(func) == "string" then
-          resolved_mappings[cmd] = { text = func }
+          resolved_mappings[cmd] = { text = desc or func }
           map_options.desc = map_options.desc or func
           vfunc = state.commands[func .. "_visual"]
           func = state.commands[func]


### PR DESCRIPTION
Would fix: #1413 
Allowing a custom desc to be passed when sending a keymap instead of just defaulting to the `command passed`
Ex: Sending `{ 'diff_files', desc = "Diff Two Files' }` would now set the help text to "Diff Two Files" instead of "diff_files"