### PR TITLE
fix: remove invalid_tabs before _for_each_state

### DIFF
--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -51,6 +51,7 @@ M._get_all_states = function()
 end
 
 M._for_each_state = function(source_name, action)
+  M.dispose_invalid_tabs()
   for _, state in ipairs(all_states) do
     if source_name == nil or state.name == source_name then
       action(state)


### PR DESCRIPTION
fix https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1067

# problem

Probably, neovim does not fire the `TabClosed` autocmd in some conditions.
So invalid tabs might be remained to the manager states.

# solution

check & dispose invalid states before enumerate it.
