### PR TITLE
feat(components): add support for `mini.icons`

### DIFF
--- a/lua/neo-tree/sources/document_symbols/lib/kinds.lua
+++ b/lua/neo-tree/sources/document_symbols/lib/kinds.lua
@@ -39,11 +39,17 @@ local kinds_map = {}
 ---@return table res of the form { name = kind_display_name, icon = kind_icon, hl = kind_hl }
 M.get_kind = function(kind_id)
   local kind_name = kinds_id_to_name[kind_id]
-  return vim.tbl_extend(
-    "force",
-    { name = kind_name or ("Unknown: " .. kind_id), icon = "?", hl = "" },
-    kind_name and (kinds_map[kind_name] or {}) or kinds_map["Unknown"]
-  )
+  local name, icon, hl = kind_name or ("Unknown: " .. kind_id), "?", ""
+  if kind_name then
+    local _, mini_icons = pcall(require, "mini.icons")
+    if _G.MiniIcons ~= nil then
+      icon, hl = mini_icons.get("lsp", kind_name)
+    else
+      local kind = kinds_map[kind_name]
+      icon, hl = kind.icon or icon, kind.hl or hl
+    end
+  end
+  return { name = name, icon = icon, hl = hl }
 end
 
 ---Setup the module with custom kinds


### PR DESCRIPTION
This adds support for `mini.icons` for providing icons for not just files but also directories

![2024-07-05_10:09:40_screenshot](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/1591837/e5816947-8b42-43d0-a039-aaf5b6355836)
