### PR TITLE
fix(preview): allow enabling when node is directory

### DIFF
--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -375,9 +375,6 @@ end
 
 Preview.show = function(state)
   local node = state.tree:get_node()
-  if node.type == "directory" then
-    return
-  end
 
   if instance then
     instance:findWindow(state)


### PR DESCRIPTION
@pynappo
This is the exact same pr like john-h-k/neo-tree.nvim#1.

Edit: It would be great if there would be some kind of directory preview (with eza/lsd/ls/tree), but that's mostly certainly something for a separate pr. (I did look into this but couldn't find the correct place in the code to implement this)