### PR TITLE
fix(renderer): save position on neo-tree window scrolled

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1059,7 +1059,7 @@ local attach_position_autocmds = function(nt_bufnr, state)
     end,
   })
 
-  autocmd({ "CursorMoved", "ModeChanged" }, {
+  autocmd({ "CursorMoved", "ModeChanged", "WinScrolled" }, {
     buffer = nt_bufnr,
     callback = function(args)
       if state.bufnr ~= args.buf then


### PR DESCRIPTION
Fix the wired jumping when we scroll the file tree and click the file, usually happens when we use a mouse.

Before:

https://github.com/user-attachments/assets/f83fd006-8bff-45b4-9863-d5c3a9cd1a6d


After:

https://github.com/user-attachments/assets/a66c8893-f1b3-4e54-9b79-1416b9bb3e50

