### PR TITLE
feat: add close to fuzzy_finder_mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ use {
               ["<C-n>"] = "move_cursor_down",
               ["<up>"] = "move_cursor_up",
               ["<C-p>"] = "move_cursor_up",
+              ["<esc>"] = "close",
               -- ['<key>'] = function(state, scroll_padding) ... end,
             },
           },

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -448,6 +448,7 @@ local config = {
         ["<C-n>"] = "move_cursor_down",
         ["<up>"] = "move_cursor_up",
         ["<C-p>"] = "move_cursor_up",
+        ["<esc>"] = "close"
       },
     },
     async_directory_scan = "auto", -- "auto"   means refreshes are async, but it's synchronous when called from the Neotree commands.


### PR DESCRIPTION
Useful for users who wants to map something else than `<esc>` (e.g. `<C-e>` or `<C-c>)` to close the fuzzy finder input window