### PR TITLE
refactor: use vim.{bo/wo/go/o} for options

### DIFF
--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -38,8 +38,8 @@ M.get_prior_window = function(ignore_filetypes, ignore_winfixbuf)
       local success, is_valid = pcall(vim.api.nvim_win_is_valid, last_win)
       if success and is_valid and not (ignore_winfixbuf and utils.is_winfixbuf(last_win)) then
         local buf = vim.api.nvim_win_get_buf(last_win)
-        local ft = vim.api.nvim_buf_get_option(buf, "filetype")
-        local bt = vim.api.nvim_buf_get_option(buf, "buftype") or "normal"
+        local ft = vim.bo[buf].filetype
+        local bt = vim.bo[buf].buftype or "normal"
         if ignore[ft] ~= true and ignore[bt] ~= true then
           return last_win
         end

--- a/lua/neo-tree/setup/deprecations.lua
+++ b/lua/neo-tree/setup/deprecations.lua
@@ -14,12 +14,12 @@ M.show_migrations = function()
     table.insert(content, 1, header)
     local buf = vim.api.nvim_create_buf(false, true)
     vim.api.nvim_buf_set_lines(buf, 0, -1, false, content)
-    vim.api.nvim_buf_set_option(buf, "buftype", "nofile")
-    vim.api.nvim_buf_set_option(buf, "bufhidden", "wipe")
-    vim.api.nvim_buf_set_option(buf, "buflisted", false)
-    vim.api.nvim_buf_set_option(buf, "swapfile", false)
-    vim.api.nvim_buf_set_option(buf, "modifiable", false)
-    vim.api.nvim_buf_set_option(buf, "filetype", "markdown")
+    vim.bo[buf].buftype = "nofile"
+    vim.bo[buf].bufhidden = "wipe"
+    vim.bo[buf].buflisted = false
+    vim.bo[buf].swapfile = false
+    vim.bo[buf].modifiable = false
+    vim.bo[buf].filetype = "markdown"
     vim.api.nvim_buf_set_name(buf, "Neo-tree migrations")
     vim.defer_fn(function()
       vim.cmd(string.format("%ssplit", #content))

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -201,7 +201,7 @@ M.buffer_enter_event = function()
   if prior_buf < 1 then
     return
   end
-  local prior_type = vim.api.nvim_buf_get_option(prior_buf, "filetype")
+  local prior_type = vim.bo[prior_buf].filetype
 
   -- there is nothing more we want to do with floating windows
   -- but when prior_type is neo-tree we might need to redirect buffer somewhere else.

--- a/lua/neo-tree/setup/netrw.lua
+++ b/lua/neo-tree/setup/netrw.lua
@@ -56,7 +56,7 @@ M.hijack = function()
     local replace_with_bufnr = vim.fn.bufnr("#")
     local is_currently_neo_tree = false
     if replace_with_bufnr > 0 then
-      if vim.api.nvim_buf_get_option(replace_with_bufnr, "filetype") == "neo-tree" then
+      if vim.bo[replace_with_bufnr].filetype == "neo-tree" then
         -- don't hijack the current window if it's already a Neo-tree sidebar
         local _, position = pcall(vim.api.nvim_buf_get_var, replace_with_bufnr, "neo_tree_position")
         if position ~= "current" then

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -871,7 +871,7 @@ local use_window_picker = function(state, path, cmd)
     local result, err = pcall(vim.cmd, cmd .. " " .. vim.fn.fnameescape(path))
     if result or err == "Vim(edit):E325: ATTENTION" then
       -- fixes #321
-      vim.api.nvim_buf_set_option(0, "buflisted", true)
+      vim.bo[0].buflisted = true
       events.fire_event(events.FILE_OPENED, path)
     else
       log.error("Error opening file:", err)

--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -154,7 +154,7 @@ function Preview:revert()
   else
     local foldenable = utils.get_value(self.truth, "options.foldenable", nil, false)
     if foldenable ~= nil then
-      vim.api.nvim_win_set_option(self.winid, "foldenable", self.truth.options.foldenable)
+      vim.wo[self.winid].foldenable = self.truth.options.foldenable
     end
     vim.api.nvim_win_set_var(self.winid, "neo_tree_preview", 0)
   end
@@ -172,7 +172,7 @@ function Preview:revert()
       vim.fn.winrestview(self.truth.view)
     end)
   end
-  vim.api.nvim_buf_set_option(self.bufnr, "bufhidden", self.truth.options.bufhidden)
+  vim.bo[self.bufnr].bufhidden = self.truth.options.bufhidden
 end
 
 ---Subscribe to event and add it to the preview event list.
@@ -254,12 +254,12 @@ function Preview:activate()
       bufnr = self.bufnr,
       view = vim.api.nvim_win_call(self.winid, vim.fn.winsaveview),
       options = {
-        bufhidden = vim.api.nvim_buf_get_option(self.bufnr, "bufhidden"),
-        foldenable = vim.api.nvim_win_get_option(self.winid, "foldenable"),
+        bufhidden = vim.bo[self.bufnr].bufhidden,
+        foldenable = vim.wo[self.winid].foldenable,
       },
     }
-    vim.api.nvim_buf_set_option(self.bufnr, "bufhidden", "hide")
-    vim.api.nvim_win_set_option(self.winid, "foldenable", false)
+    vim.bo[self.bufnr].bufhidden = "hide"
+    vim.wo[self.winid].foldenable = false
   end
   self.active = true
   vim.api.nvim_win_set_var(self.winid, "neo_tree_preview", 1)

--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -50,7 +50,7 @@ local function find_replacement_buffer(for_buf)
     if buf ~= for_buf then
       local is_valid = vim.api.nvim_buf_is_valid(buf)
       if is_valid then
-        local buftype = vim.api.nvim_buf_get_option(buf, "buftype")
+        local buftype = vim.bo[buf].buftype
         if buftype == "" then
           return buf
         end
@@ -112,11 +112,11 @@ local function rename_buffer(old_path, new_path)
       if utils.truthy(new_buf_name) then
         local new_buf = vim.fn.bufadd(new_buf_name)
         vim.fn.bufload(new_buf)
-        vim.api.nvim_buf_set_option(new_buf, "buflisted", true)
+        vim.bo[new_buf].buflisted = true
         replace_buffer_in_windows(buf, new_buf)
 
-        if vim.api.nvim_buf_get_option(buf, "buftype") == "" then
-          local modified = vim.api.nvim_buf_get_option(buf, "modified")
+        if vim.bo[buf].buftype == "" then
+          local modified = vim.bo[buf].modified
           if modified then
             local old_buffer_lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
             vim.api.nvim_buf_set_lines(new_buf, 0, -1, false, old_buffer_lines)

--- a/lua/neo-tree/ui/highlights.lua
+++ b/lua/neo-tree/ui/highlights.lua
@@ -123,14 +123,14 @@ end
 local calculate_faded_highlight_group = function(hl_group_name, fade_percentage)
   local normal = vim.api.nvim_get_hl_by_name("Normal", true)
   if type(normal.foreground) ~= "number" then
-    if vim.api.nvim_get_option("background") == "dark" then
+    if vim.go.background == "dark" then
       normal.foreground = 0xffffff
     else
       normal.foreground = 0x000000
     end
   end
   if type(normal.background) ~= "number" then
-    if vim.api.nvim_get_option("background") == "dark" then
+    if vim.go.background == "dark" then
       normal.background = 0x000000
     else
       normal.background = 0xffffff

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -929,11 +929,11 @@ local get_buffer = function(bufname, state)
   if bufnr < 1 then
     bufnr = vim.api.nvim_create_buf(false, false)
     vim.api.nvim_buf_set_name(bufnr, bufname)
-    vim.api.nvim_buf_set_option(bufnr, "buftype", "nofile")
-    vim.api.nvim_buf_set_option(bufnr, "swapfile", false)
-    vim.api.nvim_buf_set_option(bufnr, "filetype", "neo-tree")
-    vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
-    vim.api.nvim_buf_set_option(bufnr, "undolevels", -1)
+    vim.bo[bufnr].buftype = "nofile"
+    vim.bo[bufnr].swapfile = false
+    vim.bo[bufnr].filetype = "neo-tree"
+    vim.bo[bufnr].modifiable = false
+    vim.bo[bufnr].undolevels = -1
     autocmd.buf.define(bufnr, "BufDelete", function()
       M.position.save(state)
     end)

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -389,7 +389,7 @@ M.get_opened_buffers = function()
         buffer_name = "[No Name]#" .. buffer
       end
       opened_buffers[buffer_name] = {
-        ["modified"] = vim.api.nvim_buf_get_option(buffer, "modified"),
+        ["modified"] = vim.bo[buffer].modified,
         ["loaded"] = vim.api.nvim_buf_is_loaded(buffer),
       }
     end
@@ -578,7 +578,7 @@ end
 M.is_winfixbuf = function(win_id)
   if vim.fn.exists("&winfixbuf") == 1 then
     win_id = win_id or vim.api.nvim_get_current_win()
-    return vim.api.nvim_get_option_value("winfixbuf", { win = win_id })
+    return vim.wo[win_id].winfixbuf
   end
   return false
 end
@@ -600,7 +600,7 @@ M.is_real_file = function(afile, true_for_terminals)
 
   local success, bufnr = pcall(vim.fn.bufnr, afile)
   if success and bufnr > 0 then
-    local buftype = vim.api.nvim_buf_get_option(bufnr, "buftype")
+    local buftype = vim.bo[bufnr].buftype
 
     if true_for_terminals and buftype == "terminal" then
       return true
@@ -814,7 +814,7 @@ M.open_file = function(state, path, open_cmd, bufnr)
     end
     if result or err == "Vim(edit):E325: ATTENTION" then
       -- fixes #321
-      vim.api.nvim_buf_set_option(0, "buflisted", true)
+      vim.bo[0].buflisted = true
       events.fire_event(events.FILE_OPENED, path)
     else
       log.error("Error opening file:", err)

--- a/tests/neo-tree/sources/filesystem/filesystem_netrw_hijack_spec.lua
+++ b/tests/neo-tree/sources/filesystem/filesystem_netrw_hijack_spec.lua
@@ -83,7 +83,7 @@ describe("Filesystem netrw hijack", function()
   --    if #vim.api.nvim_list_wins() ~= 2 then
   --      return false
   --    end
-  --    return vim.api.nvim_buf_get_option(0, "filetype") == "neo-tree"
+  --    return vim.bo[0].filetype == "neo-tree"
   --  end, "neotree is not in the second window")
   --end)
 end)

--- a/tests/utils/verify.lua
+++ b/tests/utils/verify.lua
@@ -57,7 +57,7 @@ verify.tree_focused = function(timeout)
     if not verify.get_state() then
       return false
     end
-    return vim.api.nvim_buf_get_option(0, "filetype") == "neo-tree"
+    return vim.bo[0].filetype == "neo-tree"
   end, "Current buffer is not a 'neo-tree' filetype")
 end
 


### PR DESCRIPTION
part of an effort to cleanup the codebase