### PR TITLE
fix(fs_actions): windowize paths on windows before moving

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -181,7 +181,10 @@ M.move_node = function(source, destination, callback, using_root_directory)
   local _, name = utils.split_path(source)
   get_unused_name(destination or source, using_root_directory, function(dest)
     -- Resolve user-inputted relative paths out of the absolute paths
-    dest = utils.normalize_path(dest)
+    dest = vim.fs.normalize(dest)
+    if utils.is_windows then
+      utils.windowize_path(dest)
+    end
     local function move_file()
       create_all_parents(dest)
       loop.fs_rename(source, dest, function(err)

--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -181,7 +181,7 @@ M.move_node = function(source, destination, callback, using_root_directory)
   local _, name = utils.split_path(source)
   get_unused_name(destination or source, using_root_directory, function(dest)
     -- Resolve user-inputted relative paths out of the absolute paths
-    dest = vim.fs.normalize(dest)
+    dest = utils.normalize_path(dest)
     local function move_file()
       create_all_parents(dest)
       loop.fs_rename(source, dest, function(err)

--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -183,7 +183,7 @@ M.move_node = function(source, destination, callback, using_root_directory)
     -- Resolve user-inputted relative paths out of the absolute paths
     dest = vim.fs.normalize(dest)
     if utils.is_windows then
-      utils.windowize_path(dest)
+      dest = utils.windowize_path(dest)
     end
     local function move_file()
       create_all_parents(dest)


### PR DESCRIPTION
Fix for `bad argument to fs_state` error when cutting and pasting on Windows.

Closes #1693