### PR TITLE
feat: configurable indent marker level

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ use {
           },
           indent = {
             indent_size = 2,
+            level = 2,
             padding = 1, -- extra padding on left hand side
             -- indent guides
             with_markers = true,

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -1035,6 +1035,7 @@ for each source, or just do it once in the default_component_configs section:
           indent_marker = "│",
           last_indent_marker = "└",
           indent_size = 2,
+          level = 2
         },
       },
     })

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -188,6 +188,7 @@ local config = {
       with_markers = true,
       indent_marker = "│",
       last_indent_marker = "└",
+      marker_start_level = 2, -- the directory node in which the marker should start rendering
       highlight = "NeoTreeIndentMarker",
       -- expander config, needed for nesting files
       with_expanders = nil, -- if nil and file nesting is enabled, will enable expanders

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -389,6 +389,7 @@ M.indent = function(config, node, state)
   local skip_marker = state.skip_marker_at_level
   local indent_size = config.indent_size or 2
   local padding = config.padding or 0
+  local start_level = config.level or 2
   local level = node.level
   local with_markers = config.with_markers
   local with_expanders = config.with_expanders == nil and file_nesting.is_enabled()
@@ -403,7 +404,7 @@ M.indent = function(config, node, state)
     end
   end
 
-  if indent_size == 0 or level < 2 or not with_markers then
+  if indent_size == 0 or level < start_level or not with_markers then
     local len = indent_size * level + padding
     local expander = get_expander()
     if level == 0 or not expander then
@@ -426,12 +427,12 @@ M.indent = function(config, node, state)
     table.insert(indent, { text = string.rep(" ", padding) })
   end
 
-  for i = 1, level do
+  for i = start_level - 1, level do
     local char = ""
     local spaces_count = indent_size
     local highlight = nil
 
-    if i > 1 and not skip_marker[i] or i == level then
+    if i > start_level - 1 and not skip_marker[i] or i == level then
       spaces_count = spaces_count - 1
       char = indent_marker
       highlight = marker_highlight


### PR DESCRIPTION
The current marker starts after the 2nd node, and this PR modifies the indent function to make the indent marker start from node 0 or 1, also making it configurable. Just like this:

<img width="852" alt="combined" src="https://github.com/user-attachments/assets/58754003-51b6-4aab-ae27-087bfd0d27e9" />

I tried covering some edge cases due to the different combinations from:
```lua
  local indent_size = config.indent_size
  local padding = config.padding
  local marker_start_level = config.marker_start_level
  local level = node.level
  local with_markers = config.with_markers
  local with_expanders = config.with_expanders == nil and file_nesting.is_enabled()
    or config.with_expanders
```

Most of the logic was changed, of course I am open to improving the quality of the code and implement perhaps more edge cases or anything else. Thank you