### PR TITLE
refactor(types): change `neotree.Config` to a partial class

### DIFF
--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -99,8 +99,6 @@ local function try_netrw_hijack(path)
   return false
 end
 
----@class (partial) neotree.Config : neotree.Config.Base
-
 ---@param config neotree.Config
 M.setup = function(config)
   -- merging is deferred until ensure_config

--- a/lua/neo-tree.lua
+++ b/lua/neo-tree.lua
@@ -99,6 +99,8 @@ local function try_netrw_hijack(path)
   return false
 end
 
+---@class (partial) neotree.Config : neotree.Config.Base
+
 ---@param config neotree.Config
 M.setup = function(config)
   -- merging is deferred until ensure_config

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -1,4 +1,4 @@
----@type neotree.Config
+---@type neotree.Config.Base
 local config = {
   -- If a user has a sources list it will replace this one.
   -- Only sources listed here will be loaded.

--- a/lua/neo-tree/types/config.lua
+++ b/lua/neo-tree/types/config.lua
@@ -106,45 +106,47 @@
 
 ---@alias neotree.Config.BorderStyle "NC"|"none"|"rounded"|"shadow"|"single"|"solid"
 
----@class (exact) neotree.Config
----@field sources string[]?
----@field add_blank_line_at_top boolean?
----@field auto_clean_after_session_restore boolean?
----@field close_if_last_window boolean?
----@field default_source string?
----@field enable_diagnostics boolean?
----@field enable_git_status boolean?
----@field enable_modified_markers boolean?
----@field enable_opened_markers boolean?
----@field enable_refresh_on_write boolean?
----@field enable_cursor_hijack boolean?
----@field git_status_async boolean?
----@field git_status_async_options neotree.Config.GitStatusAsync?
----@field hide_root_node boolean?
----@field retain_hidden_root_indent boolean?
+---@class (exact) neotree.Config.Base
+---@field sources string[]
+---@field add_blank_line_at_top boolean
+---@field auto_clean_after_session_restore boolean
+---@field close_if_last_window boolean
+---@field default_source string
+---@field enable_diagnostics boolean
+---@field enable_git_status boolean
+---@field enable_modified_markers boolean
+---@field enable_opened_markers boolean
+---@field enable_refresh_on_write boolean
+---@field enable_cursor_hijack boolean
+---@field git_status_async boolean
+---@field git_status_async_options neotree.Config.GitStatusAsync
+---@field hide_root_node boolean
+---@field retain_hidden_root_indent boolean
 ---@field log_level "trace"|"debug"|"info"|"warn"|"error"|"fatal"|nil
----@field log_to_file boolean|string?
----@field open_files_in_last_window boolean?
----@field open_files_do_not_replace_types string[]?
----@field open_files_using_relative_paths boolean?
----@field popup_border_style neotree.Config.BorderStyle?
----@field resize_timer_interval integer|-1?
----@field sort_case_insensitive boolean?
----@field sort_function fun(a: any, b: any)?
----@field use_popups_for_input boolean?
----@field use_default_mappings boolean?
----@field source_selector neotree.Config.SourceSelector?
----@field event_handlers neotree.Event.Handler[]?
----@field default_component_configs neotree.Config.ComponentDefaults?
----@field renderers neotree.Config.Renderers?
----@field nesting_rules neotree.FileNesting.Rule[]?
----@field commands table<string, fun()>?
----@field window neotree.Config.Window?
+---@field log_to_file boolean|string
+---@field open_files_in_last_window boolean
+---@field open_files_do_not_replace_types string[]
+---@field open_files_using_relative_paths boolean
+---@field popup_border_style neotree.Config.BorderStyle
+---@field resize_timer_interval integer|-1
+---@field sort_case_insensitive boolean
+---@field sort_function fun(a: any, b: any)
+---@field use_popups_for_input boolean
+---@field use_default_mappings boolean
+---@field source_selector neotree.Config.SourceSelector
+---@field event_handlers neotree.Event.Handler[]
+---@field default_component_configs neotree.Config.ComponentDefaults
+---@field renderers neotree.Config.Renderers
+---@field nesting_rules neotree.FileNesting.Rule[]
+---@field commands table<string, fun()>
+---@field window neotree.Config.Window
 ---
----@field filesystem neotree.Config.Filesystem?
----@field buffers neotree.Config.Buffers?
----@field git_status neotree.Config.GitStatus?
----@field document_symbols neotree.Config.DocumentSymbols?
+---@field filesystem neotree.Config.Filesystem
+---@field buffers neotree.Config.Buffers
+---@field git_status neotree.Config.GitStatus
+---@field document_symbols neotree.Config.DocumentSymbols
 
----@class (exact) neotree.Config._Full : neotree.Config
+---@class (exact) neotree.Config._Full : neotree.Config.Base
 ---@field prior_windows table<string, integer[]>?
+
+---@class (partial) neotree.Config : neotree.Config.Base

--- a/lua/neo-tree/types/config.lua
+++ b/lua/neo-tree/types/config.lua
@@ -130,11 +130,11 @@
 ---@field popup_border_style neotree.Config.BorderStyle
 ---@field resize_timer_interval integer|-1
 ---@field sort_case_insensitive boolean
----@field sort_function fun(a: any, b: any)
+---@field sort_function? fun(a: any, b: any):boolean
 ---@field use_popups_for_input boolean
 ---@field use_default_mappings boolean
 ---@field source_selector neotree.Config.SourceSelector
----@field event_handlers neotree.Event.Handler[]
+---@field event_handlers? neotree.Event.Handler[]
 ---@field default_component_configs neotree.Config.ComponentDefaults
 ---@field renderers neotree.Config.Renderers
 ---@field nesting_rules neotree.FileNesting.Rule[]


### PR DESCRIPTION
as of last month, lua_ls has a convenient (partial) class type which lets us be more sure about the values in neotree's actual config while being less sure about the user's passed in config