### PR TITLE
feat(filesystem): Customisable column width

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,18 +216,22 @@ use {
           -- If you don't want to use these columns, you can set `enabled = false` for each of them individually
           file_size = {
             enabled = true,
+            width = 12, -- width of the column
             required_width = 64, -- min width of window required to show this column
           },
           type = {
             enabled = true,
+            width = 10, -- width of the column
             required_width = 122, -- min width of window required to show this column
           },
           last_modified = {
             enabled = true,
+            width = 20, -- width of the column
             required_width = 88, -- min width of window required to show this column
           },
           created = {
             enabled = true,
+            width = 20, -- width of the column
             required_width = 110, -- min width of window required to show this column
           },
           symlink_target = {

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -248,18 +248,22 @@ local config = {
     -- If you don't want to use these columns, you can set `enabled = false` for each of them individually
     file_size = {
       enabled = true,
+      width = 12, -- width of the column
       required_width = 64, -- min width of window required to show this column
     },
     type = {
       enabled = true,
+      width = 10, -- width of the column
       required_width = 110, -- min width of window required to show this column
     },
     last_modified = {
       enabled = true,
+      width = 20, -- width of the column
       required_width = 88, -- min width of window required to show this column
     },
     created = {
       enabled = false,
+      width = 20, -- width of the column
       required_width = 120, -- min width of window required to show this column
     },
     symlink_target = {

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -457,20 +457,27 @@ M.indent = function(config, node, state)
   return indent
 end
 
+local truncate_string = function(str, max_length)
+  if #str <= max_length then
+    return str
+  end
+  return str:sub(1, max_length - 1) .. "…"
+end
+
 local get_header = function (state, label, size)
   if state.sort and state.sort.label == label then
     local icon = state.sort.direction == 1 and "▲" or "▼"
     size = size - 2
-    return string.format("%" .. size .. "s %s  ", label, icon)
+    return vim.fn.printf("%" .. size .. "s %s  ", truncate_string(label, size), icon)
   end
-  return string.format("%" .. size .. "s  ", label)
+  return vim.fn.printf("%" .. size .. "s  ", truncate_string(label, size))
 end
 
 M.file_size = function (config, node, state)
   -- Root node gets column labels
   if node:get_depth() == 1 then
     return {
-      text = get_header(state, "Size", 12),
+      text = get_header(state, "Size", config.width),
       highlight = highlights.FILE_STATS_HEADER
     }
   end
@@ -488,7 +495,7 @@ M.file_size = function (config, node, state)
   end
 
   return {
-    text = string.format("%12s  ", text),
+    text = vim.fn.printf("%" .. config.width .. "s  ", truncate_string(text, config.width)),
     highlight = config.highlight or highlights.FILE_STATS
   }
 end
@@ -503,7 +510,7 @@ local file_time = function(config, node, state, stat_field)
       label = "Created"
     end
     return {
-      text = get_header(state, label, 20),
+      text = get_header(state, label, config.width),
       highlight = highlights.FILE_STATS_HEADER
     }
   end
@@ -513,7 +520,7 @@ local file_time = function(config, node, state, stat_field)
   local seconds = value and value.sec or nil
   local display = seconds and os.date("%Y-%m-%d %I:%M %p", seconds) or "-"
   return {
-    text = string.format("%20s  ", display),
+    text = vim.fn.printf("%" .. config.width .. "s  ", truncate_string(display, config.width)),
     highlight = config.highlight or highlights.FILE_STATS
   }
 end
@@ -542,13 +549,13 @@ M.type = function (config, node, state)
   -- Root node gets column labels
   if node:get_depth() == 1 then
     return {
-      text = get_header(state, "Type", 10),
+      text = get_header(state, "Type", config.width),
       highlight = highlights.FILE_STATS_HEADER
     }
   end
 
   return {
-    text = string.format("%10s  ", text),
+    text = vim.fn.printf("%" .. config.width .. "s  ", truncate_string(text, config.width)),
     highlight = highlights.FILE_STATS
   }
 end


### PR DESCRIPTION
I've added a `width` field to the configs so that the width of the columns displayed in the file explorer can be customised. Text that are too long are also truncated with `…` to prevent the columns from being offset.

Edit: `vim.fn.printf` is used instead of `string.format` to prevent an error when the width is more than 99.

Demo:
<img width="1022" alt="image" src="https://github.com/user-attachments/assets/e5450829-9320-43ed-a7e2-d4520d242722">

```lua
require("neo-tree").setup({
  default_component_configs = {
    last_modified = {
      width = 10,
    },
    created = {
      enabled = true,
      width = 30,
    },
  },
})
```

This is the fix mentioned in #1614.