### PR TITLE
Fix(git): next_git_modified broken

### DIFF
--- a/lua/neo-tree/sources/filesystem/commands.lua
+++ b/lua/neo-tree/sources/filesystem/commands.lua
@@ -148,13 +148,13 @@ end
 local focus_next_git_modified = function(state, reverse)
   local node = assert(state.tree:get_node())
   local current_path = node:get_id()
-  local _, worktreeInfo = require("neo-tree.git").find_existing_worktree(current_path)
-  if not utils.truthy(worktreeInfo) then
+  local _, worktree_info = require("neo-tree.git").find_existing_worktree(current_path)
+  if not utils.truthy(worktree_info) then
     return
   end
-  ---@cast worktreeInfo -nil
+  ---@cast worktree_info -nil
   local paths = { current_path }
-  for path, status in pairs(worktreeInfo.status) do
+  for path, status in pairs(worktree_info.status) do
     if path ~= current_path and not vim.tbl_contains({ "!", "?" }, status) then
       --don't include files not in the current working directory
       if utils.is_subpath(state.path, path) then


### PR DESCRIPTION
neo-tree.git.find_existing_status removed from #1958 but neo-tree.sources.filesystem.commands.focus_next
_git_modified keep using it