### PR TITLE
fix(buffers): Normalize paths for buffers source

### DIFF
--- a/lua/neo-tree/sources/buffers/lib/items.lua
+++ b/lua/neo-tree/sources/buffers/lib/items.lua
@@ -70,9 +70,8 @@ M.get_opened_buffers = function(state)
       add_buffer(b, path)
     else
       if #state.path > 1 then
-        local rootsub = path:sub(1, #state.path)
         -- make sure this is within the root path
-        if utils.normalize_path(rootsub) == utils.normalize_path(state.path) then
+        if utils.is_subpath(state.path, path) then
           add_buffer(b, path)
         end
       else

--- a/lua/neo-tree/sources/buffers/lib/items.lua
+++ b/lua/neo-tree/sources/buffers/lib/items.lua
@@ -72,7 +72,7 @@ M.get_opened_buffers = function(state)
       if #state.path > 1 then
         local rootsub = path:sub(1, #state.path)
         -- make sure this is within the root path
-        if rootsub == state.path then
+        if utils.normalize_path(rootsub) == utils.normalize_path(state.path) then
           add_buffer(b, path)
         end
       else

--- a/lua/neo-tree/sources/common/file-items.lua
+++ b/lua/neo-tree/sources/common/file-items.lua
@@ -93,7 +93,7 @@ end
 local create_item, set_parents
 
 function create_item(context, path, _type, bufnr)
-  local parent_path, name = utils.split_path(path)
+  local parent_path, name = utils.split_path(utils.normalize_path(path))
   local id = path
   if path == "[No Name]" and bufnr then
     parent_path = context.state.path


### PR DESCRIPTION
Firstly, for my first contribution to neo-tree, I would like to thank the neo-tree maintainers for producing an such an awesome piece of software. Neo-tree is an integral part of my experience with Neovim as my daily driver, and an amazing example of the wider Neovim ecosystem. I also thank the maintainers for the opportunity to contribute, and welcome any feedback on my contributions.

----------

Paths should be normalized when: 
- Checking their membership in the root directory, and 
- Acquiring their parent paths 

before adding them to the buffers source.

This PR fixes issue #1617. 