### PR TITLE
fix: handle custom uris when revealing files

### DIFF
--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1177,7 +1177,7 @@ M.abspath_prefix = function(path)
       or path:match([[^/]])
   end
 
-  return path:match("^/") or path:match("^[^:/]+://")
+  return path:match("^/")
 end
 
 local table_merge_internal


### PR DESCRIPTION
Closes #1875 

a weird-looking fix but this just reverts to what neo-tree did before whenever a custom uri is opened