### PR TITLE
feat(filesystem): customizable timestamp formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,8 +301,11 @@ use {
             --   "show_file_details",
             --   -- format strings of the timestamps shown for date created and last modified (see `:h os.date()`)
             --   -- both options accept a string or a function that takes in the date in seconds and returns a string to display
-            --   created_format = "%Y-%m-%d %I:%M %p",
-            --   modified_format = function(seconds) ... end,
+            --   -- config = {
+            --   --   created_format = "%Y-%m-%d %I:%M %p",
+            --   --   modified_format = "relative", -- equivalent to the line below
+            --   --   modified_format = function(seconds) return require('neo-tree.utils').relative_date(seconds) end
+            --   -- }
             -- },
           }
         },

--- a/README.md
+++ b/README.md
@@ -297,6 +297,13 @@ use {
             ["<"] = "prev_source",
             [">"] = "next_source",
             ["i"] = "show_file_details",
+            -- ["i"] = {
+            --   "show_file_details",
+            --   -- format strings of the timestamps shown for date created and last modified (see `:h os.date()`)
+            --   -- both options accept a string or a function that takes in the date in seconds and returns a string to display
+            --   created_format = "%Y-%m-%d %I:%M %p",
+            --   modified_format = function(seconds) ... end,
+            -- },
           }
         },
         nesting_rules = {},

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -306,6 +306,22 @@ d    = delete:               Delete the selected file or directory.
 i    = show_file_details     Show file details in popup window, such as size
                              and last modified date.
 
+                             This command supports two optional options to
+                             change the format string for timestamps,
+                             `config.created_format` for date created and
+                             `config.modified_format` for last modified (see
+                             `:h os.date()`). Both options also accept a
+                             function that takes in the date in seconds and
+                             returns a string to display, which can be used to
+                             implement custom features like relative
+                             timestamps.
+
+                             If the options are not set, they default to the
+                             value of `default_component_configs.created.format`
+                             and `default_component_configs.modified.format` in
+                             the root config, which in turn defaults to
+                             "%Y-%m-%d %I:%M %p".
+
 r    = rename:               Rename the selected file or directory.
 
 y    = copy_to_clipboard:    Mark file to be copied.

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -303,24 +303,22 @@ A    = add_directory:        Create a new directory, in this mode it does not
 d    = delete:               Delete the selected file or directory.
                              Supports visual selection.~
 
-i    = show_file_details     Show file details in popup window, such as size
+i    = show_file_details     Show file details in a popup window, such as size
                              and last modified date.
 
                              This command supports two optional options to
-                             change the format string for timestamps,
-                             `config.created_format` for date created and
-                             `config.modified_format` for last modified (see
-                             `:h os.date()`). Both options also accept a
+                             change the format string for file timestamps,
+                             `config.created_format` for the date created and
+                             `config.modified_format` for the date last
+                             modified (see `:h os.date()`). Instead of a
+                             format string, these options also accept a
                              function that takes in the date in seconds and
-                             returns a string to display, which can be used to
-                             implement custom features like relative
-                             timestamps.
+                             returns a string to display. They also accept
+                             "relative" as a valid format, which will format
+                             the timestamp as a human-readable relative date.
 
                              If the options are not set, they default to the
