### PR TITLE
fix: terrible git status performance in large repo

### DIFF
--- a/lua/neo-tree/git/status.lua
+++ b/lua/neo-tree/git/status.lua
@@ -255,11 +255,11 @@ M.status_async = function(path, base, opts)
         args = { "-C", git_root, "diff", "--staged", "--name-status", base, "--" },
         enable_recording = false,
         maximium_results = context.max_lines,
-        on_stdout = vim.schedule_wrap(function(err, line, job)
+        on_stdout = function(err, line, job)
           if should_process(err, line, job, "status_async staged error:") then
             table.insert(context.lines, line)
           end
-        end),
+        end,
         on_stderr = function(err, line)
           if err and err > 0 then
             log.error("status_async staged error: ", err, line)
@@ -272,14 +272,14 @@ M.status_async = function(path, base, opts)
         args = { "-C", git_root, "diff", "--name-status" },
         enable_recording = false,
         maximium_results = context.max_lines,
-        on_stdout = vim.schedule_wrap(function(err, line, job)
+        on_stdout = function(err, line, job)
           if should_process(err, line, job, "status_async unstaged error:") then
             if line then
               line = " " .. line
             end
             table.insert(context.lines, line)
           end
-        end),
+        end,
         on_stderr = function(err, line)
           if err and err > 0 then
             log.error("status_async unstaged error: ", err, line)
@@ -292,14 +292,14 @@ M.status_async = function(path, base, opts)
         args = { "-C", git_root, "ls-files", "--exclude-standard", "--others" },
         enable_recording = false,
         maximium_results = context.max_lines,
-        on_stdout = vim.schedule_wrap(function(err, line, job)
+        on_stdout = function(err, line, job)
           if should_process(err, line, job, "status_async untracked error:") then
             if line then
               line = "?	" .. line
             end
             table.insert(context.lines, line)
           end
-        end),
+        end,
         on_stderr = function(err, line)
           if err and err > 0 then
             log.error("status_async untracked error: ", err, line)


### PR DESCRIPTION
`schedule_wrap` floods the event loop with work that could've been done right away much faster here. massive improvement with my goofy git repo $HOME without a .gitignore
![image](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/23123008/b70962b8-dfe4-4a66-bc67-c8a18b15346f)
![image](https://github.com/nvim-neo-tree/neo-tree.nvim/assets/23123008/3844bdc5-8387-4f21-b731-4d76318e1e5c)
