### PR TITLE
fix(setup): defer hijack until setup or BufEnter

### DIFF
--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -77,9 +77,27 @@ M.set_log_level = function(level)
   require("neo-tree.log").set_level(level)
 end
 
+local function try_netrw_hijack(path)
+  if not path or #path == 0 then
+    return false
+  end
+
+  local netrw = require("neo-tree.setup.netrw")
+  if netrw.get_hijack_behavior() ~= "disabled" then
+    vim.cmd("silent! autocmd! FileExplorer *")
+    local stats = (vim.uv or vim.loop).fs_stat(path)
+    if stats and stats.type == "directory" then
+      return netrw.hijack(path)
+    end
+  end
+  return false
+end
 M.setup = function(config)
   -- merging is deferred until ensure_config
   new_user_config = config
+  if vim.v.vim_did_enter == 0 then
+    try_netrw_hijack(vim.fn.argv(0))
+  end
 end
 
 M.show_logs = function()

--- a/plugin/neo-tree.lua
+++ b/plugin/neo-tree.lua
@@ -30,17 +30,14 @@ end
 
 -- currently need to check first arg to not break hijacked on
 -- configs that already lazy-load neo-tree (e.g. lazyvim)
-local first_arg = vim.fn.argv(0) --[[@as string]]
-if not try_netrw_hijack(first_arg) then
-  local augroup = vim.api.nvim_create_augroup("NeoTree_NetrwDeferred", { clear = true })
-  vim.api.nvim_create_autocmd("BufEnter", {
-    group = augroup,
-    callback = function(args)
-      if try_netrw_hijack(args.file) then
-        vim.api.nvim_del_augroup_by_id(augroup)
-      end
-    end,
-  })
-end
+local augroup = vim.api.nvim_create_augroup("NeoTree_NetrwDeferred", { clear = true })
+vim.api.nvim_create_autocmd("BufEnter", {
+  group = augroup,
+  callback = function(args)
+    if try_netrw_hijack(args.file) then
+      vim.api.nvim_del_augroup_by_id(augroup)
+    end
+  end,
+})
 
 vim.g.loaded_neo_tree = 1

--- a/plugin/neo-tree.lua
+++ b/plugin/neo-tree.lua
@@ -22,15 +22,14 @@ local function try_netrw_hijack(path)
     vim.cmd("silent! autocmd! FileExplorer *")
     local stats = (vim.uv or vim.loop).fs_stat(path)
     if stats and stats.type == "directory" then
-      return netrw.hijack()
+      return netrw.hijack(path)
     end
   end
   return false
 end
 
--- currently need to check first arg to not break hijacked on
--- configs that already lazy-load neo-tree (e.g. lazyvim)
 local augroup = vim.api.nvim_create_augroup("NeoTree_NetrwDeferred", { clear = true })
+
 vim.api.nvim_create_autocmd("BufEnter", {
   group = augroup,
   callback = function(args)

--- a/plugin/neo-tree.lua
+++ b/plugin/neo-tree.lua
@@ -17,13 +17,15 @@ local function try_netrw_hijack(path)
     return false
   end
 
+  local stats = (vim.uv or vim.loop).fs_stat(path)
+  if not stats or stats.type ~= "directory" then
+    return false
+  end
+
   local netrw = require("neo-tree.setup.netrw")
   if netrw.get_hijack_behavior() ~= "disabled" then
     vim.cmd("silent! autocmd! FileExplorer *")
-    local stats = (vim.uv or vim.loop).fs_stat(path)
-    if stats and stats.type == "directory" then
-      return netrw.hijack(path)
-    end
+    return netrw.hijack()
   end
   return false
 end


### PR DESCRIPTION
fixing #1658 

issue being that try_netrw_hijack should not run instantly on setup, else it always has open_default behavior if you don't lazy-load neo-tree