### PR TITLE
fix(filesystem): ignore dotfiles properly for find filter

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/filter_external.lua
+++ b/lua/neo-tree/sources/filesystem/lib/filter_external.lua
@@ -193,9 +193,6 @@ M.filter_files_external = function(
     if types.executable then
       append("-executable")
     end
-    if not ignore.dotfiles then
-      append("-not", "-path", "*/.*")
-    end
     if glob ~= nil and not full_path then
       append("-iname", glob)
     elseif glob ~= nil and full_path then

--- a/lua/neo-tree/sources/filesystem/lib/filter_external.lua
+++ b/lua/neo-tree/sources/filesystem/lib/filter_external.lua
@@ -184,6 +184,9 @@ M.filter_files_external = function(
         file_types[#file_types + 1] = file_type_map[k]
       end
     end
+    if ignore.dotfiles then
+      append("-name", ".*", "-prune", "-o")
+    end
     if #file_types > 0 then
       append("-type", table.concat(file_types, ","))
     end
@@ -202,6 +205,7 @@ M.filter_files_external = function(
     elseif regex ~= nil then
       append("-regextype", "sed", "-regex", regex)
     end
+    append("-print")
     append_find_args()
   elseif cmd == "fzf" then
     -- This does not work yet, there's some kind of issue with how fzf uses stdout


### PR DESCRIPTION
Not sure what was the purpose of that exclusion, but it was causing issues when `find` command is used within `filter` logic. 
```lua
if not ignore.dotfiles then
  append("-not", "-path", "*/.*")
end
```
You would expect that when `ignore-dotfiles` is `false` you don't want to exclude dot files and directories. In fact it was not just excluding dot files, but all the other valid options if current `path` contains any `.` directories. For example for me the resulting command was
```bash
find  "/Users/nouwa/.config/nvim" -not -path '*/.*' -iname "*lua*"
```
and because my path has `.config` -- all files were excluded, producing empty search result.

Once this section removed, eveyrhing works as expected with both `ignore.dotfiles = true` and `false`.
