### PR TITLE
fix(renderer): don't clear node id focus on CursorMoved

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -711,10 +711,11 @@ M.position.restore = function(state)
     end)
   end
   if state.position.node_id then
-    print(state.position.node_id)
     log.debug("Focusing on node_id: " .. state.position.node_id)
+    vim.print("Focusing on node_id: " .. state.position.node_id)
     M.focus_node(state, state.position.node_id, true)
   end
+
   M.position.clear(state)
 end
 
@@ -1103,8 +1104,10 @@ M.acquire_window = function(state)
     vim.api.nvim_set_current_win(state.winid)
     -- Used to track the position of the cursor within the tree as it gains and loses focus
     win:on({ "CursorMoved" }, function()
-      M.position.clear(state)
-      M.position.save(state)
+      if win.winid == vim.api.nvim_get_current_win() then
+        M.position.clear(state)
+        M.position.save(state)
+      end
     end)
     win:on({ "BufDelete" }, function()
       M.position.save(state)

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -660,8 +660,9 @@ M.position = {}
 
 ---Saves a window position to be restored later
 ---@param state neotree.State
-M.position.save = function(state)
-  if state.position.topline and state.position.lnum then
+---@param force boolean?
+M.position.save = function(state, force)
+  if not force and state.position.topline and state.position.lnum then
     log.debug("There's already a position saved to be restored. Cannot save another.")
     return
   end
@@ -712,7 +713,6 @@ M.position.restore = function(state)
   end
   if state.position.node_id then
     log.debug("Focusing on node_id: " .. state.position.node_id)
-    vim.print("Focusing on node_id: " .. state.position.node_id)
     M.focus_node(state, state.position.node_id, true)
   end
 
@@ -1105,8 +1105,7 @@ M.acquire_window = function(state)
     -- Used to track the position of the cursor within the tree as it gains and loses focus
     win:on({ "CursorMoved" }, function()
       if win.winid == vim.api.nvim_get_current_win() then
-        M.position.clear(state)
-        M.position.save(state)
+        M.position.save(state, true)
       end
     end)
     win:on({ "BufDelete" }, function()

--- a/tests/neo-tree/command/command_spec.lua
+++ b/tests/neo-tree/command/command_spec.lua
@@ -8,7 +8,6 @@ local run_focus_command = function(command, expected_tree_node)
 
   vim.cmd(command)
   u.wait_for_neo_tree({ interval = 10, timeout = 200 })
-  --u.wait_for_neo_tree()
   verify.window_handle_is_not(winid)
   verify.buf_name_endswith("neo-tree filesystem [1]")
   if expected_tree_node then
@@ -130,6 +129,20 @@ describe("Command", function()
       local testfile = fs_tree.lookup["topfile1"].abspath
       u.editfile(testfile)
       run_focus_command(cmd, testfile)
+    end)
+
+    it("`:Neotree reveal` should also reveal properly when cursormoved triggers", function()
+      local testfile = fs_tree.lookup["./foo/bar/baz2.txt"].abspath
+      u.editfile(testfile)
+      require("neo-tree.command").execute({
+        toggle = true,
+        reveal = true,
+        reveal_force_cwd = true,
+      })
+
+      -- It seems like in headless mode, CursorMoved is not emitted.
+      vim.api.nvim_exec_autocmds("CursorMoved", {})
+      verify.filesystem_tree_node_is(testfile)
     end)
   end)
 


### PR DESCRIPTION
Resolves this regression https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1838#issuecomment-3240307703

CursorMoved is apparently not emitted in headless mode, which is why the tests didn't catch this regression. A new test has been added to cover this regression.