### PR TITLE
feat: add `icon.provider` option to components for full control

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,17 @@ use {
             folder_closed = "",
             folder_open = "",
             folder_empty = "󰜌",
+            provider = function(icon, node, state) -- default icon provider utilizes nvim-web-devicons if available
+              if node.type == "file" or node.type == "terminal" then
+                local success, web_devicons = pcall(require, "nvim-web-devicons")
+                local name = node.type == "terminal" and "terminal" or node.name
+                if success then
+                  local devicon, hl = web_devicons.get_icon(name)
+                  icon.text = devicon or icon.text
+                  icon.highlight = hl or icon.highlight
+                end
+              end
+            end,
             -- The next two settings are only a fallback, if you use nvim-web-devicons and configure default icons there
             -- then these will never be used.
             default = "*",

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -203,7 +203,18 @@ local config = {
       -- The next two settings are only a fallback, if you use nvim-web-devicons and configure default icons there
       -- then these will never be used.
       default = "*",
-      highlight = "NeoTreeFileIcon"
+      highlight = "NeoTreeFileIcon",
+      provider = function(icon, node, state) -- default icon provider utilizes nvim-web-devicons if available
+        if node.type == "file" or node.type == "terminal" then
+          local success, web_devicons = pcall(require, "nvim-web-devicons")
+          local name = node.type == "terminal" and "terminal" or node.name
+          if success then
+            local devicon, hl = web_devicons.get_icon(name)
+            icon.text = devicon or icon.text
+            icon.highlight = hl or icon.highlight
+          end
+        end
+      end
     },
     modified = {
       symbol = "[+] ",

--- a/lua/neo-tree/sources/document_symbols/components.lua
+++ b/lua/neo-tree/sources/document_symbols/components.lua
@@ -15,14 +15,18 @@ local common = require("neo-tree.sources.common.components")
 
 local M = {}
 
-M.icon = function(config, node, state)
-  return {
+M.kind_icon = function(config, node, state)
+  local icon = {
     text = node:get_depth() == 1 and "" or node.extra.kind.icon,
-    highlight = node.extra and node.extra.kind.hl or highlights.FILE_NAME,
+    highlight = node.extra.kind.hl,
   }
-end
 
-M.kind_icon = M.icon
+  if config.provider then
+    icon = config.provider(icon, node, state) or icon
+  end
+
+  return icon
+end
 
 M.kind_name = function(config, node, state)
   return {


### PR DESCRIPTION
This supersedes #1510 

Previously I looked at adding direct support for `mini.icons` into the code base. @miversen33 made a fantastic point that it seems like icon providing is a simple pattern that can grow arbitrarily and it might make sense to make it configurable by the user to provide their own icon provider for components. This adds a new section to the common section of the components to utilize an icon provider for resolving icons based on a node/state.

I took a look at the `document_symbols` component and I'm honestly not sure what the best approach for that part is. Should we try to unify it with the component's icon provider and have it override it to an icon provider of LSP kinds or should we make a new config option specifically for that component that has a similar pattern?

Let me know what you think of this, it basically sets up the current `nvim-web-devicons` support as a default icon provider for components.

Here is an example of using the new feature where the user uses `mini.icons`:

```lua
---@type LazySpec
return {
  "nvim-neo-tree/neo-tree.nvim",
  dependencies = {
    { "echasnovski/mini.icons", opts = {} } -- add mini.icons
  },
  opts = {
    default_component_configs = {
      icon = {
        provider = function(icon, node) -- setup a custom icon provider
          local text, hl
          local mini_icons = require "mini.icons"
          if node.type == "file" then -- if it's a file, set the text/hl
            text, hl = mini_icons.get("file", node.name)
          elseif node.type == "directory" then -- get directory icons
            text, hl = mini_icons.get("directory", node.name)
            -- only set the icon text if it is not expanded
            if node:is_expanded() then text = nil end
          end

          -- set the icon text/highlight only if it exists
          if text then icon.text = text end
          if hl then icon.highlight = hl end
        end,
      },
    },
  },
}
```