### PR TITLE
fix(help): clamp help window size on VimResized

### DIFF
--- a/lua/neo-tree/sources/common/help.lua
+++ b/lua/neo-tree/sources/common/help.lua
@@ -96,7 +96,7 @@ M.show = function(state, title, prefix_key)
 
   ---@return integer lines The number of screen lines that the popup should occupy at most
   local popup_max_height = function()
-    -- statuscolumn
+    -- statusline
     local statusline_lines = 0
     local laststatus = vim.o.laststatus
     if laststatus ~= 0 then


### PR DESCRIPTION
Fixes #931 

Before:
![image](https://github.com/user-attachments/assets/e42a3ecd-69c7-415a-b7ae-73de360ab04a)

After:
![image](https://github.com/user-attachments/assets/dd735e66-b1a1-4284-bf12-c4e46be94e00)
