### PR TITLE
Fix(git_status): respect `dir` parameter passed into command

### DIFF
--- a/lua/neo-tree/sources/git_status/init.lua
+++ b/lua/neo-tree/sources/git_status/init.lua
@@ -24,6 +24,7 @@ end
 ---Navigate to the given path.
 ---@param path string Path to navigate to. If empty, will navigate to the cwd.
 M.navigate = function(state, path, path_to_reveal, callback, async)
+  state.path = path or state.path
   state.dirty = false
   if path_to_reveal then
     renderer.position.set(state, path_to_reveal)

--- a/lua/neo-tree/sources/git_status/lib/items.lua
+++ b/lua/neo-tree/sources/git_status/lib/items.lua
@@ -13,7 +13,7 @@ M.get_git_status = function(state)
     return
   end
   state.loading = true
-  local status_lookup, project_root = git.status(state.git_base, true)
+  local status_lookup, project_root = git.status(state.git_base, true, state.path)
   state.path = project_root or state.path or vim.fn.getcwd()
   local context = file_items.create_context()
   context.state = state


### PR DESCRIPTION
should close #1309
now this should work
```lua
      {
        "<leader>ge",
        function()
          require("neo-tree.command").execute({
            toggle = true,
            dir = LazyVim.root(), -- or comment it, then cwd becomes default
            source = "git_status",
          })
        end,
        desc = "Git Explorer",
      },

```