### PR TITLE
Delete enable_normal_mode_for_inputs from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ use {
         popup_border_style = "rounded",
         enable_git_status = true,
         enable_diagnostics = true,
-        enable_normal_mode_for_inputs = false, -- Enable normal mode for input dialogs.
         open_files_do_not_replace_types = { "terminal", "trouble", "qf" }, -- when opening files, do not use windows containing these filetypes or buftypes
         sort_case_insensitive = false, -- used when sorting files and directories in the tree
         sort_function = nil , -- use a custom function for sorting files and directories in the tree 


### PR DESCRIPTION
Update readme.md to follow PR: https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1395

Delete enable_normal_mode_for_inputs from README example