### PR TITLE
feat: add open_files_using_relative_paths option

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ use {
         enable_git_status = true,
         enable_diagnostics = true,
         open_files_do_not_replace_types = { "terminal", "trouble", "qf" }, -- when opening files, do not use windows containing these filetypes or buftypes
+        open_files_using_relative_paths = false,
         sort_case_insensitive = false, -- used when sorting files and directories in the tree
         sort_function = nil , -- use a custom function for sorting files and directories in the tree 
         -- sort_function = function (a,b)

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -34,7 +34,7 @@ local config = {
   log_to_file = false, -- true, false, "/path/to/file.log", use :NeoTreeLogs to show the file
   open_files_in_last_window = true, -- false = open files in top left window
   open_files_do_not_replace_types = { "terminal", "Trouble", "qf", "edgy" }, -- when opening files, do not use windows containing these filetypes or buftypes
-  open_file_with_relative = false, -- true = open file with relative path
+  open_files_using_relative_paths = false,
   -- popup_border_style is for input and confirmation dialogs.
   -- Configurtaion of floating window is done in the individual source sections.
   -- "NC" is a special style that works well with NormalNC set

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -34,6 +34,7 @@ local config = {
   log_to_file = false, -- true, false, "/path/to/file.log", use :NeoTreeLogs to show the file
   open_files_in_last_window = true, -- false = open files in top left window
   open_files_do_not_replace_types = { "terminal", "Trouble", "qf", "edgy" }, -- when opening files, do not use windows containing these filetypes or buftypes
+  open_file_with_relative = false, -- true = open file with relative path
   -- popup_border_style is for input and confirmation dialogs.
   -- Configurtaion of floating window is done in the individual source sections.
   -- "NC" is a special style that works well with NormalNC set

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -730,7 +730,7 @@ local open_with_cmd = function(state, open_cmd, toggle_directory, open_file)
     if type(open_file) == "function" then
       open_file(state, path, open_cmd, bufnr)
     else
-      utils.open_file(state, path, open_cmd, bufnr, require('neo-tree').config.open_file_with_relative)
+      utils.open_file(state, path, open_cmd, bufnr)
     end
     local extra = node.extra or {}
     local pos = extra.position or extra.end_position

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -730,7 +730,7 @@ local open_with_cmd = function(state, open_cmd, toggle_directory, open_file)
     if type(open_file) == "function" then
       open_file(state, path, open_cmd, bufnr)
     else
-      utils.open_file(state, path, open_cmd, bufnr)
+      utils.open_file(state, path, open_cmd, bufnr, require('neo-tree').config.open_file_with_relative)
     end
     local extra = node.extra or {}
     local pos = extra.position or extra.end_position

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -689,7 +689,7 @@ end
 ---@param path string The file to open
 ---@param open_cmd string? The vimcommand to use to open the file
 ---@param bufnr number|nil The buffer number to open
-M.open_file = function(state, path, open_cmd, bufnr, relative)
+M.open_file = function(state, path, open_cmd, bufnr)
   open_cmd = open_cmd or "edit"
   -- If the file is already open, switch to it.
   bufnr = bufnr or M.find_buffer_by_name(path)
@@ -707,7 +707,8 @@ M.open_file = function(state, path, open_cmd, bufnr, relative)
   end
 
   if M.truthy(path) then
-    local escaped_path = M.escape_path_for_cmd(relative and vim.fn.fnamemodify(path, ':.') or path)
+    local relative = require("neo-tree").config.open_files_using_relative_paths
+    local escaped_path = M.escape_path_for_cmd(relative and vim.fn.fnamemodify(path, ":.") or path)
     local bufnr_or_path = bufnr or escaped_path
     local events = require("neo-tree.events")
     local result = true

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -689,7 +689,7 @@ end
 ---@param path string The file to open
 ---@param open_cmd string? The vimcommand to use to open the file
 ---@param bufnr number|nil The buffer number to open
-M.open_file = function(state, path, open_cmd, bufnr)
+M.open_file = function(state, path, open_cmd, bufnr, relative)
   open_cmd = open_cmd or "edit"
   -- If the file is already open, switch to it.
   bufnr = bufnr or M.find_buffer_by_name(path)
@@ -707,7 +707,7 @@ M.open_file = function(state, path, open_cmd, bufnr)
   end
 
   if M.truthy(path) then
-    local escaped_path = M.escape_path_for_cmd(path)
+    local escaped_path = M.escape_path_for_cmd(relative and vim.fn.fnamemodify(path, ':.') or path)
     local bufnr_or_path = bufnr or escaped_path
     local events = require("neo-tree.events")
     local result = true


### PR DESCRIPTION
fix https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1561

Both NvimTree and NERDTree open files with relative paths by default.