### PR TITLE
fix(git): process GIT_EVENT for git_status_async again

### DIFF
--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -402,12 +402,10 @@ M.setup = function(config, global_config)
 
   -- Respond to git events from git_status source or Fugitive
   if global_config.enable_git_status then
-    if not global_config.git_status_async then
-      manager.subscribe(M.name, {
-        event = events.GIT_EVENT,
-        handler = wrap(manager.refresh),
-      })
-    end
+    manager.subscribe(M.name, {
+      event = events.GIT_EVENT,
+      handler = wrap(manager.refresh),
+    })
     manager.subscribe(M.name, {
       event = events.GIT_STATUS_CHANGED,
       handler = wrap(manager.git_status_changed),


### PR DESCRIPTION
Found the boundary condition in the previous commit.A corner case for issue: https://github.com/nvim-neo-tree/neo-tree.nvim/issues/724

Handle event `GIT_EVENT` in `enable_git_status = true` both when use git_status_sync/git_status_async. I’m not sure why this check was added, but it works after removing it.