### PR TITLE
fix(command): allow reveal_file to be used with dir

### DIFF
--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -210,19 +210,26 @@ handle_reveal = function(args, state)
   -- Deal with cwd if we need to
   local cwd = state.path
   local path = args.reveal_file
+  local dir = args.dir
   if cwd == nil then
     cwd = manager.get_cwd(state)
   end
+
+  if dir == nil then
+    dir, _ = utils.split_path(path)
+  elseif not utils.is_subpath(dir, path) then
+    error(string.format('%s is not a subpath of %s', path, args.dir))
+  end
+
   if args.reveal_force_cwd and not utils.is_subpath(cwd, path) then
-    args.dir, _ = utils.split_path(path)
+    args.dir = dir
     do_show_or_focus(args, state, true)
     return
   elseif not utils.is_subpath(cwd, path) then
     -- force was not specified, so we need to ask the user
-    cwd, _ = utils.split_path(path)
-    inputs.confirm("File not in cwd. Change cwd to " .. cwd .. "?", function(response)
+    inputs.confirm("File not in cwd. Change cwd to " .. dir .. "?", function(response)
       if response == true then
-        args.dir = cwd
+        args.dir = dir
       else
         args.reveal_file = nil
       end

--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -207,12 +207,19 @@ do_show_or_focus = function(args, state, force_navigate)
 end
 
 handle_reveal = function(args, state)
+  if args.dir then
+    if not utils.is_subpath(args.dir, args.reveal_file) then
+      args.reveal_file = nil
+    end
+    do_show_or_focus(args, state, true)
+    return
+  end
+
   -- Deal with cwd if we need to
   local cwd = state.path or manager.get_cwd(state)
-  local dir = args.dir or cwd
-
+  local dir = cwd
   if not utils.is_subpath(dir, args.reveal_file) then
-    dir, _ = utils.split_path(args.reveal_file)
+    dir, _ = utils.split_path(args.reveal_file) --[[@as string]]
   end
 
   if args.reveal_force_cwd or utils.is_subpath(cwd, args.reveal_file) then

--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -209,30 +209,27 @@ end
 handle_reveal = function(args, state)
   -- Deal with cwd if we need to
   local cwd = state.path or manager.get_cwd(state)
-  local path = args.reveal_file
   local dir = args.dir or cwd
 
-  if not utils.is_subpath(dir, path) then
-    dir, _ = utils.split_path(path)
+  if not utils.is_subpath(dir, args.reveal_file) then
+    dir, _ = utils.split_path(args.reveal_file)
   end
 
-  if args.reveal_force_cwd and not utils.is_subpath(cwd, path) then
+  if args.reveal_force_cwd or utils.is_subpath(cwd, args.reveal_file) then
     args.dir = dir
     do_show_or_focus(args, state, true)
     return
-  elseif not utils.is_subpath(cwd, path) then
-    -- force was not specified, so we need to ask the user
-    inputs.confirm("File not in cwd. Change cwd to " .. dir .. "?", function(response)
-      if response == true then
-        args.dir = dir
-      else
-        args.reveal_file = nil
-      end
-      do_show_or_focus(args, state, true)
-    end)
-    return
-  else
-    do_show_or_focus(args, state, true)
   end
+
+  -- force was not specified and the file does not belong to cwd, so we need to ask the user
+  inputs.confirm("File not in cwd. Change cwd to " .. dir .. "?", function(response)
+    if response == true then
+      args.dir = dir
+    else
+      args.reveal_file = nil
+    end
+    do_show_or_focus(args, state, true)
+  end)
 end
+
 return M

--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -208,17 +208,12 @@ end
 
 handle_reveal = function(args, state)
   -- Deal with cwd if we need to
-  local cwd = state.path
+  local cwd = state.path or manager.get_cwd(state)
   local path = args.reveal_file
-  local dir = args.dir
-  if cwd == nil then
-    cwd = manager.get_cwd(state)
-  end
+  local dir = args.dir or cwd
 
-  if dir == nil then
+  if not utils.is_subpath(dir, path) then
     dir, _ = utils.split_path(path)
-  elseif not utils.is_subpath(dir, path) then
-    error(string.format('%s is not a subpath of %s', path, args.dir))
   end
 
   if args.reveal_force_cwd and not utils.is_subpath(cwd, path) then


### PR DESCRIPTION
This PR changes the behaviour of the command when used with `dir` option.
With this change the root/cwd will be set to `dir` if the revealing file is a children of the `dir`, otherwise the root/cwd will be set to the directory of the revealing file.

related PR/issues:
https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1500
https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1501