-                             value of `default_component_configs.created.format`
-                             and `default_component_configs.modified.format` in
-                             the root config, which in turn defaults to
-                             "%Y-%m-%d %I:%M %p".
+                             format string "%Y-%m-%d %I:%M %p".
 
 r    = rename:               Rename the selected file or directory.
 

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -440,7 +440,7 @@ local config = {
         ["."] = "set_root",
         ["[g"] = "prev_git_modified",
         ["]g"] = "next_git_modified",
-        ["i"] = { "show_file_details", config = { created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" } }, -- (see `:h neo-tree-mappings`)
+        ["i"] = "show_file_details", -- see `:h neo-tree-file-actions` for options to customize the window.
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -257,10 +257,14 @@ local config = {
     last_modified = {
       enabled = true,
       required_width = 88, -- min width of window required to show this column
+      format = "%Y-%m-%d %I:%M %p", -- format string for timestamp (see ISO C function `strftime`, `format` parameter)
+                                    -- or use a function that takes in the date in seconds and returns a string
     },
     created = {
       enabled = false,
       required_width = 120, -- min width of window required to show this column
+      format = "%Y-%m-%d %I:%M %p", -- format string for timestamp (see ISO C function `strftime`, `format` parameter)
+                                    -- or use a function that takes in the date in seconds and returns a string
     },
     symlink_target = {
       enabled = false,

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -258,13 +258,13 @@ local config = {
       enabled = true,
       required_width = 88, -- min width of window required to show this column
       format = "%Y-%m-%d %I:%M %p", -- format string for timestamp (see `:h os.date()`)
-                                    -- or use a function that takes in the date in seconds and returns a string
+                                    -- or use a function that takes in the date in seconds and returns a string to display
     },
     created = {
       enabled = false,
       required_width = 120, -- min width of window required to show this column
       format = "%Y-%m-%d %I:%M %p", -- format string for timestamp (see `:h os.date()`)
-                                    -- or use a function that takes in the date in seconds and returns a string
+                                    -- or use a function that takes in the date in seconds and returns a string to display
     },
     symlink_target = {
       enabled = false,
@@ -440,7 +440,7 @@ local config = {
         ["."] = "set_root",
         ["[g"] = "prev_git_modified",
         ["]g"] = "next_git_modified",
-        ["i"] = "show_file_details",
+        ["i"] = { "show_file_details", created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" }, -- (see `:h neo-tree-mappings`)
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },
@@ -570,7 +570,7 @@ local config = {
         ["<bs>"] = "navigate_up",
         ["."] = "set_root",
         ["bd"] = "buffer_delete",
-        ["i"] = "show_file_details",
+        ["i"] = { "show_file_details", created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" }, -- (see `:h neo-tree-mappings`)
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },
@@ -591,7 +591,7 @@ local config = {
         ["gc"] = "git_commit",
         ["gp"] = "git_push",
         ["gg"] = "git_commit_and_push",
-        ["i"] = "show_file_details",
+        ["i"] = { "show_file_details", created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" }, -- (see `:h neo-tree-mappings`)
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -572,7 +572,7 @@ local config = {
         ["<bs>"] = "navigate_up",
         ["."] = "set_root",
         ["bd"] = "buffer_delete",
-        ["i"] = { "show_file_details", config = { created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" } }, -- (see `:h neo-tree-mappings`)
+        ["i"] = "show_file_details", -- see `:h neo-tree-file-actions` for options to customize the window.
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },
@@ -593,7 +593,7 @@ local config = {
         ["gc"] = "git_commit",
         ["gp"] = "git_push",
         ["gg"] = "git_commit_and_push",
-        ["i"] = { "show_file_details", config = { created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" } }, -- (see `:h neo-tree-mappings`)
+        ["i"] = "show_file_details", -- see `:h neo-tree-file-actions` for options to customize the window.
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -257,13 +257,13 @@ local config = {
     last_modified = {
       enabled = true,
       required_width = 88, -- min width of window required to show this column
-      format = "%Y-%m-%d %I:%M %p", -- format string for timestamp (see ISO C function `strftime`, `format` parameter)
+      format = "%Y-%m-%d %I:%M %p", -- format string for timestamp (see `:h os.date()`)
                                     -- or use a function that takes in the date in seconds and returns a string
     },
     created = {
       enabled = false,
       required_width = 120, -- min width of window required to show this column
-      format = "%Y-%m-%d %I:%M %p", -- format string for timestamp (see ISO C function `strftime`, `format` parameter)
+      format = "%Y-%m-%d %I:%M %p", -- format string for timestamp (see `:h os.date()`)
                                     -- or use a function that takes in the date in seconds and returns a string
     },
     symlink_target = {

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -259,12 +259,14 @@ local config = {
       required_width = 88, -- min width of window required to show this column
       format = "%Y-%m-%d %I:%M %p", -- format string for timestamp (see `:h os.date()`)
                                     -- or use a function that takes in the date in seconds and returns a string to display
+      --format = require("neo-tree.utils").relative_date, -- enable relative timestamps
     },
     created = {
       enabled = false,
       required_width = 120, -- min width of window required to show this column
       format = "%Y-%m-%d %I:%M %p", -- format string for timestamp (see `:h os.date()`)
                                     -- or use a function that takes in the date in seconds and returns a string to display
+      --format = require("neo-tree.utils").relative_date, -- enable relative timestamps
     },
     symlink_target = {
       enabled = false,

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -440,7 +440,7 @@ local config = {
         ["."] = "set_root",
         ["[g"] = "prev_git_modified",
         ["]g"] = "next_git_modified",
-        ["i"] = { "show_file_details", created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" }, -- (see `:h neo-tree-mappings`)
+        ["i"] = { "show_file_details", config = { created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" } }, -- (see `:h neo-tree-mappings`)
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },
@@ -570,7 +570,7 @@ local config = {
         ["<bs>"] = "navigate_up",
         ["."] = "set_root",
         ["bd"] = "buffer_delete",
-        ["i"] = { "show_file_details", created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" }, -- (see `:h neo-tree-mappings`)
+        ["i"] = { "show_file_details", config = { created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" } }, -- (see `:h neo-tree-mappings`)
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },
@@ -591,7 +591,7 @@ local config = {
         ["gc"] = "git_commit",
         ["gp"] = "git_push",
         ["gg"] = "git_commit_and_push",
-        ["i"] = { "show_file_details", created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" }, -- (see `:h neo-tree-mappings`)
+        ["i"] = { "show_file_details", config = { created_format = "%Y-%m-%d %I:%M %p", modified_format = "%Y-%m-%d %I:%M %p" } }, -- (see `:h neo-tree-mappings`)
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -530,14 +530,16 @@ M.show_file_details = function(state)
     table.insert(left, "Size")
     table.insert(right, utils.human_size(stat.size))
     table.insert(left, "Created")
-    local created_format = require("neo-tree").config.default_component_configs.created.format
+    local created_format = state.config.created_format
+      or require("neo-tree").config.default_component_configs.created.format
     if type(created_format) == "function" then
       table.insert(right, created_format(stat.birthtime.sec))
     else
       table.insert(right, os.date(created_format, stat.birthtime.sec))
     end
     table.insert(left, "Modified")
-    local modified_format = require("neo-tree").config.default_component_configs.last_modified.format
+    local modified_format = state.config.modified_format
+      or require("neo-tree").config.default_component_configs.modified.format
     if type(modified_format) == "function" then
       table.insert(right, modified_format(stat.mtime.sec))
     else

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -530,9 +530,19 @@ M.show_file_details = function(state)
     table.insert(left, "Size")
     table.insert(right, utils.human_size(stat.size))
     table.insert(left, "Created")
-    table.insert(right, os.date("%Y-%m-%d %I:%M %p", stat.birthtime.sec))
+    local created_format = require("neo-tree").config.default_component_configs.created.format
+    if type(created_format) == "function" then
+      table.insert(right, created_format(stat.birthtime.sec))
+    else
+      table.insert(right, os.date(created_format, stat.birthtime.sec))
+    end
     table.insert(left, "Modified")
-    table.insert(right, os.date("%Y-%m-%d %I:%M %p", stat.mtime.sec))
+    local modified_format = require("neo-tree").config.default_component_configs.last_modified.format
+    if type(modified_format) == "function" then
+      table.insert(right, modified_format(stat.mtime.sec))
+    else
+      table.insert(right, os.date(modified_format, stat.mtime.sec))
+    end
   end
 
   local lines = {}

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -512,6 +512,7 @@ M.show_debug_info = function(state)
   print(vim.inspect(state))
 end
 
+local default_filetime_format = "%Y-%m-%d %I:%M %p"
 M.show_file_details = function(state)
   local node = state.tree:get_node()
   if node.type == "message" then
@@ -530,21 +531,11 @@ M.show_file_details = function(state)
     table.insert(left, "Size")
     table.insert(right, utils.human_size(stat.size))
     table.insert(left, "Created")
-    local created_format = state.config.created_format
-      or require("neo-tree").config.default_component_configs.created.format
-    if type(created_format) == "function" then
-      table.insert(right, created_format(stat.birthtime.sec))
-    else
-      table.insert(right, os.date(created_format, stat.birthtime.sec))
-    end
+    local created_format = state.config.created_format or default_filetime_format
+    table.insert(right, utils.date(created_format, stat.birthtime.sec))
     table.insert(left, "Modified")
-    local modified_format = state.config.modified_format
-      or require("neo-tree").config.default_component_configs.modified.format
-    if type(modified_format) == "function" then
-      table.insert(right, modified_format(stat.mtime.sec))
-    else
-      table.insert(right, os.date(modified_format, stat.mtime.sec))
-    end
+    local modified_format = state.config.modified_format or default_filetime_format
+    table.insert(right, utils.date(modified_format, stat.mtime.sec))
   end
 
   local lines = {}

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -518,10 +518,7 @@ local file_time = function(config, node, state, stat_field)
   local stat = utils.get_stat(node)
   local value = stat and stat[stat_field]
   local seconds = value and value.sec or nil
-  local display = "-"
-  if seconds ~= nil then
-    display = utils.date(config.format, seconds)
-  end
+  local display = seconds and utils.date(config.format, seconds) or "-"
 
   return {
     text = vim.fn.printf("%" .. config.width .. "s  ", truncate_string(display, config.width)),

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -457,7 +457,7 @@ M.indent = function(config, node, state)
   return indent
 end
 
-local get_header = function (state, label, size)
+local get_header = function(state, label, size)
   if state.sort and state.sort.label == label then
     local icon = state.sort.direction == 1 and "▲" or "▼"
     size = size - 2
@@ -466,12 +466,12 @@ local get_header = function (state, label, size)
   return string.format("%" .. size .. "s  ", label)
 end
 
-M.file_size = function (config, node, state)
+M.file_size = function(config, node, state)
   -- Root node gets column labels
   if node:get_depth() == 1 then
     return {
       text = get_header(state, "Size", 12),
-      highlight = highlights.FILE_STATS_HEADER
+      highlight = highlights.FILE_STATS_HEADER,
     }
   end
 
@@ -489,7 +489,7 @@ M.file_size = function (config, node, state)
 
   return {
     text = string.format("%12s  ", text),
-    highlight = config.highlight or highlights.FILE_STATS
+    highlight = config.highlight or highlights.FILE_STATS,
   }
 end
 
@@ -504,7 +504,7 @@ local file_time = function(config, node, state, stat_field)
     end
     return {
       text = get_header(state, label, 20),
-      highlight = highlights.FILE_STATS_HEADER
+      highlight = highlights.FILE_STATS_HEADER,
     }
   end
 
@@ -518,7 +518,7 @@ local file_time = function(config, node, state, stat_field)
 
   return {
     text = string.format("%20s  ", display),
-    highlight = config.highlight or highlights.FILE_STATS
+    highlight = config.highlight or highlights.FILE_STATS,
   }
 end
 
@@ -541,19 +541,19 @@ M.symlink_target = function(config, node, state)
   end
 end
 
-M.type = function (config, node, state)
+M.type = function(config, node, state)
   local text = node.ext or node.type
   -- Root node gets column labels
   if node:get_depth() == 1 then
     return {
       text = get_header(state, "Type", 10),
-      highlight = highlights.FILE_STATS_HEADER
+      highlight = highlights.FILE_STATS_HEADER,
     }
   end
 
   return {
     text = string.format("%10s  ", text),
-    highlight = highlights.FILE_STATS
+    highlight = highlights.FILE_STATS,
   }
 end
 

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -511,7 +511,15 @@ local file_time = function(config, node, state, stat_field)
   local stat = utils.get_stat(node)
   local value = stat and stat[stat_field]
   local seconds = value and value.sec or nil
-  local display = seconds and os.date("%Y-%m-%d %I:%M %p", seconds) or "-"
+  local display = "-"
+  if seconds ~= nil then
+    if type(config.format) == "function" then
+      display = config.format(seconds)
+    else
+      display = os.date(config.format, seconds)
+    end
+  end
+
   return {
     text = string.format("%20s  ", display),
     highlight = config.highlight or highlights.FILE_STATS

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -513,11 +513,7 @@ local file_time = function(config, node, state, stat_field)
   local seconds = value and value.sec or nil
   local display = "-"
   if seconds ~= nil then
-    if type(config.format) == "function" then
-      display = config.format(seconds)
-    else
-      display = os.date(config.format, seconds)
-    end
+    display = utils.date(config.format, seconds)
   end
 
   return {

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -220,6 +220,37 @@ M.human_size = function(size)
   return human
 end
 
+---Converts a Unix timestamp into a human readable relative timestamps
+---@param seconds integer
+---@return string
+M.relative_date = function(seconds)
+  local now = os.time()
+  local diff = now - seconds
+
+  local function format(value, unit)
+    return value .. " " .. unit .. (value == 1 and "" or "s") .. " ago"
+  end
+
+  if diff < 60 then
+    return "Just now"
+  elseif diff < 3600 then
+    local minutes = math.floor(diff / 60)
+    return format(minutes, "minute")
+  elseif diff < 86400 then
+    local hours = math.floor(diff / 3600)
+    return format(hours, "hour")
+  elseif diff < 86400 * 30 then
+    local days = math.floor(diff / 86400)
+    return format(days, "day")
+  elseif diff < 86400 * 365 then
+    local months = math.floor(diff / (86400 * 30))
+    return format(months, "month")
+  else
+    local years = math.floor(diff / (86400 * 365))
+    return format(years, "year")
+  end
+end
+
 ---Gets non-zero diagnostics counts for each open file and each ancestor directory.
 ---severity_number and severity_string refer to the highest severity with
 ---non-zero diagnostics count.

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -250,6 +250,8 @@ M.relative_date = function(seconds)
   return format(years, "year")
 end
 
+---@alias neotree.DateFormat string|"relative"|fun(integer):string
+
 ---Formats dates. Supports relative dates as a preset, as well as custom formatting using arbitrary functions.
 ---Used to let users customize date formatting.
 ---
@@ -258,7 +260,7 @@ end
 ---Else, `format` is presumed to be a format string for os.date().
 ---
 ---@see os.date()
----@param format string|"relative"|fun(integer):string How to format `seconds` into a date string.
+---@param format neotree.DateFormat How to format `seconds` into a date string.
 ---@param seconds integer? Seconds since the platform epoch (Unix or otherwise). If nil, will be the current time.
 ---@return string formatted_date A string that represents the date.
 M.date = function(format, seconds)
@@ -273,7 +275,7 @@ M.date = function(format, seconds)
   end
   local formatted_date = os.date(format, seconds)
   if type(formatted_date) ~= "string" then
-    error('[neo-tree]: the format should not make os.date return a table (i.e. not "*t")')
+    error('[neo-tree]: the format should not make os.date return a table (e.g. not "*t")')
   end
   return formatted_date
 end

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -245,10 +245,37 @@ M.relative_date = function(seconds)
   elseif diff < 86400 * 365 then
     local months = math.floor(diff / (86400 * 30))
     return format(months, "month")
-  else
-    local years = math.floor(diff / (86400 * 365))
-    return format(years, "year")
   end
+  local years = math.floor(diff / (86400 * 365))
+  return format(years, "year")
+end
+
+---Formats dates. Supports relative dates as a preset, as well as custom formatting using arbitrary functions.
+---Used to let users customize date formatting.
+---
+---If `format` == "relative", it will use utils.relative_date to format.
+---If `format` is a function, it should return a string for neo-tree to display.
+---Else, `format` is presumed to be a format string for os.date().
+---
+---@see os.date()
+---@param format string|"relative"|fun(integer):string How to format `seconds` into a date string.
+---@param seconds integer? Seconds since the platform epoch (Unix or otherwise). If nil, will be the current time.
+---@return string formatted_date A string that represents the date.
+M.date = function(format, seconds)
+  if not seconds then
+    seconds = os.time()
+  end
+  if format == "relative" then
+    return M.relative_date(seconds)
+  end
+  if type(format) == "function" then
+    return format(seconds)
+  end
+  local formatted_date = os.date(format, seconds)
+  if type(formatted_date) ~= "string" then
+    error('[neo-tree]: the format should not make os.date return a table (i.e. not "*t")')
+  end
+  return formatted_date
 end
 
 ---Gets non-zero diagnostics counts for each open file and each ancestor directory.


### PR DESCRIPTION
I've added a `format` field in the configs for the components `last_modified` and `created` so that users can change the format string used to display timestamps in the file explorer. The field also accepts a function that returns a string so that features like relative timestamps can be implemented. The change is also applied to the file details popup window.

Here's an example setup:

```lua
require("neo-tree").setup({
  default_component_configs = {
    last_modified = {
      enabled = true,
      format = function(seconds)
        local now = os.time()
        local diff = now - seconds

        local function pluralise(value, unit)
          return value .. " " .. unit .. (value == 1 and "" or "s") .. " ago"
        end

        if diff < 60 then
          return "Just now"
        elseif diff < 3600 then
          local minutes = math.floor(diff / 60)
          return pluralise(minutes, "minute")
        elseif diff < 86400 then
          local hours = math.floor(diff / 3600)
          return pluralise(hours, "hour")
        elseif diff < 86400 * 30 then
          local days = math.floor(diff / 86400)
          return pluralise(days, "day")
        elseif diff < 86400 * 365 then
          local months = math.floor(diff / (86400 * 30))
          return pluralise(months, "month")
        else
          local years = math.floor(diff / (86400 * 365))
          return pluralise(years, "year")
        end
      end,
    },
    created = {
      enabled = true,
      format = "%e %b %y at %I:%M %p",
    },
  },
})
```

![File explorer](https://github.com/user-attachments/assets/8c35e1fa-f2a1-4584-af69-3470afd5eaae)
![File details popup window](https://github.com/user-attachments/assets/cce0eda8-c7d5-4d78-a57e-408ef561f00b)

The columns are offset in the image because the the timestamp is longer than the column heading. I'll be opening a separate pull request that deals with that.