### PR TITLE
fix(preview): stop preview from moving floating tree

### DIFF
--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -33,7 +33,7 @@ local function create_floating_preview_window(state)
   elseif state.current_position == "float" then
     local pos = vim.api.nvim_win_get_position(state.winid)
     -- preview will be same height and top as tree
-    row = pos[1] - 1
+    row = pos[1]
     height = winheight
 
     -- tree and preview window will be side by side and centered in the editor


### PR DESCRIPTION
Fixes half of #514 - at least the "moving up" part.

It seems that the added `-1` here was exactly what moved the floating window by 1 each time a preview window was created. Seems to work correctly without it in float and non-float mode.

To check, set neo tree to float and toggle preview on a file several times with and without this fix.