### PR TITLE
feat(set_root): allow filesystem and buffers to run set_root when the cursor is on both files and directories

### DIFF
--- a/lua/neo-tree/sources/buffers/commands.lua
+++ b/lua/neo-tree/sources/buffers/commands.lua
@@ -81,16 +81,16 @@ end
 
 M.set_root = function(state)
   local node = state.tree:get_node()
+  while node and node.type ~= "directory" do
+    local parent_id = node:get_parent_id()
+    node = parent_id and state.tree:get_node(parent_id) or nil
+  end
+
   if not node then
     return
   end
 
-  local id = node.type == "directory" and node:get_id() or node:get_parent_id()
-  if not id then
-    return
-  end
-
-  buffers.navigate(state, id)
+  buffers.navigate(state, node:get_id())
 end
 
 cc._add_common_commands(M)

--- a/lua/neo-tree/sources/buffers/commands.lua
+++ b/lua/neo-tree/sources/buffers/commands.lua
@@ -81,7 +81,7 @@ end
 
 M.set_root = function(state)
   local node = state.tree:get_node()
-  local id = node.type == "directory" and node.id or node._parent_id
+  local id = node.type == "directory" and node:get_id() or node:get_parent_id()
   buffers.navigate(state, id)
 end
 

--- a/lua/neo-tree/sources/buffers/commands.lua
+++ b/lua/neo-tree/sources/buffers/commands.lua
@@ -81,9 +81,12 @@ end
 
 M.set_root = function(state)
   local node = state.tree:get_node()
-  local id = node.type == "directory" and node:get_id() or node:get_parent_id()
+  if not node then
+    return
+  end
 
   -- "node:get_parent_id()" and "node:get_id()" may return nil in some cases
+  local id = node.type == "directory" and node:get_id() or node:get_parent_id()
   if not id then
     return
   end

--- a/lua/neo-tree/sources/buffers/commands.lua
+++ b/lua/neo-tree/sources/buffers/commands.lua
@@ -82,6 +82,12 @@ end
 M.set_root = function(state)
   local node = state.tree:get_node()
   local id = node.type == "directory" and node:get_id() or node:get_parent_id()
+
+  -- "node:get_parent_id()" and "node:get_id()" may return nil in some cases
+  if not id then
+    return
+  end
+
   buffers.navigate(state, id)
 end
 

--- a/lua/neo-tree/sources/buffers/commands.lua
+++ b/lua/neo-tree/sources/buffers/commands.lua
@@ -85,7 +85,6 @@ M.set_root = function(state)
     return
   end
 
-  -- "node:get_parent_id()" and "node:get_id()" may return nil in some cases
   local id = node.type == "directory" and node:get_id() or node:get_parent_id()
   if not id then
     return

--- a/lua/neo-tree/sources/buffers/commands.lua
+++ b/lua/neo-tree/sources/buffers/commands.lua
@@ -80,11 +80,9 @@ M.rename = function(state)
 end
 
 M.set_root = function(state)
-  local tree = state.tree
-  local node = tree:get_node()
-  if node.type == "directory" then
-    buffers.navigate(state, node.id)
-  end
+  local node = state.tree:get_node()
+  local id = node.type == "directory" and node.id or node._parent_id
+  buffers.navigate(state, id)
 end
 
 cc._add_common_commands(M)

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -222,14 +222,13 @@ M.rename = function(state)
 end
 
 M.set_root = function(state)
-  local tree = state.tree
-  local node = tree:get_node()
-  if node.type == "directory" then
-    if state.search_pattern then
-      fs.reset_search(state, false)
-    end
-    fs._navigate_internal(state, node.id, nil, nil, false)
+  if state.search_pattern then
+    fs.reset_search(state, false)
   end
+
+  local node = state.tree:get_node()
+  local id = node.type == "directory" and node.id or node._parent_id
+  fs._navigate_internal(state, id, nil, nil, false)
 end
 
 ---Toggles whether hidden files are shown or not.

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -227,16 +227,16 @@ M.set_root = function(state)
   end
 
   local node = state.tree:get_node()
+  while node and node.type ~= "directory" do
+    local parent_id = node:get_parent_id()
+    node = parent_id and state.tree:get_node(parent_id) or nil
+  end
+
   if not node then
     return
   end
 
-  local id = node.type == "directory" and node:get_id() or node:get_parent_id()
-  if not id then
-    return
-  end
-
-  fs._navigate_internal(state, id, nil, nil, false)
+  fs._navigate_internal(state, node:get_id(), nil, nil, false)
 end
 
 ---Toggles whether hidden files are shown or not.

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -228,6 +228,12 @@ M.set_root = function(state)
 
   local node = state.tree:get_node()
   local id = node.type == "directory" and node:get_id() or node:get_parent_id()
+
+  -- "node:get_parent_id()" and "node:get_id()" may return nil in some cases
+  if not id then
+    return
+  end
+
   fs._navigate_internal(state, id, nil, nil, false)
 end
 

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -227,9 +227,12 @@ M.set_root = function(state)
   end
 
   local node = state.tree:get_node()
-  local id = node.type == "directory" and node:get_id() or node:get_parent_id()
+  if not node then
+    return
+  end
 
   -- "node:get_parent_id()" and "node:get_id()" may return nil in some cases
+  local id = node.type == "directory" and node:get_id() or node:get_parent_id()
   if not id then
     return
   end

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -231,7 +231,6 @@ M.set_root = function(state)
     return
   end
 
-  -- "node:get_parent_id()" and "node:get_id()" may return nil in some cases
   local id = node.type == "directory" and node:get_id() or node:get_parent_id()
   if not id then
     return

--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -227,7 +227,7 @@ M.set_root = function(state)
   end
 
   local node = state.tree:get_node()
-  local id = node.type == "directory" and node.id or node._parent_id
+  local id = node.type == "directory" and node:get_id() or node:get_parent_id()
   fs._navigate_internal(state, id, nil, nil, false)
 end
 


### PR DESCRIPTION
This Pull Request adds features that has been mentioned in #1419, and enhances the functionality of `set_root` for `Neotree buffers` and `Neotree filesystem`.
