### PR TITLE
feat(commands): Add descending order_by_name support

### DIFF
--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -441,7 +441,16 @@ end
 
 M.order_by_name = function(state)
   set_sort(state, "Name")
-  state.sort_field_provider = nil
+  local config = require("neo-tree").config
+  if config.sort_case_insensitive then
+    state.sort_field_provider = function(node)
+      return node.path:lower()
+    end
+  else
+    state.sort_field_provider = function(node)
+      return node.path
+    end
+  end
   require("neo-tree.sources.manager").refresh(state.name)
 end
 

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -345,7 +345,8 @@ M.name = function(config, node, state)
   if node:get_depth() == 1 and node.type ~= "message" then
     highlight = highlights.ROOT_NAME
     if state.sort and state.sort.label == "Name" then
-      text = text .. state.sort.direction == 1 and "  ▲" or "  ▼"
+      local icon = state.sort.direction == 1 and "▲" or "▼"
+      text = text .. "  " .. icon
     end
   else
     local filtered_by = M.filtered_by(config, node, state)

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -344,7 +344,7 @@ M.name = function(config, node, state)
 
   if node:get_depth() == 1 and node.type ~= "message" then
     highlight = highlights.ROOT_NAME
-    if state.sort and state.sort.label == "Name" then
+    if state.current_position == "current" and state.sort and state.sort.label == "Name" then
       local icon = state.sort.direction == 1 and "▲" or "▼"
       text = text .. "  " .. icon
     end

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -344,6 +344,9 @@ M.name = function(config, node, state)
 
   if node:get_depth() == 1 and node.type ~= "message" then
     highlight = highlights.ROOT_NAME
+    if state.sort and state.sort.label == "Name" then
+      text = text .. state.sort.direction == 1 and "  ▲" or "  ▼"
+    end
   else
     local filtered_by = M.filtered_by(config, node, state)
     highlight = filtered_by.highlight or highlight

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -41,6 +41,7 @@ local function create_state(tabid, sd, winid)
   state.dirty = true
   state.position = {}
   state.git_base = "HEAD"
+  state.sort = { label = "Name", direction = 1 }
   events.fire_event(events.STATE_CREATED, state)
   table.insert(all_states, state)
   return state


### PR DESCRIPTION
Expands #1694 

> Currently, `order_by_name` does not respect sort direction.
This addition would add support to toggle between ascending & descending name sort.

* Updates the state creation with a default sort of `{ label = "Name", direction = 1 }`
  * This prevents needing to send the `order_by_name` command twice to reverse sort order
* Adds a sort icon to the "Name" column when in "window" view
  * Should not apply to the "tab" view