### PR TITLE
fix(renderer): check if current buffer is loaded

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -778,6 +778,7 @@ create_tree = function(state)
   state.tree = NuiTree({
     ns_id = highlights.ns_id,
     winid = state.winid,
+    bufnr = state.bufnr,
     get_node_id = function(node)
       return node.id
     end,

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -163,13 +163,15 @@ M.close = function(state, focus_prior_window)
     end
     state.winid = nil
   end
-  local bufnr = utils.get_value(state, "bufnr", 0, true)
-  state.bufnr = nil
-  vim.schedule(function()
-    if bufnr > 0 and vim.api.nvim_buf_is_valid(bufnr) then
-      vim.api.nvim_buf_delete(bufnr, { force = true })
-    end
-  end)
+  if window_existed then
+    local bufnr = utils.get_value(state, "bufnr", 0, true)
+    state.bufnr = nil
+    vim.schedule(function()
+      if bufnr > 0 and vim.api.nvim_buf_is_valid(bufnr) then
+        vim.api.nvim_buf_delete(bufnr, { force = true })
+      end
+    end)
+  end
   return window_existed
 end
 

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1013,6 +1013,9 @@ M.acquire_window = function(state)
       vim.api.nvim_win_set_buf(state.winid, state.bufnr)
     else
       close_old_window()
+      if state.bufnr and vim.api.nvim_buf_is_valid(state.bufnr) then
+        vim.api.nvim_buf_delete(state.bufnr, { force = true })
+      end
       win = NuiSplit(win_options)
       win:mount()
       state.bufnr = win.bufnr

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1087,7 +1087,7 @@ M.window_exists = function(state)
     window_exists = false
   elseif position == "current" then
     window_exists = vim.api.nvim_win_is_valid(winid)
-      and vim.api.nvim_buf_is_valid(bufnr)
+      and vim.api.nvim_buf_is_loaded(bufnr)
       and vim.api.nvim_win_get_buf(winid) == bufnr
   else
     local isvalid = M.is_window_valid(winid)


### PR DESCRIPTION
closes: #1415

I failed to detect one edge case in
- https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1406

Old code was guaranteed that `state.bufnr` was deleted inside `close_old_window` function but now only when `window_existed`.
Since you changed the code so that buffer might survive even when window is closed a couple months ago, we needed to delete the old remaining buffer regardless of `window_existed` for this specific if-cases.