### PR TITLE
feat(popups): Add title formatting option

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1792,9 +1792,11 @@ Popups will be created with a |filetype| of `neo-tree-popup`. You can use this
 as the target for autocmds or to exclude them from being acted upon by other
 plugins.
 
-They can also be configured by setting the `popup_border_style` in your config,
-and the colors of that border are controlled by the `NeoTreeFloatBorder`
-highlight group. If you you use the special `NC` option for
+They can also be configured by setting the `popup_border_style` in your config.
+To modify the title bar text that appears on a popup window, use
+the `window.popup.title` config option to define a function mapping the window
+state to a string. The colors of the popup border are controlled by the
+`NeoTreeFloatBorder` highlight group.If you you use the special `NC` option for
 `popup_border_style`, the title bar of that popup uses the `NeoTreeTitleBar`
 highlight group.
 

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -356,6 +356,9 @@ local config = {
         width = "50%",
       },
       position = "50%", -- 50% means center it
+      title = function (state) -- format the text that appears at the top of a popup window
+        return "Neo-tree " .. state.name:gsub("^%l", string.upper)
+      end,
       -- you can also specify border here, if you want a different setting from
       -- the global popup_border_style.
     },

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -880,8 +880,14 @@ local function create_floating_window(state, win_options, bufname)
     local win
     state.force_float = nil
     -- First get the default options for floating windows.
-    local sourceTitle = state.name:gsub("^%l", string.upper)
-    win_options = popups.popup_options("Neo-tree " .. sourceTitle, 40, win_options)
+    local title = utils.resolve_config_option(
+        state,
+        "window.popup.title",
+        function (current_state)
+            return "Neo-tree " .. current_state.name:gsub("^%l", string.upper)
+        end
+    )
+    win_options = popups.popup_options(title, 40, win_options)
     win_options.win_options = nil
     win_options.zindex = 40
 


### PR DESCRIPTION
Hello 👋

Love the plugin, spend so much of my dev time using it, so I thought I'd contribute a feature I really wanted.

Allows you to specify a function in your config that takes the state and resolves a popup title. Since it's a function you can even add stateful data if you really wished. Of course the current defaults are respected and this shouldn't have any breaking changes.

<img width="807" alt="image" src="https://github.com/user-attachments/assets/c3a5473e-d390-44aa-a77a-cc87432d996d">

<img width="844" alt="image" src="https://github.com/user-attachments/assets/769798a4-3bf2-475e-917e-9d4e229c9213">

