### PR TITLE
fix(git): upkeep watcher refs, enable watch for sync git_status

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -51,11 +51,15 @@ local on_directory_loaded = function(context, dir_path)
         return
       end
     end
-    if nt.config.enable_git_status and nt.config.git_status_async then
+    if nt.config.enable_git_status then
       for i, child in ipairs(folder.children) do
         if vim.endswith(child.path, ".git") and not git.find_existing_worktree(child.path) then
           -- try running a status (and potentially start tracking)
-          git.status_async(target_path, nil, nt.config.git_status_async_options)
+          if nt.config.git_status_async then
+            git.status_async(target_path, nil, nt.config.git_status_async_options)
+          else
+            git.status(target_path, nil, false)
+          end
           break
         end
       end


### PR DESCRIPTION
close(https://github.com/nvim-neo-tree/neo-tree.nvim/issues/724)

1. After each render, there will do `watcher.references - 1`. When `watcher.references == 0`, the watcher will stop. Therefore, every time a git status refresh is triggered, watch_folder need to be triggered to do `watcher.references + 1`.

2. If set `filesystem.use_libuv_file_watcher = true`, it means that when the git state of the current repository is modified outside of neovim—for example, by using the git command line, any change to the `.git` directory will trigger `Neotree` to refresh git-status. This is unrelated to whether `git_status_async` is enabled.