### PR TITLE
fix(filesystem): handle case-insensitive renames on all OSs

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -26,7 +26,7 @@ local function rename_is_safe(original_path, destination)
     return true
   end
 
-  if utils.is_windows then
+  if utils.is_windows or utils.is_macos then
     -- check to see if we're just renaming the original to a different case
     local orig = utils.normalize_path(original_path)
     local dest = utils.normalize_path(destination)
@@ -635,15 +635,7 @@ local rename_node = function(msg, name, get_destination, path, callback)
 
     local destination = get_destination(new_name)
 
-    -- Check for case changes
-    local is_case_change_only = false
-    local original_filename = vim.fn.fnamemodify(path, ":t")
-    if original_filename:lower() == new_name:lower() then
-      is_case_change_only = true
-    end
-
-    -- Only check for existing files if it's not just a case change
-    if not is_case_change_only and not rename_is_safe(path, destination) then
+    if not rename_is_safe(path, destination) then
       log.warn(destination, " already exists, canceling")
       return
     end

--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -15,22 +15,33 @@ local Path = require("plenary").path
 
 local M = {}
 
+---@param a uv.fs_stat.result?
+---@param b uv.fs_stat.result?
+---@return boolean equal Whether a and b are stats of the same file
+local same_file = function(a, b)
+  return a and b and a.dev == b.dev and a.ino == b.ino or false
+end
+
 ---Checks to see if a file can safely be renamed to its destination without data loss.
 ---Also prevents renames from going through if the rename will not do anything.
----Has an additional check for renaming files to a different case (e.g. for windows)
----@param original_path string
+---Has an additional check for case-insensitive filesystems (e.g. for windows)
+---@param source string
 ---@param destination string
 ---@return boolean rename_is_safe
-local function rename_is_safe(original_path, destination)
-  if not uv.fs_stat(destination) then
+local function rename_is_safe(source, destination)
+  local destination_file = uv.fs_stat(destination)
+  if not destination_file then
     return true
   end
 
-  if utils.is_windows or utils.is_macos then
-    -- check to see if we're just renaming the original to a different case
-    local orig = utils.normalize_path(original_path)
-    local dest = utils.normalize_path(destination)
-    return orig ~= dest and orig:lower() == dest:lower()
+  local src = utils.normalize_path(source)
+  local dest = utils.normalize_path(destination)
+  local changing_casing = src ~= dest and src:lower() == dest:lower()
+  if changing_casing then
+    local src_file = uv.fs_stat(src)
+    -- We check that the two paths resolve to the same canonical filename and file.
+    return same_file(src_file, destination_file)
+      and uv.fs_realpath(src) == uv.fs_realpath(destination)
   end
   return false
 end

--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -635,7 +635,15 @@ local rename_node = function(msg, name, get_destination, path, callback)
 
     local destination = get_destination(new_name)
 
-    if not rename_is_safe(path, destination) then
+    -- Check for case changes
+    local is_case_change_only = false
+    local original_filename = vim.fn.fnamemodify(path, ":t")
+    if original_filename:lower() == new_name:lower() then
+      is_case_change_only = true
+    end
+
+    -- Only check for existing files if it's not just a case change
+    if not is_case_change_only and not rename_is_safe(path, destination) then
       log.warn(destination, " already exists, canceling")
       return
     end

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -914,6 +914,8 @@ if M.is_windows == true then
   M.path_separator = "\\"
 end
 
+M.is_macos = vim.fn.has("mac") == 1
+
 ---Remove the path separator from the end of a path in a cross-platform way.
 ---@param path string The path to remove the separator from.
 ---@return string string The path without any trailing separator.


### PR DESCRIPTION
## error

**helloworld.c** and **Helloworld.c** are recognized as the same file

I found a small issue with neo-tree. For example, if your file is named:

`helloworld.c`

and you want to rename it to:

`Helloworld.c`

you will get the ` warning: already exists, canceling`.

---

Neovim version information:

```
NVIM v0.10.4
Build type: Release
LuaJIT 2.1.1741730670
Run ":verbose version" for more info
```

---

System info:
```
Darwin IUSX 24.1.0 Darwin Kernel Version 24.1.0: Thu Oct 10 21:03:11 PDT 2024; root:xnu-11215.41.3~2/RELEASE_ARM64_T6020 arm64
```

I know this issue doesn’t exist on Linux, but it does exist on my macOS system. This PR might have some issues, but it works fine on my system and fixes the problem. However, the code might not be very elegant.