### PR TITLE
feat(commands): Add descending order_by_name support

### DIFF
--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -441,7 +441,16 @@ end
 
 M.order_by_name = function(state)
   set_sort(state, "Name")
-  state.sort_field_provider = nil
+  local config = require("neo-tree").config
+  if config.sort_case_insensitive then
+    state.sort_field_provider = function(node)
+      return node.path:lower()
+    end
+  else
+    state.sort_field_provider = function(node)
+      return node.path
+    end
+  end
   require("neo-tree.sources.manager").refresh(state.name)
 end
 


### PR DESCRIPTION
Currently, `order_by_name` does not respect sort direction. 
This addition would add support to toggle between ascending & descending name sort.

Potential issues - this does not add a sort order indicator.