### PR TITLE
fix(renderer): fix cut & paste stack overflow on hidden root

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -10,6 +10,7 @@ local keymap = require("nui.utils.keymap")
 local autocmd = require("nui.utils.autocmd")
 local log = require("neo-tree.log")
 local windows = require("neo-tree.ui.windows")
+local nt = require("neo-tree")
 
 local M = { resize_timer_interval = 50 }
 local ESC_KEY = utils.keycode("<ESC>")
@@ -657,13 +658,14 @@ M.position = {
     end
   end,
   set = function(state, node_id)
-    if not type(node_id) == "string" and node_id > "" then
+    if type(node_id) ~= "string" or node_id == "" then
       return
     end
-    local manager = require("neo-tree.sources.manager")
-    local hide_root_node = require("neo-tree").config.hide_root_node
-    if hide_root_node and node_id == manager.get_cwd(state) then
-      return
+    if state.tree then
+      local node = state.tree:get_node(node_id)
+      if node and node.skip_node then
+        return
+      end
     end
     state.position.node_id = node_id
   end,

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -660,6 +660,11 @@ M.position = {
     if not type(node_id) == "string" and node_id > "" then
       return
     end
+    local manager = require("neo-tree.sources.manager")
+    local hide_root_node = require("neo-tree").config.hide_root_node
+    if hide_root_node and node_id == manager.get_cwd(state) then
+      return
+    end
     state.position.node_id = node_id
   end,
   clear = function(state)

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -660,9 +660,7 @@ M.position = {
     if not type(node_id) == "string" and node_id > "" then
       return
     end
-    local manager = require("neo-tree.sources.manager")
-    local hide_root_node = require("neo-tree").config.hide_root_node
-    if hide_root_node and node_id == manager.get_cwd(state) then
+    if state.tree and state.tree:get_node(node_id).skip_node then
       return
     end
     state.position.node_id = node_id

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -660,7 +660,9 @@ M.position = {
     if not type(node_id) == "string" and node_id > "" then
       return
     end
-    if state.tree and state.tree:get_node(node_id).skip_node then
+    local manager = require("neo-tree.sources.manager")
+    local hide_root_node = require("neo-tree").config.hide_root_node
+    if hide_root_node and node_id == manager.get_cwd(state) then
       return
     end
     state.position.node_id = node_id


### PR DESCRIPTION
This fixes stack overflow when cutting and pasting a file with 'hide_root_node = true' (#1517). The renderer was trying to focus a hidden root node.