### PR TITLE
fix(setup): defer merging config until needed

### DIFF
--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -1,6 +1,4 @@
 local vim = vim
-local utils = require("neo-tree.utils")
-local log = require("neo-tree.log")
 local M = {}
 
 -- DEPRECATED: to be removed in a future release, use this instead:
@@ -11,13 +9,18 @@ M.close_all = function()
   require("neo-tree.command").execute({ action = "close" })
 end
 
+local new_user_config = nil
+
+---Updates the config of neo-tree using the latest user config passed through setup, if any.
 M.ensure_config = function()
-  if not M.config then
-    M.setup({ log_to_file = false }, true)
+  if not M.config or new_user_config then
+    M.config = require("neo-tree.setup").merge_config(new_user_config)
+    new_user_config = nil
   end
 end
 
 M.get_prior_window = function(ignore_filetypes, ignore_winfixbuf)
+  local utils = require("neo-tree.utils")
   ignore_filetypes = ignore_filetypes or {}
   local ignore = utils.list_to_dict(ignore_filetypes)
   ignore["neo-tree"] = true
@@ -47,6 +50,7 @@ M.get_prior_window = function(ignore_filetypes, ignore_winfixbuf)
 end
 
 M.paste_default_config = function()
+  local utils = require("neo-tree.utils")
   local base_path = debug.getinfo(utils.truthy).source:match("@(.*)/utils/init.lua$")
   local config_path = base_path .. utils.path_separator .. "defaults.lua"
   local lines = vim.fn.readfile(config_path)
@@ -70,20 +74,25 @@ M.paste_default_config = function()
 end
 
 M.set_log_level = function(level)
-  log.set_level(level)
+  require("neo-tree.log").set_level(level)
 end
 
-M.setup = function(config, is_auto_config)
-  M.config = require("neo-tree.setup").merge_config(config, is_auto_config)
-  local netrw = require("neo-tree.setup.netrw")
-  if not is_auto_config and netrw.get_hijack_netrw_behavior() ~= "disabled" then
-    vim.cmd("silent! autocmd! FileExplorer *")
-    netrw.hijack()
+M.setup = function(config)
+  -- merging is deferred until ensure_config
+  new_user_config = config
+  if vim.v.vim_did_enter == 1 then
+    M.ensure_config()
+    local netrw = require("neo-tree.setup.netrw")
+    if netrw.get_hijack_behavior() ~= "disabled" then
+      vim.cmd("silent! autocmd! FileExplorer *")
+      -- if first buffer is a directory, then hijack
+      netrw.hijack()
+    end
   end
 end
 
 M.show_logs = function()
-  vim.cmd("tabnew " .. log.outfile)
+  vim.cmd("tabnew " .. require("neo-tree.log").outfile)
 end
 
 return M

--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -80,15 +80,6 @@ end
 M.setup = function(config)
   -- merging is deferred until ensure_config
   new_user_config = config
-  if vim.v.vim_did_enter == 1 then
-    M.ensure_config()
-    local netrw = require("neo-tree.setup.netrw")
-    if netrw.get_hijack_behavior() ~= "disabled" then
-      vim.cmd("silent! autocmd! FileExplorer *")
-      -- if first buffer is a directory, then hijack
-      netrw.hijack()
-    end
-  end
 end
 
 M.show_logs = function()

--- a/lua/neo-tree/command/completion.lua
+++ b/lua/neo-tree/command/completion.lua
@@ -87,9 +87,9 @@ M.complete_args = function(argLead, cmdLine)
       return get_ref_completions(key .. "=")
     elseif arg_type == parser.LIST then
       local valid_values = parser.arguments[key].values
