### PR TITLE
fix: schedule quit for `close_if_last_window`

### DIFF
--- a/plugin/neo-tree.lua
+++ b/plugin/neo-tree.lua
@@ -150,7 +150,9 @@ vim.api.nvim_create_autocmd("WinClosed", {
         return
       end
     end
-    vim.cmd("qa!")
+    vim.schedule(function()
+      vim.cmd("q!")
+    end)
   end,
 })
 

--- a/plugin/neo-tree.lua
+++ b/plugin/neo-tree.lua
@@ -150,6 +150,7 @@ vim.api.nvim_create_autocmd("WinClosed", {
         return
       end
     end
+    -- this needs to be scheduled, otherwise VimLeavePre autocmds won't trigger
     vim.schedule(function()
       vim.cmd("q!")
     end)


### PR DESCRIPTION
Closes #1836 

Apparently when a quit isn't scheduled it prevents leaving autocmds from working.