### PR TITLE
fix(events): don't clear before events are defined

### DIFF
--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -477,7 +477,6 @@ M.merge_config = function(user_config)
 
   if events_setup then
     events.clear_all_events()
-    events_setup = false
   end
   define_events()
 

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -475,7 +475,10 @@ M.merge_config = function(user_config)
   log.use_file(user_config.log_to_file, true)
   log.debug("setup")
 
-  events.clear_all_events()
+  if events_setup then
+    events.clear_all_events()
+    events_setup = false
+  end
   define_events()
 
   -- Prevent netrw hijacking lazy-loading from conflicting with normal hijacking.


### PR DESCRIPTION
fixes integration with nvim-lsp-file-operations

Closes #1782 