### PR TITLE
Check for nil state.tree

### DIFF
--- a/lua/neo-tree/sources/common/hijack_cursor.lua
+++ b/lua/neo-tree/sources/common/hijack_cursor.lua
@@ -20,7 +20,7 @@ local hijack_cursor_handler = function()
     end
 
     local state = manager.get_state(source, nil, winid)
-    if state == nil then
+    if state == nil or not state.tree then
       return
     end
     local node = state.tree:get_node()


### PR DESCRIPTION
I've been getting a crash with certain directories because it's possible for the state table to not contain a tree temporarily. This fixes the issue.