### PR TITLE
fix:foldlevel breaks help display (#1476)

### DIFF
--- a/lua/neo-tree/sources/common/help.lua
+++ b/lua/neo-tree/sources/common/help.lua
@@ -88,6 +88,9 @@ M.show = function(state, title, prefix_key)
     focusable = true,
     zindex = 50,
     relative = "editor",
+    win_options = {
+      foldenable = false, -- Prevent folds from hiding lines
+    },
   }
 
   local popup_max_height = function()
@@ -122,11 +125,6 @@ M.show = function(state, title, prefix_key)
   local options = popups.popup_options(title, width, options)
   local popup = Popup(options)
   popup:mount()
-
-  -- Disable folding to avoid display issues from foldlevel
-  vim.api.nvim_set_option_value("foldenable", false, {
-    win = popup.winid,
-  })
 
   popup:map("n", "<esc>", function()
     popup:unmount()

--- a/lua/neo-tree/sources/common/help.lua
+++ b/lua/neo-tree/sources/common/help.lua
@@ -69,12 +69,14 @@ M.show = function(state, title, prefix_key)
 
   local width = math.min(60, max_width + 1)
 
+  local col
   if state.current_position == "right" then
     col = vim.o.columns - tree_width - width - 1
   else
     col = tree_width - 1
   end
 
+  ---@type nui_popup_options
   local options = {
     position = {
       row = 2,
@@ -121,8 +123,8 @@ M.show = function(state, title, prefix_key)
     options.size.height = max_height
   end
 
-  local title = title or "Neotree Help"
-  local options = popups.popup_options(title, width, options)
+  title = title or "Neotree Help"
+  options = popups.popup_options(title, width, options)
   local popup = Popup(options)
   popup:mount()
 

--- a/lua/neo-tree/sources/common/help.lua
+++ b/lua/neo-tree/sources/common/help.lua
@@ -123,6 +123,11 @@ M.show = function(state, title, prefix_key)
   local popup = Popup(options)
   popup:mount()
 
+  -- Disable folding to avoid display issues from foldlevel
+  vim.api.nvim_set_option_value("foldenable", false, {
+    win = popup.winid,
+  })
+
   popup:map("n", "<esc>", function()
     popup:unmount()
   end, { noremap = true })


### PR DESCRIPTION
When a lower fold level is set the help menu content folds and because of the keybindings you cannot easily unfold things. To avoid this we disable folding in the help popup window.

https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1476