-      if valid_values and not parsed[key] then
+      if valid_values and not (parsed[key] and #parsed[key] > 0) then
         for _, vv in ipairs(valid_values) do
-          if vv:find(value) then
+          if vv:find(value, 1, true) then
             table.insert(candidates, key .. "=" .. vv)
           end
         end

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -470,7 +470,7 @@ local merge_renderers = function(default_config, source_default_config, user_con
   end
 end
 
-M.merge_config = function(user_config, is_auto_config)
+M.merge_config = function(user_config)
   local default_config = vim.deepcopy(defaults)
   user_config = vim.deepcopy(user_config or {})
 

--- a/lua/neo-tree/setup/netrw.lua
+++ b/lua/neo-tree/setup/netrw.lua
@@ -1,17 +1,14 @@
+local nt = require("neo-tree")
 local utils = require("neo-tree.utils")
-local log = require("neo-tree.log")
-local manager = require("neo-tree.sources.manager")
-local command = require("neo-tree.command")
 local M = {}
 
 local get_position = function(source_name)
-  local nt = require("neo-tree")
   local pos = utils.get_value(nt.config, source_name .. ".window.position", "left", true)
   return pos
 end
 
-M.get_hijack_netrw_behavior = function()
-  local nt = require("neo-tree")
+M.get_hijack_behavior = function()
+  nt.ensure_config()
   local option = "filesystem.hijack_netrw_behavior"
   local hijack_behavior = utils.get_value(nt.config, option, "open_default", true)
   if hijack_behavior == "disabled" then
@@ -21,13 +18,16 @@ M.get_hijack_netrw_behavior = function()
   elseif hijack_behavior == "open_current" then
     return hijack_behavior
   else
-    log.error("Invalid value for " .. option .. ": " .. hijack_behavior)
+    require("neo-tree.log").error("Invalid value for " .. option .. ": " .. hijack_behavior)
     return "disabled"
   end
 end
 
+---@return boolean hijacked Whether the hijack was successful
 M.hijack = function()
-  local hijack_behavior = M.get_hijack_netrw_behavior()
+  local manager = require("neo-tree.sources.manager")
+  local log = require("neo-tree.log")
+  local hijack_behavior = M.get_hijack_behavior()
   if hijack_behavior == "disabled" then
     return false
   end

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1,6 +1,4 @@
-local vim = vim
 local log = require("neo-tree.log")
-local filesize = require("neo-tree.utils.filesize.filesize")
 local bit = require("bit")
 local ffi_available, ffi = pcall(require, "ffi")
 
@@ -215,7 +213,7 @@ end
 ---@param size any
 ---@return string
 M.human_size = function(size)
-  local human = filesize(size, { output = "string" })
+  local human = require("neo-tree.utils.filesize.filesize")(size, { output = "string" })
   ---@cast human string
   return human
 end

--- a/plugin/neo-tree.lua
+++ b/plugin/neo-tree.lua
@@ -11,4 +11,42 @@ end, {
   end,
 })
 
+---@return boolean hijacked whether the hijack worked
+local function try_netrw_hijack()
+  require("neo-tree").ensure_config()
+  local netrw = require("neo-tree.setup.netrw")
+  if netrw.get_hijack_behavior() ~= "disabled" then
+    vim.cmd("silent! autocmd! FileExplorer *")
+    return netrw.hijack()
+  end
+  return false
+end
+
+---@param path string The path to check1
+---@return boolean is_directory Whether it's a directory
+local is_directory = function(path)
+  if not path or #path == 0 then
+    return false
+  end
+  local stats = (vim.uv or vim.loop).fs_stat(path)
+  return stats and stats.type == "directory" or false
+end
+if
+  is_directory(vim.fn.argv(0) --[[@as string]])
+then
+  -- currently needed to work around configs that already lazy-load neo-tree (e.g. lazyvim)
+  try_netrw_hijack()
+else
+  local augroup = vim.api.nvim_create_augroup("NeoTree_NetrwDeferred", { clear = true })
+  vim.api.nvim_create_autocmd("BufEnter", {
+    group = augroup,
+    callback = function(args)
+      if is_directory(args.file) then
+        try_netrw_hijack()
+        vim.api.nvim_del_augroup_by_id(augroup)
+      end
+    end,
+  })
+end
+
 vim.g.loaded_neo_tree = 1

--- a/plugin/neo-tree.lua
+++ b/plugin/neo-tree.lua
@@ -1,0 +1,14 @@
+if vim.g.loaded_neo_tree == 1 or vim.g.loaded_neo_tree == true then
+  return
+end
+
+vim.api.nvim_create_user_command("Neotree", function(ctx)
+  require("neo-tree.command")._command(unpack(ctx.fargs))
+end, {
+  nargs = "*",
+  complete = function(argLead, cmdLine)
+    require("neo-tree.command").complete_args(argLead, cmdLine)
+  end,
+})
+
+vim.g.loaded_neo_tree = 1

--- a/plugin/neo-tree.lua
+++ b/plugin/neo-tree.lua
@@ -2,13 +2,12 @@ if vim.g.loaded_neo_tree == 1 or vim.g.loaded_neo_tree == true then
   return
 end
 
+-- Possibly convert this to lua using customlist instead of custom in the future?
 vim.api.nvim_create_user_command("Neotree", function(ctx)
   require("neo-tree.command")._command(unpack(ctx.fargs))
 end, {
   nargs = "*",
-  complete = function(argLead, cmdLine)
-    require("neo-tree.command").complete_args(argLead, cmdLine)
-  end,
+  complete = "custom,v:lua.require'neo-tree.command'.complete_args",
 })
 
 ---@param path string? The path to check

--- a/plugin/neo-tree.vim
+++ b/plugin/neo-tree.vim
@@ -1,8 +1,0 @@
-if exists('g:loaded_neo_tree')
-  finish
-endif
-
-command! -nargs=* -complete=custom,v:lua.require'neo-tree.command'.complete_args
-            \ Neotree lua require("neo-tree.command")._command(<f-args>)
-
-let g:loaded_neo_tree = 1

--- a/tests/mininit.lua
+++ b/tests/mininit.lua
@@ -21,10 +21,8 @@ vim.cmd([[
 vim.opt.swapfile = false
 
 vim.cmd([[
-  runtime plugin/neo-tree.vim
+  runtime plugin/neo-tree.lua
 ]])
 
 -- For debugging
-P = function(...)
-  print(unpack(vim.tbl_map(vim.inspect, { ... })))
-end
+P = vim.print

--- a/tests/utils/init.lua
+++ b/tests/utils/init.lua
@@ -93,13 +93,13 @@ end
 ---@param linenr_end? integer (1-indexed, inclusive)
 function mod.assert_buf_lines(bufnr, lines, linenr_start, linenr_end)
   mod.eq(
+    lines,
     vim.api.nvim_buf_get_lines(
       bufnr,
       linenr_start and linenr_start - 1 or 0,
       linenr_end or -1,
       false
-    ),
-    lines
+    )
   )
 end
 


### PR DESCRIPTION
neo-tree has a ton of configuration, so sometimes merging the config table takes a significant portion of startup time. This leads to people lazy-loading neo-tree which sometimes causes issues to be filed, mostly with netrw hijacking. This PR defers the merging until:

- When netrw may need to be hijacked
- `:Neotree` command parsing/execution

On my machine, this reduces startuptime to ~2-3ms when it was previously ~30ms.

Some precautions are taken to prevent breaking people's setups who already lazy-load neo-tree.

Also turned the plugin file to lua because it's easier for me to work with.

Edit: fixed a bug where `source=` cmdline completion wouldn't work.