### PR TITLE
fix(filesystem): prevent infinite loop when scanning a directory containing entries more than ENTRIES_BATCH_SIZE

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -419,8 +419,8 @@ local function sync_scan(context, path_to_scan)
   else -- scan_mode == "shallow"
     local dir, err = uv.fs_opendir(path_to_scan, nil, ENTRIES_BATCH_SIZE)
     if dir then
-      local stats = uv.fs_readdir(dir)
       repeat
+        local stats = uv.fs_readdir(dir)
         if not stats then
           break
         end


### PR DESCRIPTION
`sync_scan` function causes infinite loop when scanning a directory containing entries more than `ENTRIES_BATCH_SIZE` in `shallow` scan mode.
This PR fixes that issue.