### PR TITLE
feat(preview): Scroll Preview window command and bindings

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -224,10 +224,10 @@ P          = toggle_preview: Toggles "preview mode", see |neo-tree-preview-mode|
 
 l           = focus_preview: Focus the active preview window
 
-<C-d>      = scroll_preview: Scrolls preview window down (without focusing it)
+<C-f>      = scroll_preview: Scrolls preview window down (without focusing it)
                              see |neo-tree-preview-mode| for params 
 
-<C-u>      = scroll_preview: Scrolls preview window up (without focusing it)
+<C-b>      = scroll_preview: Scrolls preview window up (without focusing it)
                              see |neo-tree-preview-mode| for params 
 
 <esc>      = revert_preview: Ends "preview_mode" if it is enabled, and reverts
@@ -411,8 +411,8 @@ an existing split by configuring the command like this:
         mappings = {
           ["P"] = { "toggle_preview", config = { use_float = false, use_image_nvim = true } },
           ["l"] = "focus_preview",
-          ["<C-u>"] = { "scroll_preview", config = {direction = 10} },
-          ["<C-d>"] = { "scroll_preview", config = {direction = -10} },
+          ["<C-b>"] = { "scroll_preview", config = {direction = 10} },
+          ["<C-f>"] = { "scroll_preview", config = {direction = -10} },
         }
       }
     })

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -224,6 +224,12 @@ P          = toggle_preview: Toggles "preview mode", see |neo-tree-preview-mode|
 
 l           = focus_preview: Focus the active preview window
 
+<C-d>      = scroll_preview: Scrolls preview window down (without focusing it)
+                             see |neo-tree-preview-mode| for params 
+
+<C-u>      = scroll_preview: Scrolls preview window up (without focusing it)
+                             see |neo-tree-preview-mode| for params 
+
 <esc>      = revert_preview: Ends "preview_mode" if it is enabled, and reverts
                              any preview windows to what was being shown before
                              preview mode began.
@@ -404,6 +410,9 @@ an existing split by configuring the command like this:
       window = {
         mappings = {
           ["P"] = { "toggle_preview", config = { use_float = false, use_image_nvim = true } },
+          ["l"] = "focus_preview",
+          ["<C-u>"] = { "scroll_preview", config = {direction = 10} },
+          ["<C-d>"] = { "scroll_preview", config = {direction = -10} },
         }
       }
     })

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -368,8 +368,8 @@ local config = {
       -- ["<cr>"] = { "open", config = { expand_nested_files = true } }, -- expand nested file takes precedence
       ["<esc>"] = "cancel", -- close preview or floating neo-tree window
       ["P"] = { "toggle_preview", config = { use_float = true, use_image_nvim = false } },
-      ["<C-d>"] = { "scroll_preview", config = {direction = -10} },
-      ["<C-u>"] = { "scroll_preview", config = {direction = 10} },
+      ["<C-f>"] = { "scroll_preview", config = {direction = -10} },
+      ["<C-b>"] = { "scroll_preview", config = {direction = 10} },
       ["l"] = "focus_preview",
       ["S"] = "open_split",
       -- ["S"] = "split_with_window_picker",

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -368,6 +368,8 @@ local config = {
       -- ["<cr>"] = { "open", config = { expand_nested_files = true } }, -- expand nested file takes precedence
       ["<esc>"] = "cancel", -- close preview or floating neo-tree window
       ["P"] = { "toggle_preview", config = { use_float = true, use_image_nvim = false } },
+      ["<C-d>"] = { "scroll_preview", config = {direction = -10} },
+      ["<C-u>"] = { "scroll_preview", config = {direction = 10} },
       ["l"] = "focus_preview",
       ["S"] = "open_split",
       -- ["S"] = "split_with_window_picker",

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -664,6 +664,10 @@ M.toggle_preview = function(state)
   Preview.toggle(state)
 end
 
+M.scroll_preview = function(state)
+  Preview.scroll(state)
+end
+
 M.focus_preview = function()
   Preview.focus()
 end

--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -435,4 +435,17 @@ Preview.focus = function()
   end
 end
 
+Preview.scroll = function(state)
+  local direction = state.config.direction
+  local input = direction < 0 and [[]] or [[]]
+  local count = math.abs(direction)
+
+  if Preview:is_active() then
+    vim.api.nvim_win_call(instance.winid, function()
+      vim.cmd([[normal! ]] .. count .. input)
+    end)
+  end
+
+end
+
 return Preview

--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -437,6 +437,7 @@ end
 
 Preview.scroll = function(state)
   local direction = state.config.direction
+  -- NOTE: Chars below are raw escape codes for <Ctrl-E>/<Ctrl-Y>
   local input = direction < 0 and [[]] or [[]]
   local count = math.abs(direction)
 


### PR DESCRIPTION
I'd like to extend #675 with scrolling capabilities.

1. I took telescope's code for preview scrolling. Code simply sends <C-Y> and <C-E>, nothing complex.
2. Scrolling is performed without focusing the preview window (for me, it's important)
3. Scroll step is configurable