### PR TITLE
fix(utils): update broken table_move call site after refactor

### DIFF
--- a/plugin/neo-tree.lua
+++ b/plugin/neo-tree.lua
@@ -62,7 +62,7 @@ vim.api.nvim_create_autocmd({ "WinEnter" }, {
       ---@diagnostic disable-next-line: deprecated
       if table.move then
         utils.prior_windows[tabid] =
-          require("neo-tree.utils._compat").table_move(tab_windows, 80, win_count, 1, {})
+          require("neo-tree.utils._compat").luajit.table_move(tab_windows, 80, win_count, 1, {})
         return
       end
 


### PR DESCRIPTION
#1946 left behind an use of the old `utils._compat.table_move` (now renamed to `utils._compat.luajit.table_move`). This causes crashes when the invocation is reached (e.g. [nvim-dap-ui](https://github.com/rcarriga/nvim-dap-ui) will trigger the bug under certain conditions). 