### PR TITLE
fix: handle more edge cases for Windows path escaping

### DIFF
--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1053,11 +1053,10 @@ M.escape_path_for_cmd = function(path)
     -- character in a path segment. see #1264, #1352, and #1448 for more info.
     local need_extra_esc = path:find("[%[%]`%$~]")
     local esc = need_extra_esc and "\\\\" or "\\"
-    -- this punctuation does not get escaped by fnaemescape
     escaped_path = escaped_path:gsub("\\[%(%)%^&;]", esc .. "%1")
-    -- this punctuation gets escaped by fnameescape and always needs an extra
-    -- escape if it is the start of a path segment
-    escaped_path = escaped_path:gsub("\\\\['` ]", "\\%1")
+    if need_extra_esc then
+      escaped_path = escaped_path:gsub("\\\\['` ]", "\\%1")
+    end
   end
   return escaped_path
 end

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1042,25 +1042,22 @@ end
 ---be lost.
 ---
 ---For more details, see issue #889 when this function was introduced, and further
----discussions in #1264 and #1352.
+---discussions in #1264, #1352, and #1448.
 ---@param path string
 ---@return string
 M.escape_path_for_cmd = function(path)
   local escaped_path = vim.fn.fnameescape(path)
   if M.is_windows then
-    -- on windows, some punctuation preceeded by a `\` needs to have a second
-    -- `\` added to preserve the path separator. this is a naive replacement and
-    -- definitely not bullet proof. if we start finding issues with opening files
-    -- or changing directories, look here first. #1382 was the first regression
-    -- from the implementation that used lua's %p to match punctuation, which
-    -- did not quite work. the following characters were tested on windows to
-    -- be known to require an extra escape character.
-    for _, c in ipairs({ "&", "(", ")", ";", "^", "`" }) do
-      -- lua doesn't seem to have a problem with an unnecessary `%` escape
-      -- (e.g., `%;`), so we can use it to ensure we match the punctuation
-      -- for the ones that do (e.g., `%(` and `%^`)
-      escaped_path = escaped_path:gsub("\\%" .. c, "\\%1")
-    end
+    -- there is too much history to this logic to capture in a reasonable comment.
+    -- essentially, the following logic adds a number of `\` depending on the leading
+    -- character in a path segment. see #1264, #1352, and #1448 for more info.
+    local need_extra_esc = path:find("[%[%]`%$~]")
+    local esc = need_extra_esc and "\\\\" or "\\"
+    -- this punctuation does not get escaped by fnaemescape
+    escaped_path = escaped_path:gsub("\\[%(%)%^&;]", esc .. "%1")
+    -- this punctuation gets escaped by fnameescape and always needs an extra
+    -- escape if it is the start of a path segment
+    escaped_path = escaped_path:gsub("\\\\['` ]", "\\%1")
   end
   return escaped_path
 end


### PR DESCRIPTION
This PR fixes #1448, among other edge cases that weren't previously handled.

Relevant notes were captured in the discussion for #1448, but the gist is that certain punctuation (`[`, `]`, backticks, `$`, etc.) causes Neovim to drop an escaped path separator on Windows. This requires us to use an **additional** `\` (e.g. `X:\[foo]\\\(bar)\baz.txt`).