### PR TITLE
fix(utils): handle edge case for `is_subpath`

### DIFF
--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -883,11 +883,12 @@ M.is_subpath = function(base, path)
   base = M.normalize_path(base)
   path = M.normalize_path(path)
   if path:sub(1, #base) == base then
-    local base_parent, base_tail = M.split_path(base)
-    local path_parent, path_tail = M.split_path(path)
-    -- edge case of /a/b vs /a/bbbb
-    if path_parent == base_parent then
-      return path_tail == base_tail
+    local base_parts = M.split(base, M.path_separator)
+    local path_parts = M.split(path, M.path_separator)
+    for i, part in ipairs(base_parts) do
+      if path_parts[i] ~= part then
+        return false
+      end
     end
     return true
   end

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -862,7 +862,7 @@ M.normalize_path = function(path)
     path = path:sub(1, 1):upper() .. path:sub(2)
     -- Turn mixed forward and back slashes into all forward slashes
     -- using NeoVim's logic
-    path = vim.fs.normalize(path)
+    path = vim.fs.normalize(path, { win = true })
     -- Now use backslashes, as expected by the rest of Neo-Tree's code
     path = path:gsub("/", M.path_separator)
   end
@@ -879,12 +879,19 @@ M.is_subpath = function(base, path)
   elseif base == path then
     return true
   end
+
   base = M.normalize_path(base)
   path = M.normalize_path(path)
-  if base:match("^.*()/") and path:match("^.*()/") then
-    return base == path
+  if path:sub(1, #base) == base then
+    local base_parent, base_tail = M.split_path(base)
+    local path_parent, path_tail = M.split_path(path)
+    -- edge case of /a/b vs /a/bbbb
+    if path_parent == base_parent then
+      return path_tail == base_tail
+    end
+    return true
   end
-  return string.sub(path, 1, string.len(base)) == base
+  return false
 end
 
 ---The file system path separator for the current platform.

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -870,9 +870,9 @@ M.normalize_path = function(path)
 end
 
 ---Check if a path is a subpath of another.
---@param base string The base path.
---@param path string The path to check is a subpath.
---@return boolean boolean True if it is a subpath, false otherwise.
+---@param base string The base path.
+---@param path string The path to check is a subpath.
+---@return boolean boolean True if it is a subpath, false otherwise.
 M.is_subpath = function(base, path)
   if not M.truthy(base) or not M.truthy(path) then
     return false

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -881,6 +881,9 @@ M.is_subpath = function(base, path)
   end
   base = M.normalize_path(base)
   path = M.normalize_path(path)
+  if base:match("^.*()/") and path:match("^.*()/") then
+    return base == path
+  end
   return string.sub(path, 1, string.len(base)) == base
 end
 

--- a/tests/neo-tree/utils/path_spec.lua
+++ b/tests/neo-tree/utils/path_spec.lua
@@ -36,6 +36,7 @@ describe("is_subpath", function()
     utils.is_windows = true
     common_tests()
     assert.are.same(true, utils.is_subpath("C:", "C:"))
+    assert.are.same(false, utils.is_subpath("C:", "D:"))
     assert.are.same(true, utils.is_subpath("C:/A", [[C:\A]]))
 
     -- Test Windows paths with backslashes

--- a/tests/neo-tree/utils/path_spec.lua
+++ b/tests/neo-tree/utils/path_spec.lua
@@ -1,0 +1,65 @@
+pcall(require, "luacov")
+local utils = require("neo-tree.utils")
+
+describe("is_subpath", function()
+  local common_tests = function()
+    -- Relative paths
+    assert.are.same(true, utils.is_subpath("a", "a/subpath"))
+    assert.are.same(false, utils.is_subpath("a", "b/c"))
+    assert.are.same(false, utils.is_subpath("a", "b"))
+  end
+  it("should work with unix paths", function()
+    local old = utils.is_windows
+    utils.is_windows = false
+    common_tests()
+    assert.are.same(true, utils.is_subpath("/a", "/a/subpath"))
+    assert.are.same(false, utils.is_subpath("/a", "/b/c"))
+
+    -- Edge cases
+    assert.are.same(false, utils.is_subpath("", ""))
+    assert.are.same(true, utils.is_subpath("/", "/"))
+
+    -- Paths with trailing slashes
+    assert.are.same(true, utils.is_subpath("/a/", "/a/subpath"))
+    assert.are.same(true, utils.is_subpath("/a/", "/a/subpath/"))
+    assert.are.same(true, utils.is_subpath("/a", "/a/subpath"))
+    assert.are.same(true, utils.is_subpath("/a", "/a/subpath/"))
+
+    -- Paths with different casing
+    assert.are.same(true, utils.is_subpath("/TeSt", "/TeSt/subpath"))
+    assert.are.same(false, utils.is_subpath("/A", "/a/subpath"))
+    assert.are.same(false, utils.is_subpath("/A", "/a/subpath"))
+    utils.is_windows = old
+  end)
+  it("should work on windows paths", function()
+    local old = utils.is_windows
+    utils.is_windows = true
+    common_tests()
+    assert.are.same(true, utils.is_subpath("C:", "C:"))
+    assert.are.same(true, utils.is_subpath("C:/A", [[C:\A]]))
+
+    -- Test Windows paths with backslashes
+    assert.are.same(true, utils.is_subpath([[C:\Users\user]], [[C:\Users\user\Documents]]))
+    assert.are.same(false, utils.is_subpath([[C:\Users\user]], [[D:\Users\user]]))
+    assert.are.same(false, utils.is_subpath([[C:\Users\user]], [[C:\Users\usera]]))
+
+    -- Test Windows paths with forward slashes
+    assert.are.same(true, utils.is_subpath("C:/Users/user", "C:/Users/user/Documents"))
+    assert.are.same(false, utils.is_subpath("C:/Users/user", "D:/Users/user"))
+    assert.are.same(false, utils.is_subpath("C:/Users/user", "C:/Users/usera"))
+
+    -- Test Windows paths with drive letters
+    assert.are.same(true, utils.is_subpath("C:", "C:/Users/user"))
+    assert.are.same(false, utils.is_subpath("C:", "D:/Users/user"))
+
+    -- Test Windows paths with UNC paths
+    assert.are.same(true, utils.is_subpath([[\\server\share]], [[\\server\share\folder]]))
+    assert.are.same(false, utils.is_subpath([[\\server\share]], [[\\server2\share]]))
+
+    -- Test Windows paths with trailing backslashes
+    assert.are.same(true, utils.is_subpath([[C:\Users\user\]], [[C:\Users\user\Documents]]))
+    assert.are.same(true, utils.is_subpath("C:/Users/user/", "C:/Users/user/Documents"))
+
+    utils.is_windows = old
+  end)
+end)


### PR DESCRIPTION
I noticed that when I renamed a file in neo-tree some of my opened buffers got changed weirdly. I tracked this to the is_subpath function.
The problem is with the following example
```
/home/user/project/file
/home/user/project/file_for_example
```
These paths would be matched as a correct subpath, even though they aren't.

I added a simple check I believe fixes this issue