### PR TITLE
fix(lsp): prefer `get_clients` over `get_active_clients`

### DIFF
--- a/lua/neo-tree/sources/document_symbols/lib/symbols_utils.lua
+++ b/lua/neo-tree/sources/document_symbols/lib/symbols_utils.lua
@@ -164,13 +164,15 @@ local on_lsp_resp = function(lsp_resp, state)
   renderer.show_nodes(items, state)
 end
 
+-- latter is deprecated in neovim v0.11
+local get_clients = vim.lsp.get_clients or vim.lsp.get_active_clients
 M.render_symbols = function(state)
   local bufnr = state.lsp_bufnr
   local bufname = state.path
 
   -- if no client found, terminate
   local client_found = false
-  for _, client in pairs(vim.lsp.get_active_clients({ bufnr = bufnr })) do
+  for _, client in pairs(get_clients({ bufnr = bufnr })) do
     if client.server_capabilities.documentSymbolProvider then
       client_found = true
       break


### PR DESCRIPTION
The former is only available in v0.10 upwards and i believe neo-tree still supports neovim v0.9. but to prevent deprecation warnings we should prefer the former over the latter when possible.

Closes #1551.