### PR TITLE
fix: sources.manager.dispose* functions not working

### DIFF
--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -369,7 +369,9 @@ local dispose_state = function(state)
 end
 
 M.dispose = function(source_name, tabid)
-  for i, state in ipairs(all_states) do
+  -- Iterate in reverse because we are removing items during loop
+  for i = #all_states, 1, -1 do
+    local state = all_states[i]
     if source_name == nil or state.name == source_name then
       if not tabid or tabid == state.tabid then
         log.trace(state.name, " disposing of tab: ", tabid)
@@ -384,7 +386,9 @@ M.dispose_tab = function(tabid)
   if not tabid then
     error("dispose_tab: tabid cannot be nil")
   end
-  for i, state in ipairs(all_states) do
+  -- Iterate in reverse because we are removing items during loop
+  for i = #all_states, 1, -1 do
+    local state = all_states[i]
     if tabid == state.tabid then
       log.trace(state.name, " disposing of tab: ", tabid, state.name)
       dispose_state(state)
@@ -410,7 +414,9 @@ M.dispose_window = function(winid)
   if not winid then
     error("dispose_window: winid cannot be nil")
   end
-  for i, state in ipairs(all_states) do
+  -- Iterate in reverse because we are removing items during loop
+  for i = #all_states, 1, -1 do
+    local state = all_states[i]
     if state.id == winid then
       log.trace(state.name, " disposing of window: ", winid, state.name)
       dispose_state(state)


### PR DESCRIPTION
This is a simple change to fix the `sources.manager.dispose*` functions, which aren't currently working properly.

The bug is a classic remove while looping issue, solved by iterating in reverse. I've just copied the change from the `dispose_invalid_tabs` function.