### PR TITLE
fix(log): remove file attribute on close

### DIFF
--- a/lua/neo-tree/log.lua
+++ b/lua/neo-tree/log.lua
@@ -144,7 +144,6 @@ log_maker.new = function(config)
       -- Assume that subsequent writes will fail too, so stop logging to file.
       log.use_file(false, true)
       log.error("Error writing to log:", writeerr)
-      log.file:close()
     end
 
     local curtime = os.time()
@@ -200,8 +199,7 @@ log_maker.new = function(config)
       -- Ignore this if vim is exiting
       if vim.v.dying > 0 or vim.v.exiting ~= vim.NIL then
         if log.file then
-          config.use_file = false
-          log.file:close()
+          log.use_file(false, true)
         end
       end
 
@@ -313,6 +311,10 @@ log_maker.new = function(config)
   log.use_file = function(file, quiet)
     if file == false then
       config.use_file = false
+      if log.file then
+        log.file:close()
+        log.file = nil
+      end
       if not quiet then
         log.info("Logging to file disabled")
       end
@@ -374,9 +376,7 @@ log_maker.new = function(config)
     else
       errmsg = "assertion failed!"
     end
-    if config.use_file then
-      log_to_file("ERROR", errmsg)
-    end
+    log.error(errmsg)
     return assert(v, errmsg)
   end
 


### PR DESCRIPTION
Should actually close #1882

mistakenly thought file:close was a no-op on already-closed files