### PR TITLE
fix(container): truncate text by cell width/characters

### DIFF
--- a/lua/neo-tree/sources/common/container.lua
+++ b/lua/neo-tree/sources/common/container.lua
@@ -53,7 +53,7 @@ local render_content = function(config, node, state, context)
   local add_padding = function(rendered_item, should_pad)
     for _, data in ipairs(rendered_item) do
       if data.text then
-        local padding = (should_pad and #data.text and data.text:sub(1, 1) ~= " ") and " " or ""
+        local padding = (should_pad and #data.text > 0 and data.text:sub(1, 1) ~= " ") and " " or ""
         data.text = padding .. data.text
         should_pad = data.text:sub(#data.text) ~= " "
       end
@@ -145,6 +145,7 @@ local truncate_layer_keep_right = function(layer, skip_count, max_length)
   while i > 0 do
     local item = layer[i]
     i = i - 1
+    local width = vim.api.nvim_strwidth
     local text_length = vim.fn.strchars(item.text)
     local remaining_to_skip = skip_count - skipped
     if remaining_to_skip > 0 then
@@ -152,11 +153,11 @@ local truncate_layer_keep_right = function(layer, skip_count, max_length)
         skipped = skipped + text_length
         item.text = ""
       else
-        item.text = vim.fn.strcharpart(item.text, 0, text_length - remaining_to_skip)
-        text_length = vim.fn.strchars(item.text)
+        item.text = utils.truncate_by_cell(item.text, text_length - remaining_to_skip)
+        text_length = width(item.text)
         if text_length + taken > max_length then
-          item.text = vim.fn.strcharpart(item.text, text_length - (max_length - taken))
-          text_length = vim.fn.strchars(item.text)
+          item.text = utils.truncate_by_cell(item.text, max_length - taken)
+          text_length = width(item.text)
         end
         table.insert(result, item)
         taken = taken + text_length
@@ -164,8 +165,8 @@ local truncate_layer_keep_right = function(layer, skip_count, max_length)
       end
     elseif taken <= max_length then
       if text_length + taken > max_length then
-        item.text = vim.fn.strcharpart(item.text, text_length - (max_length - taken))
-        text_length = vim.fn.strchars(item.text)
+        item.text = utils.truncate_by_cell(item.text, max_length - taken)
+        text_length = width(item.text)
       end
       table.insert(result, item)
       taken = taken + text_length

--- a/lua/neo-tree/sources/common/container.lua
+++ b/lua/neo-tree/sources/common/container.lua
@@ -153,10 +153,10 @@ local truncate_layer_keep_right = function(layer, skip_count, max_length)
         skipped = skipped + text_length
         item.text = ""
       else
-        item.text = utils.truncate_by_cell(item.text, text_length - remaining_to_skip)
+        item.text = utils.truncate_by_cell(item.text, text_length - remaining_to_skip, "right")
         text_length = width(item.text)
         if text_length + taken > max_length then
-          item.text = utils.truncate_by_cell(item.text, max_length - taken)
+          item.text = utils.truncate_by_cell(item.text, max_length - taken, "right")
           text_length = width(item.text)
         end
         table.insert(result, item)
@@ -165,7 +165,7 @@ local truncate_layer_keep_right = function(layer, skip_count, max_length)
       end
     elseif taken <= max_length then
       if text_length + taken > max_length then
-        item.text = utils.truncate_by_cell(item.text, max_length - taken)
+        item.text = utils.truncate_by_cell(item.text, max_length - taken, "right")
         text_length = width(item.text)
       end
       table.insert(result, item)

--- a/lua/neo-tree/sources/common/container.lua
+++ b/lua/neo-tree/sources/common/container.lua
@@ -54,7 +54,7 @@ local render_content = function(config, node, state, context)
   local add_padding = function(rendered_item, should_pad)
     for _, data in ipairs(rendered_item) do
       if data.text then
-        local padding = (should_pad and data.text:sub(1, 1) ~= " ") and " " or ""
+        local padding = (should_pad and #data.text > 0 and data.text:sub(1, 1) ~= " ") and " " or ""
         data.text = padding .. data.text
         should_pad = data.text:sub(#data.text) ~= " "
       end
@@ -141,7 +141,7 @@ local truncate_layer_keep_right = function(layer, skip_count, max_width)
   local result = {}
   local taken = 0
   local skipped = 0
-  for i = #layer, 0, -1 do
+  for i = #layer, 1, -1 do
     local item = layer[i]
     local text_width = strwidth(item.text)
     local remaining_to_skip = skip_count - skipped

--- a/lua/neo-tree/sources/common/container.lua
+++ b/lua/neo-tree/sources/common/container.lua
@@ -53,7 +53,7 @@ local render_content = function(config, node, state, context)
   local add_padding = function(rendered_item, should_pad)
     for _, data in ipairs(rendered_item) do
       if data.text then
-        local padding = (should_pad and #data.text > 0 and data.text:sub(1, 1) ~= " ") and " " or ""
+        local padding = (should_pad and data.text:sub(1, 1) ~= " ") and " " or ""
         data.text = padding .. data.text
         should_pad = data.text:sub(#data.text) ~= " "
       end

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -112,7 +112,6 @@ end
 ---@param state table State of the source to close
 ---@param focus_prior_window boolean | nil if true or nil, focus the window that was previously focused
 M.close = function(state, focus_prior_window)
-
   log.debug("Closing window, but saving position first.")
   M.position.save(state)
 

--- a/lua/neo-tree/ui/selector.lua
+++ b/lua/neo-tree/ui/selector.lua
@@ -39,29 +39,6 @@ local sep_tbl = function(sep)
   return sep
 end
 
--- Function below provided by @akinsho
--- https://github.com/nvim-neo-tree/neo-tree.nvim/pull/427#discussion_r924947766
-
--- truncate a string based on number of display columns/cells it occupies
--- so that multibyte characters are not broken up mid-character
----@param str string
----@param col_limit number
----@return string
-local function truncate_by_cell(str, col_limit)
-  local api = vim.api
-  local fn = vim.fn
-  if str and str:len() == api.nvim_strwidth(str) then
-    return fn.strcharpart(str, 0, col_limit)
-  end
-  local short = fn.strcharpart(str, 0, col_limit)
-  if api.nvim_strwidth(short) > col_limit then
-    while api.nvim_strwidth(short) > col_limit do
-      short = fn.strcharpart(short, 0, fn.strchars(short) - 1)
-    end
-  end
-  return short
-end
-
 ---get_separators
 -- Returns information about separator on each tab.
 ---@param source_index integer: index of source
@@ -172,9 +149,9 @@ local text_layout = function(text, content_layout, output_width, trunc_char)
   local left_pad, right_pad = 0, 0
   if pad_length < 0 then
     if output_width < 4 then
-      return truncate_by_cell(text, output_width)
+      return utils.truncate_by_cell(text, output_width)
     else
-      return truncate_by_cell(text, output_width - 1) .. trunc_char
+      return utils.truncate_by_cell(text, output_width - 1) .. trunc_char
     end
   elseif content_layout == "start" then
     left_pad, right_pad = 0, pad_length

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1293,38 +1293,31 @@ M.index_by_path = function(tbl, key)
   return value
 end
 
--- Function below provided by @akinsho
+local width = vim.api.nvim_strwidth
+local slice = vim.fn.slice
+-- Function below provided by @akinsho, modified by @pynappo
 -- https://github.com/nvim-neo-tree/neo-tree.nvim/pull/427#discussion_r924947766
+-- TODO: maybe use vim.stf_utf* functions instead of strchars, once neovim updates enough
 
--- truncate a string based on number of display columns/cells it occupies
+-- Truncate a string based on number of display columns/cells it occupies
 -- so that multibyte characters are not broken up mid-character
 ---@param str string
 ---@param col_limit number
 ---@param align 'left'|'right'|nil
----@return string
+---@return string shortened
 M.truncate_by_cell = function(str, col_limit, align)
-  align = align or "left"
-  local api = vim.api
-  local fn = vim.fn
-  if str and str:len() == api.nvim_strwidth(str) then
-    if align == "left" then
-      return str:sub(1, col_limit)
-    elseif align == "right" then
-      return str:sub(#str - col_limit + 1)
-    end
+  if width(str) >= col_limit then
+    return str
   end
-  local short = fn.strcharpart(str, 0, col_limit)
+  align = align or "left"
+  local short = str
   if align == "left" then
-    if api.nvim_strwidth(short) > col_limit then
-      while api.nvim_strwidth(short) > col_limit do
-        short = fn.strcharpart(short, 0, fn.strchars(short) - 1)
-      end
+    while width(short) > col_limit do
+      short = slice(short, 0, -1)
     end
   elseif align == "right" then
-    if api.nvim_strwidth(short) > col_limit then
-      while api.nvim_strwidth(short) > col_limit do
-        short = fn.strcharpart(short, 1)
-      end
+    while width(short) > col_limit do
+      short = slice(short, 1)
     end
   end
   return short

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1305,9 +1305,11 @@ local slice = vim.fn.slice
 ---@param col_limit number
 ---@param align 'left'|'right'|nil
 ---@return string shortened
+---@return number width
 M.truncate_by_cell = function(str, col_limit, align)
-  if width(str) >= col_limit then
-    return str
+  local w = width(str)
+  if w <= col_limit then
+    return str, w
   end
   align = align or "left"
   local short = str
@@ -1320,7 +1322,7 @@ M.truncate_by_cell = function(str, col_limit, align)
       short = slice(short, 1)
     end
   end
-  return short
+  return short, width(short)
 end
 
 return M

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1293,4 +1293,41 @@ M.index_by_path = function(tbl, key)
   return value
 end
 
+-- Function below provided by @akinsho
+-- https://github.com/nvim-neo-tree/neo-tree.nvim/pull/427#discussion_r924947766
+
+-- truncate a string based on number of display columns/cells it occupies
+-- so that multibyte characters are not broken up mid-character
+---@param str string
+---@param col_limit number
+---@param align 'left'|'right'
+---@return string
+M.truncate_by_cell = function(str, col_limit, align)
+  align = align or "left"
+  local api = vim.api
+  local fn = vim.fn
+  if str and str:len() == api.nvim_strwidth(str) then
+    if align == "left" then
+      return str:sub(1, col_limit)
+    elseif align == "right" then
+      return str:sub(#str - col_limit + 1)
+    end
+  end
+  local short = fn.strcharpart(str, 0, col_limit)
+  if align == "left" then
+    if api.nvim_strwidth(short) > col_limit then
+      while api.nvim_strwidth(short) > col_limit do
+        short = fn.strcharpart(short, 0, fn.strchars(short) - 1)
+      end
+    end
+  elseif align == "right" then
+    if api.nvim_strwidth(short) > col_limit then
+      while api.nvim_strwidth(short) > col_limit do
+        short = fn.strcharpart(short, 1)
+      end
+    end
+  end
+  return short
+end
+
 return M

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1307,19 +1307,20 @@ local slice = vim.fn.slice
 ---@return string shortened
 ---@return number width
 M.truncate_by_cell = function(str, col_limit, align)
-  local w = strwidth(str)
-  if w <= col_limit then
-    return str, w
+  local width = strwidth(str)
+  if width <= col_limit then
+    return str, width
   end
-  align = align or "left"
   local short = str
-  if align == "left" then
-    while strwidth(short) > col_limit do
-      short = slice(short, 0, -1)
-    end
-  elseif align == "right" then
+  if align == "right" then
+    short = slice(short, 1)
     while strwidth(short) > col_limit do
       short = slice(short, 1)
+    end
+  else
+    short = slice(short, 0, -1)
+    while strwidth(short) > col_limit do
+      short = slice(short, 0, -1)
     end
   end
   return short, strwidth(short)

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1293,7 +1293,7 @@ M.index_by_path = function(tbl, key)
   return value
 end
 
-local width = vim.api.nvim_strwidth
+local strwidth = vim.api.nvim_strwidth
 local slice = vim.fn.slice
 -- Function below provided by @akinsho, modified by @pynappo
 -- https://github.com/nvim-neo-tree/neo-tree.nvim/pull/427#discussion_r924947766
@@ -1307,22 +1307,22 @@ local slice = vim.fn.slice
 ---@return string shortened
 ---@return number width
 M.truncate_by_cell = function(str, col_limit, align)
-  local w = width(str)
+  local w = strwidth(str)
   if w <= col_limit then
     return str, w
   end
   align = align or "left"
   local short = str
   if align == "left" then
-    while width(short) > col_limit do
+    while strwidth(short) > col_limit do
       short = slice(short, 0, -1)
     end
   elseif align == "right" then
-    while width(short) > col_limit do
+    while strwidth(short) > col_limit do
       short = slice(short, 1)
     end
   end
-  return short, width(short)
+  return short, strwidth(short)
 end
 
 return M

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1300,7 +1300,7 @@ end
 -- so that multibyte characters are not broken up mid-character
 ---@param str string
 ---@param col_limit number
----@param align 'left'|'right'
+---@param align 'left'|'right'|nil
 ---@return string
 M.truncate_by_cell = function(str, col_limit, align)
   align = align or "left"


### PR DESCRIPTION
Fixes #1619.

## Current neo-tree behavior:

![image](https://github.com/user-attachments/assets/d2a24f79-87c3-4f56-a2bb-cb517968d19b)

- missing right side git status symbol for the middle file
- truncation is mid-character for the bottom file

## With this PR:

![image](https://github.com/user-attachments/assets/8e7a3626-91df-4d79-b329-2d411e1d7bd7)

## remaining issues (for future PRs?):

- Fading isn't great on non-ascii:

![image](https://github.com/user-attachments/assets/d523eacc-0c6b-44b7-ba96-13fd56ce03bf)

- Looks like padding needs to be added for wide characters:

![image](https://github.com/user-attachments/assets/632f6b1b-8c4f-4ead-b790-8e6f9794d9e4)

Also idk if this is an issue with this PR or neo-tree (might just be exacerbated due to the more intensive truncation), but changing the width repeatedly, really quickly, seems to cause the neo-tree window to scroll horizontally?

![image](https://github.com/user-attachments/assets/07a8d6c8-0ad9-40da-830b-9fa6819e9206)

tagging @Emptyfruit if they'd like to test this out.