### PR TITLE
feat(popup): support 'winborder' with `popup_border_style = ""`

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ return {
 
       require("neo-tree").setup({
         close_if_last_window = false, -- Close Neo-tree if it is the last window left in the tab
-        popup_border_style = "NC", -- or "" to use 'winborder' on nvim v0.11+
+        popup_border_style = "NC", -- or "" to use 'winborder' on Neovim v0.11+
         enable_git_status = true,
         enable_diagnostics = true,
         open_files_do_not_replace_types = { "terminal", "trouble", "qf" }, -- when opening files, do not use windows containing these filetypes or buftypes

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ return {
 
       require("neo-tree").setup({
         close_if_last_window = false, -- Close Neo-tree if it is the last window left in the tab
-        popup_border_style = "rounded",
+        popup_border_style = "NC", -- or "" to use 'winborder' on nvim v0.11+
         enable_git_status = true,
         enable_diagnostics = true,
         open_files_do_not_replace_types = { "terminal", "trouble", "qf" }, -- when opening files, do not use windows containing these filetypes or buftypes

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -39,7 +39,7 @@ local config = {
   -- popup_border_style is for input and confirmation dialogs.
   -- Configurtaion of floating window is done in the individual source sections.
   -- "NC" is a special style that works well with NormalNC set
-  popup_border_style = "NC", -- "double", "none", "rounded", "shadow", "single", "solid", (or "" to use 'winborder' on nvim v0.11+)
+  popup_border_style = "NC", -- "double", "rounded", "shadow", "single", "solid", (or "" to use 'winborder' on Neovim v0.11+)
   resize_timer_interval = 500, -- in ms, needed for containers to redraw right aligned and faded content
                                -- set to -1 to disable the resize timer entirely
   --                           -- NOTE: this will speed up to 50 ms for 1 second following a resize

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -39,7 +39,7 @@ local config = {
   -- popup_border_style is for input and confirmation dialogs.
   -- Configurtaion of floating window is done in the individual source sections.
   -- "NC" is a special style that works well with NormalNC set
-  popup_border_style = "NC", -- "double", "rounded", "shadow", "single", "solid", (or "" to use 'winborder' on Neovim v0.11+)
+  popup_border_style = "NC", -- "double", "rounded", "single", "solid", (or "" to use 'winborder' on Neovim v0.11+)
   resize_timer_interval = 500, -- in ms, needed for containers to redraw right aligned and faded content
                                -- set to -1 to disable the resize timer entirely
   --                           -- NOTE: this will speed up to 50 ms for 1 second following a resize

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -29,7 +29,7 @@ local config = {
                        -- Anything before this will be used. The last items to be processed are the untracked files.
   },
   hide_root_node = false, -- Hide the root node.
-  retain_hidden_root_indent = false, -- IF the root node is hidden, keep the indentation anyhow. 
+  retain_hidden_root_indent = false, -- IF the root node is hidden, keep the indentation anyhow.
                                      -- This is needed if you use expanders because they render in the indent.
   log_level = "info", -- "trace", "debug", "info", "warn", "error", "fatal"
   log_to_file = false, -- true, false, "/path/to/file.log", use ':lua require("neo-tree").show_logs()' to show the file
@@ -39,7 +39,7 @@ local config = {
   -- popup_border_style is for input and confirmation dialogs.
   -- Configurtaion of floating window is done in the individual source sections.
   -- "NC" is a special style that works well with NormalNC set
-  popup_border_style = "NC", -- "double", "none", "rounded", "shadow", "single" or "solid"
+  popup_border_style = "NC", -- "double", "none", "rounded", "shadow", "single", "solid", (or "" to use 'winborder' on nvim v0.11+)
   resize_timer_interval = 500, -- in ms, needed for containers to redraw right aligned and faded content
                                -- set to -1 to disable the resize timer entirely
   --                           -- NOTE: this will speed up to 50 ms for 1 second following a resize

--- a/lua/neo-tree/sources/common/preview.lua
+++ b/lua/neo-tree/sources/common/preview.lua
@@ -4,6 +4,7 @@ local events = require("neo-tree.events")
 local manager = require("neo-tree.sources.manager")
 local log = require("neo-tree.log")
 local renderer = require("neo-tree.ui.renderer")
+local NuiPopup = require("nui.popup")
 
 local neo_tree_preview_namespace = vim.api.nvim_create_namespace("neo_tree_preview")
 
@@ -77,7 +78,6 @@ local function create_floating_preview_window(state)
   options.zindex = 40
   options.buf_options.filetype = "neo-tree-preview"
 
-  local NuiPopup = require("nui.popup")
   local win = NuiPopup(options)
   win:mount()
   return win

--- a/lua/neo-tree/types/config.lua
+++ b/lua/neo-tree/types/config.lua
@@ -97,7 +97,7 @@
 ---@field created neotree.Component.Common.Created?
 ---@field symlink_target neotree.Component.Common.SymlinkTarget?
 
----@alias neotree.Config.BorderStyle "NC"|"none"|"rounded"|"shadow"|"single"|"solid"
+---@alias neotree.Config.BorderStyle "NC"|"none"|"rounded"|"shadow"|"single"|"solid"|"double"|""
 
 ---@class (exact) neotree.Config.Base
 ---@field sources string[]

--- a/lua/neo-tree/types/config.lua
+++ b/lua/neo-tree/types/config.lua
@@ -97,7 +97,7 @@
 ---@field created neotree.Component.Common.Created?
 ---@field symlink_target neotree.Component.Common.SymlinkTarget?
 
----@alias neotree.Config.BorderStyle "NC"|"none"|"rounded"|"shadow"|"single"|"solid"|"double"|""
+---@alias neotree.Config.BorderStyle "NC"|"rounded"|"shadow"|"single"|"solid"|"double"|""
 
 ---@class (exact) neotree.Config.Base
 ---@field sources string[]

--- a/lua/neo-tree/types/config.lua
+++ b/lua/neo-tree/types/config.lua
@@ -97,7 +97,7 @@
 ---@field created neotree.Component.Common.Created?
 ---@field symlink_target neotree.Component.Common.SymlinkTarget?
 
----@alias neotree.Config.BorderStyle "NC"|"rounded"|"shadow"|"single"|"solid"|"double"|""
+---@alias neotree.Config.BorderStyle "NC"|"rounded"|"single"|"solid"|"double"|""
 
 ---@class (exact) neotree.Config.Base
 ---@field sources string[]

--- a/lua/neo-tree/ui/inputs.lua
+++ b/lua/neo-tree/ui/inputs.lua
@@ -1,14 +1,9 @@
-local Input = require("nui.input")
+local NuiInput = require("nui.input")
+local nt = require("neo-tree")
 local popups = require("neo-tree.ui.popups")
-local utils = require("neo-tree.utils")
 local events = require("neo-tree.events")
 
 local M = {}
-
-local should_use_popup_input = function()
-  local nt = require("neo-tree")
-  return utils.get_value(nt.config, "use_popups_for_input", true, false)
-end
 
 M.show_input = function(input, callback)
   input:mount()
@@ -47,10 +42,10 @@ M.show_input = function(input, callback)
 end
 
 M.input = function(message, default_value, callback, options, completion)
-  if should_use_popup_input() then
+  if nt.config.use_popups_for_input then
     local popup_options = popups.popup_options(message, 10, options)
 
-    local input = Input(popup_options, {
+    local input = NuiInput(popup_options, {
       prompt = " ",
       default_value = default_value,
       on_submit = callback,
@@ -75,11 +70,11 @@ M.input = function(message, default_value, callback, options, completion)
 end
 
 M.confirm = function(message, callback)
-  if should_use_popup_input() then
+  if nt.config.use_popups_for_input then
     local popup_options = popups.popup_options(message, 10)
 
     ---@class NuiInput
-    local input = Input(popup_options, {
+    local input = NuiInput(popup_options, {
       prompt = " y/n: ",
       on_close = function()
         callback(false)

--- a/lua/neo-tree/ui/popups.lua
+++ b/lua/neo-tree/ui/popups.lua
@@ -7,6 +7,7 @@ local log = require("neo-tree.log")
 local M = {}
 
 local winborder_option_exists = vim.fn.exists("&winborder") > 0
+local invalid_borders = { "", "none" }
 M.popup_options = function(title, min_width, override_options)
   if string.len(title) ~= 0 then
     title = " " .. title .. " "
@@ -16,11 +17,13 @@ M.popup_options = function(title, min_width, override_options)
 
   local popup_border_style = nt.config.popup_border_style
   if popup_border_style == "" then
-    if winborder_option_exists then
+    -- Try to use winborder or
+    -- fallback to single
+    if not winborder_option_exists or vim.tbl_contains(invalid_borders, vim.o.winborder) then
+      popup_border_style = "single"
+    else
+      ---@diagnostic disable-next-line: cast-local-type
       popup_border_style = vim.o.winborder
-    end
-    if popup_border_style == "" then
-      popup_border_style = "NC"
     end
   end
   local popup_border_text = NuiText(title, highlights.FLOAT_TITLE)

--- a/lua/neo-tree/ui/popups.lua
+++ b/lua/neo-tree/ui/popups.lua
@@ -1,5 +1,6 @@
 local NuiText = require("nui.text")
 local NuiPopup = require("nui.popup")
+local nt = require("neo-tree")
 local highlights = require("neo-tree.ui.highlights")
 local log = require("neo-tree.log")
 
@@ -12,8 +13,15 @@ M.popup_options = function(title, min_width, override_options)
   min_width = min_width or 30
   local width = string.len(title) + 2
 
-  local nt = require("neo-tree")
   local popup_border_style = nt.config.popup_border_style
+  if popup_border_style == "" then
+    if vim.fn.exists("&winborder") > 0 then
+      popup_border_style = vim.o.winborder
+    end
+    if popup_border_style == "" then
+      popup_border_style = "NC"
+    end
+  end
   local popup_border_text = NuiText(title, highlights.FLOAT_TITLE)
   local col = 0
   -- fix popup position when using multigrid

--- a/lua/neo-tree/ui/popups.lua
+++ b/lua/neo-tree/ui/popups.lua
@@ -6,6 +6,7 @@ local log = require("neo-tree.log")
 
 local M = {}
 
+local winborder_option_exists = vim.fn.exists("&winborder") > 0
 M.popup_options = function(title, min_width, override_options)
   if string.len(title) ~= 0 then
     title = " " .. title .. " "
@@ -15,7 +16,7 @@ M.popup_options = function(title, min_width, override_options)
 
   local popup_border_style = nt.config.popup_border_style
   if popup_border_style == "" then
-    if vim.fn.exists("&winborder") > 0 then
+    if winborder_option_exists then
       popup_border_style = vim.o.winborder
     end
     if popup_border_style == "" then

--- a/lua/neo-tree/ui/popups.lua
+++ b/lua/neo-tree/ui/popups.lua
@@ -7,7 +7,8 @@ local log = require("neo-tree.log")
 local M = {}
 
 local winborder_option_exists = vim.fn.exists("&winborder") > 0
-local invalid_borders = { "", "none" }
+-- These borders will cause errors when trying to display border text with them
+local invalid_borders = { "", "none", "shadow" }
 M.popup_options = function(title, min_width, override_options)
   if string.len(title) ~= 0 then
     title = " " .. title .. " "
@@ -17,8 +18,7 @@ M.popup_options = function(title, min_width, override_options)
 
   local popup_border_style = nt.config.popup_border_style
   if popup_border_style == "" then
-    -- Try to use winborder or
-    -- fallback to single
+    -- Try to use winborder
     if not winborder_option_exists or vim.tbl_contains(invalid_borders, vim.o.winborder) then
       popup_border_style = "single"
     else


### PR DESCRIPTION
Closes #1743

~~currently not working as intended, see: https://github.com/MunifTanjim/nui.nvim/pull/403~~