### PR TITLE
fix(defaults): skip rename_basename in document_symbols mapping

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -425,7 +425,6 @@ local config = {
       ["A"] = "add_directory", -- also accepts the config.show_path and config.insert_as options.
       ["d"] = "delete",
       ["r"] = "rename",
-      ["b"] = "rename_basename",
       ["y"] = "copy_to_clipboard",
       ["x"] = "cut_to_clipboard",
       ["p"] = "paste_from_clipboard",
@@ -454,6 +453,7 @@ local config = {
         ["[g"] = "prev_git_modified",
         ["]g"] = "next_git_modified",
         ["i"] = "show_file_details", -- see `:h neo-tree-file-actions` for options to customize the window.
+        ["b"] = "rename_basename",
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },
@@ -586,6 +586,7 @@ local config = {
         ["d"] = "buffer_delete",
         ["bd"] = "buffer_delete",
         ["i"] = "show_file_details", -- see `:h neo-tree-file-actions` for options to customize the window.
+        ["b"] = "rename_basename",
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },
@@ -607,6 +608,7 @@ local config = {
         ["gp"] = "git_push",
         ["gg"] = "git_commit_and_push",
         ["i"] = "show_file_details", -- see `:h neo-tree-file-actions` for options to customize the window.
+        ["b"] = "rename_basename",
         ["o"] = { "show_help", nowait=false, config = { title = "Order by", prefix_key = "o" }},
         ["oc"] = { "order_by_created", nowait = false },
         ["od"] = { "order_by_diagnostics", nowait = false },


### PR DESCRIPTION
This fixes an issue where the `document_symbols` mode had an invalid mapping from the global map, ie. the `["b"] = "rename_basename"` mapping.

The approach is to move the global mapping `["b"] = "rename_basename"` mapping to each of the more specific `git_status`, `buffers`, and `filesystem` mappings, where they are valid.

### Issue details

When pressing `b` in the `document_symbols` tree, I was getting this message:

```
[Neo-tree WARN] Invalid mapping for  b :  nil
```

And when pressing `?` to see the keymap, I ran into this red error message:

```
E5108: Error executing lua: ...ng/.local/share/nvim/lazy/nui.nvim/lua/nui/line/init.lua:22: attempt to index local 'block' (a nil value)                                                                                                stack traceback:                                                                                                                                                                                                                                ...ng/.local/share/nvim/lazy/nui.nvim/lua/nui/line/init.lua:22: in function 'append'                                                                                                                                                    .../lazy/neo-tree.nvim/lua/neo-tree/sources/common/help.lua:62: in function 'show'
        ...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:891: in function <...y/neo-tree.nvim/lua/neo-tree/sources/common/commands.lua:888>
```