### PR TITLE
fix(command): prevent focus stealing in action="show"

### DIFF
--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -36,6 +36,7 @@ local function do_show_or_focus(args, state, force_navigate)
       return
     end
     -- close_other_sources()
+    state._no_focus = true
     local current_win = vim.api.nvim_get_current_win()
     manager.navigate(state, args.dir, args.reveal_file, function()
       -- navigate changes the window to neo-tree, so just quickly hop back to the original window

--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -39,10 +39,14 @@ local function do_show_or_focus(args, state, force_navigate)
     -- Prevent focus stealing: use nvim_open_win(enter=false) in acquire_window.
     -- This avoids WinEnter/WinLeave side effects (e.g. closing yazi.nvim floats).
     state._no_focus = true
-    local current_win = vim.api.nvim_get_current_win()
+    local previous_win = vim.api.nvim_get_current_win()
     manager.navigate(state, args.dir, args.reveal_file, function()
       -- navigate changes the window to neo-tree, so just quickly hop back to the original window
-      vim.api.nvim_set_current_win(current_win)
+      if
+        vim.api.nvim_win_is_valid(previous_win) and vim.api.nvim_get_current_win() ~= previous_win
+      then
+        vim.api.nvim_set_current_win(previous_win)
+      end
     end, false)
   elseif args.action == "focus" then
     -- "focus" mean open and jump to the window if closed, and just focus it if already opened
@@ -252,6 +256,5 @@ M._command = function(...)
   local args = parser.parse({ ... }, true)
   M.execute(args)
 end
-
 
 return M

--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -36,6 +36,8 @@ local function do_show_or_focus(args, state, force_navigate)
       return
     end
     -- close_other_sources()
+    -- Prevent focus stealing: use nvim_open_win(enter=false) in acquire_window.
+    -- This avoids WinEnter/WinLeave side effects (e.g. closing yazi.nvim floats).
     state._no_focus = true
     local current_win = vim.api.nvim_get_current_win()
     manager.navigate(state, args.dir, args.reveal_file, function()
@@ -44,6 +46,7 @@ local function do_show_or_focus(args, state, force_navigate)
     end, false)
   elseif args.action == "focus" then
     -- "focus" mean open and jump to the window if closed, and just focus it if already opened
+    state._no_focus = nil -- clear no-focus flag for focus mode
     if window_exists then
       vim.api.nvim_set_current_win(state.winid)
     end
@@ -249,5 +252,6 @@ M._command = function(...)
   local args = parser.parse({ ... }, true)
   M.execute(args)
 end
+
 
 return M

--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -36,6 +36,9 @@ local function do_show_or_focus(args, state, force_navigate)
       return
     end
     -- close_other_sources()
+    -- Prevent focus stealing: use nvim_open_win(enter=false) in acquire_window.
+    -- This avoids WinEnter/WinLeave side effects (e.g. closing yazi.nvim floats).
+    state._no_focus = true
     local current_win = vim.api.nvim_get_current_win()
     manager.navigate(state, args.dir, args.reveal_file, function()
       -- navigate changes the window to neo-tree, so just quickly hop back to the original window
@@ -43,6 +46,7 @@ local function do_show_or_focus(args, state, force_navigate)
     end, false)
   elseif args.action == "focus" then
     -- "focus" mean open and jump to the window if closed, and just focus it if already opened
+    state._no_focus = nil -- clear no-focus flag for focus mode
     if window_exists then
       vim.api.nvim_set_current_win(state.winid)
     end
@@ -248,5 +252,6 @@ M._command = function(...)
   local args = parser.parse({ ... }, true)
   M.execute(args)
 end
+
 
 return M

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -374,16 +374,7 @@ M.merge_config = function(user_config)
     event = events.VIM_BUFFER_ENTER,
     handler = M.buffer_enter_event,
   })
-  events.subscribe({
-    event = events.NEO_TREE_WINDOW_AFTER_OPEN,
-    handler = function(args)
-      if not vim.w[args.winid].neo_tree_settings_applied then
-        -- TODO: should figure out a less disorganized way to set window options
-        -- BufEnter doesn't trigger while vim is starting up so this will handle it instead.
-        M.buffer_enter_event()
-      end
-    end,
-  })
+  require("neo-tree.ui.renderer").setup_option_autocmds()
 
   if user_config.event_handlers ~= nil then
     for _, handler in ipairs(user_config.event_handlers) do
@@ -618,7 +609,6 @@ M.merge_config = function(user_config)
   end
 
   require("neo-tree.clipboard").setup(M.config.clipboard)
-  require("neo-tree.ui.renderer").setup_option_autocmds()
 
   return M.config
 end

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -108,54 +108,6 @@ local define_events = function()
   })
 end
 
-local prior_window_options = {}
-
---- Store the current window options so we can restore them when we close the tree.
---- @param winid number | nil The window id to store the options for, defaults to current window
-local store_local_window_settings = function(winid)
-  winid = winid or vim.api.nvim_get_current_win()
-  local neo_tree_settings_applied, _ =
-    pcall(vim.api.nvim_win_get_var, winid, "neo_tree_settings_applied")
-  if neo_tree_settings_applied then
-    -- don't store our own window settings
-    return
-  end
-  prior_window_options[tostring(winid)] = {
-    cursorline = vim.wo.cursorline,
-    cursorlineopt = vim.wo.cursorlineopt,
-    foldcolumn = vim.wo.foldcolumn,
-    wrap = vim.wo.wrap,
-    list = vim.wo.list,
-    spell = vim.wo.spell,
-    number = vim.wo.number,
-    relativenumber = vim.wo.relativenumber,
-    winhighlight = vim.wo.winhighlight,
-  }
-end
-
---- Restore the window options for the current window
---- @param winid number | nil The window id to restore the options for, defaults to current window
-local restore_local_window_settings = function(winid)
-  winid = winid or vim.api.nvim_get_current_win()
-  -- return local window settings to their prior values
-  local wo = prior_window_options[tostring(winid)]
-  if wo then
-    vim.wo.cursorline = wo.cursorline
-    vim.wo.cursorlineopt = wo.cursorlineopt
-    vim.wo.foldcolumn = wo.foldcolumn
-    vim.wo.wrap = wo.wrap
-    vim.wo.list = wo.list
-    vim.wo.spell = wo.spell
-    vim.wo.number = wo.number
-    vim.wo.relativenumber = wo.relativenumber
-    vim.wo.winhighlight = wo.winhighlight
-    log.debug("Window settings restored")
-    vim.api.nvim_win_set_var(0, "neo_tree_settings_applied", false)
-  else
-    log.debug("No window settings to restore")
-  end
-end
-
 local last_buffer_enter_filetype = nil
 M.buffer_enter_event = function()
   -- if it is a neo-tree window, just set local options
@@ -163,35 +115,14 @@ M.buffer_enter_event = function()
     if last_buffer_enter_filetype == "neo-tree" then
       -- we've switched to another neo-tree window
       events.fire_event(events.NEO_TREE_BUFFER_LEAVE)
-    else
-      store_local_window_settings()
-    end
-    vim.cmd([[
-    setlocal cursorline
-    setlocal cursorlineopt=line
-    setlocal nowrap
-    setlocal nolist nospell nonumber norelativenumber
-    ]])
-
-    local winhighlight =
-      "Normal:NeoTreeNormal,NormalNC:NeoTreeNormalNC,SignColumn:NeoTreeSignColumn,CursorLine:NeoTreeCursorLine,FloatBorder:NeoTreeFloatBorder,StatusLine:NeoTreeStatusLine,StatusLineNC:NeoTreeStatusLineNC,VertSplit:NeoTreeVertSplit,EndOfBuffer:NeoTreeEndOfBuffer"
-    if vim.version().minor >= 7 then
-      vim.cmd("setlocal winhighlight=" .. winhighlight .. ",WinSeparator:NeoTreeWinSeparator")
-    else
-      vim.cmd("setlocal winhighlight=" .. winhighlight)
     end
 
     events.fire_event(events.NEO_TREE_BUFFER_ENTER)
     last_buffer_enter_filetype = vim.bo.filetype
-    vim.api.nvim_win_set_var(0, "neo_tree_settings_applied", true)
     return
   end
 
   if vim.bo.filetype == "neo-tree-popup" then
-    vim.cmd([[
-    setlocal winhighlight=Normal:NeoTreeFloatNormal,FloatBorder:NeoTreeFloatBorder
-    setlocal nolist nospell nonumber norelativenumber
-    ]])
     events.fire_event(events.NEO_TREE_POPUP_BUFFER_ENTER)
     last_buffer_enter_filetype = vim.bo.filetype
     return
@@ -452,24 +383,6 @@ M.merge_config = function(user_config)
         M.buffer_enter_event()
       end
     end,
-  })
-
-  -- Setup autocmd for neo-tree BufLeave, to restore window settings.
-  -- This is set to happen just before leaving the window.
-  -- The patterns used should ensure it only runs in neo-tree windows where position = "current"
-  local augroup = vim.api.nvim_create_augroup("NeoTree_BufLeave", { clear = true })
-  local bufleave = function(data)
-    -- Vim patterns in autocmds are not quite precise enough
-    -- so we are doing a second stage filter in lua
-    local pattern = "neo%-tree [^ ]+ %[1%d%d%d%]"
-    if string.match(data.file, pattern) then
-      restore_local_window_settings()
-    end
-  end
-  vim.api.nvim_create_autocmd({ "BufWinLeave" }, {
-    group = augroup,
-    pattern = "neo-tree *",
-    callback = bufleave,
   })
 
   if user_config.event_handlers ~= nil then

--- a/lua/neo-tree/setup/init.lua
+++ b/lua/neo-tree/setup/init.lua
@@ -618,6 +618,7 @@ M.merge_config = function(user_config)
   end
 
   require("neo-tree.clipboard").setup(M.config.clipboard)
+  require("neo-tree.ui.renderer").setup_option_autocmds()
 
   return M.config
 end

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -84,6 +84,7 @@ local function create_state(tabid, sd, winid)
   ---private-ish
   ---@field orig_tree NuiTree?
   ---@field _ready boolean?
+  ---@field _no_focus boolean?
   ---@field _skip_consuming_selection boolean?
   ---@field loading boolean?
   ---window

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -3,6 +3,7 @@ local NuiTree = require("nui.tree")
 local NuiSplit = require("nui.split")
 local NuiPopup = require("nui.popup")
 local utils = require("neo-tree.utils")
+local compat = require("neo-tree.utils._compat")
 local highlights = require("neo-tree.ui.highlights")
 local popups = require("neo-tree.ui.popups")
 local events = require("neo-tree.events")
@@ -1252,6 +1253,9 @@ M.acquire_window = function(state)
   -- used by tests to determine if the tree is ready for testing
   state._ready = false
 
+  -- Check the no-focus flag set by command/init.lua action="show".
+  local no_focus = state._no_focus == true
+
   local default_position = utils.resolve_config_option(state, "window.position", "left")
   local relative = utils.resolve_config_option(state, "window.relative", "editor")
   state.current_position = state.current_position or default_position
@@ -1314,6 +1318,39 @@ M.acquire_window = function(state)
       state.bufnr = buf
       state.winid = location.winid
       vim.api.nvim_win_set_buf(state.winid, state.bufnr)
+    elseif no_focus and compat.has_split_win() and nofocus_split_map[state.current_position] then
+      -- Use nvim_open_win with enter=false (Neovim 0.10+) to create the split
+      -- without stealing focus. This avoids triggering WinEnter/BufEnter events
+      -- for the neo-tree window entirely.
+      close_old_window()
+      state.bufnr = vim.api.nvim_create_buf(false, true)
+      local size = utils.resolve_config_option(state, size_opt, default_size)
+      if type(size) == "string" then
+        size = tonumber(size)
+      end
+      local win_config = {
+        split = nofocus_split_map[state.current_position],
+        win = 0,
+      }
+      if state.current_position == "left" or state.current_position == "right" then
+        win_config.width = size or 40
+      else
+        win_config.height = size or 15
+      end
+      state.winid = vim.api.nvim_open_win(state.bufnr, false, win_config)
+      location.winid = state.winid
+      -- Apply buffer and window options that NuiSplit would normally set
+      for k, v in pairs(win_options.buf_options) do
+        vim.api.nvim_set_option_value(k, v, { buf = state.bufnr })
+      end
+      for k, v in pairs(win_options.win_options) do
+        vim.api.nvim_set_option_value(k, v, { win = state.winid })
+      end
+      if win_options.ns_id then
+        vim.api.nvim_win_set_hl_ns(state.winid, win_options.ns_id)
+      end
+      -- Mark as a "win" so the post-setup block runs (bufname, autocmds, etc.)
+      win = { winid = state.winid, bufnr = state.bufnr }
     else
       close_old_window()
       new_win = NuiSplit(nui_win_options)
@@ -1333,6 +1370,10 @@ M.acquire_window = function(state)
       state.bufnr = new_win.bufnr
       state.winid = new_win.winid
       location.winid = state.winid
+      -- Restore focus if no_focus is set (fallback for nvim < 0.10)
+      if saved_win and vim.api.nvim_win_is_valid(saved_win) then
+        vim.api.nvim_set_current_win(saved_win)
+      end
     end
     location.source = state.name
   end
@@ -1354,6 +1395,7 @@ M.acquire_window = function(state)
   end
 
   set_buffer_mappings(state)
+  state._no_focus = nil
   return state.winid
 end
 

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1159,11 +1159,6 @@ end
 ---@param win number
 ---@param buf number
 local function set_neo_tree_options(win, buf)
-  vim.print({
-    "setting",
-    win,
-    buf,
-  })
   if local_options_set[win] and local_options_set[win][buf] then
     return
   end
@@ -1356,39 +1351,6 @@ M.acquire_window = function(state)
       state.bufnr = buf
       state.winid = location.winid
       vim.api.nvim_win_set_buf(state.winid, state.bufnr)
-    elseif no_focus and compat.has_split_win() and nofocus_split_map[state.current_position] then
-      -- Use nvim_open_win with enter=false (Neovim 0.10+) to create the split
-      -- without stealing focus. This avoids triggering WinEnter/BufEnter events
-      -- for the neo-tree window entirely.
-      close_old_window()
-      state.bufnr = vim.api.nvim_create_buf(false, true)
-      local size = utils.resolve_config_option(state, size_opt, default_size)
-      if type(size) == "string" then
-        size = tonumber(size)
-      end
-      local win_config = {
-        split = nofocus_split_map[state.current_position],
-        win = 0,
-      }
-      if state.current_position == "left" or state.current_position == "right" then
-        win_config.width = size or 40
-      else
-        win_config.height = size or 15
-      end
-      state.winid = vim.api.nvim_open_win(state.bufnr, false, win_config)
-      location.winid = state.winid
-      -- Apply buffer and window options that NuiSplit would normally set
-      for k, v in pairs(win_options.buf_options) do
-        vim.api.nvim_set_option_value(k, v, { buf = state.bufnr })
-      end
-      for k, v in pairs(win_options.win_options) do
-        vim.api.nvim_set_option_value(k, v, { win = state.winid })
-      end
-      if win_options.ns_id then
-        vim.api.nvim_win_set_hl_ns(state.winid, win_options.ns_id)
-      end
-      -- Mark as a "win" so the post-setup block runs (bufname, autocmds, etc.)
-      win = { winid = state.winid, bufnr = state.bufnr }
     else
       close_old_window()
       new_win = NuiSplit(nui_win_options)
@@ -1408,10 +1370,6 @@ M.acquire_window = function(state)
       state.bufnr = new_win.bufnr
       state.winid = new_win.winid
       location.winid = state.winid
-      -- Restore focus if no_focus is set (fallback for nvim < 0.10)
-      if saved_win and vim.api.nvim_win_is_valid(saved_win) then
-        vim.api.nvim_set_current_win(saved_win)
-      end
     end
     location.source = state.name
   end

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1087,23 +1087,17 @@ local function create_floating_window(state, win_options)
       win:unmount()
     end)
   end, { once = true })
-  state.winid = win.winid
-  state.bufnr = win.bufnr
   log.debug("Created floating window with winid:", win.winid, " and bufnr:", win.bufnr)
-
-  -- why is this necessary?
-  vim.api.nvim_set_current_win(win.winid)
   return win
 end
 
 local autocmd = vim.api.nvim_create_autocmd
 ---Tracks position for the neo-tree bufnr
----@param nt_bufnr integer
 ---@param state neotree.State
-local attach_position_autocmds = function(state)
+---@param nt_bufnr integer
+local attach_position_autocmds = function(state, nt_bufnr)
   local position_augroup = vim.api.nvim_create_augroup("NeoTreePosition", { clear = false })
   local wait_for_restore = true
-  local nt_bufnr = assert(state.bufnr)
 
   autocmd("BufDelete", {
 
@@ -1120,7 +1114,7 @@ local attach_position_autocmds = function(state)
     buffer = nt_bufnr,
     group = position_augroup,
     callback = function(args)
-      if state.bufnr ~= args.buf then
+      if nt_bufnr ~= args.buf then
         return
       end
 
@@ -1138,8 +1132,11 @@ local attach_position_autocmds = function(state)
     buffer = nt_bufnr,
     group = position_augroup,
     callback = function(args)
+      if not state.winid then
+        return
+      end
       M.position.restore_selection(state)
-      if state.bufnr ~= args.buf then
+      if nt_bufnr ~= args.buf then
         wait_for_restore = true
         return
       end
@@ -1216,21 +1213,13 @@ M.setup_option_autocmds = function()
     callback = function(args)
       local win = vim.api.nvim_get_current_win()
       local buf = vim.api.nvim_win_get_buf(win)
-      if vim.bo[buf].filetype ~= "neo-tree" then
-        return
+      local ft = vim.bo[buf].filetype
+      if ft == "neo-tree" then
+        set_neo_tree_options(win, args.buf)
+      elseif ft == "neo-tree-popup" then
+        set_neo_tree_options(win, args.buf)
       end
       set_neo_tree_options(win, args.buf)
-    end,
-  })
-  autocmd({ "BufWinEnter", "BufEnter", "TabEnter", "WinEnter" }, {
-    group = option_augroup,
-    callback = function()
-      local win = vim.api.nvim_get_current_win()
-      local buf = vim.api.nvim_win_get_buf(win)
-      if vim.bo[buf].filetype ~= "neo-tree-popup" then
-        return
-      end
-      set_neo_tree_popup_options(win, buf)
     end,
   })
 end
@@ -1256,6 +1245,7 @@ local setup_buffer = function(state, bufnr)
   for k, v in pairs(neo_tree_buffer_options) do
     bo[k] = v
   end
+  attach_position_autocmds(state, bufnr)
 end
 
 ---Tries to reuse a neo-tree buffer, or creates a new one.
@@ -1330,6 +1320,7 @@ M.acquire_window = function(state)
     M.close(state)
     state.bufnr = get_buffer(state)
     new_win = create_floating_window(state, nui_win_options)
+    state.winid = new_win.winid
   elseif state.current_position == "current" then
     -- state.id is always the window id or tabnr that this state was created for
     -- in the case of a position = current state object, it will be the window id

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1222,9 +1222,6 @@ M.setup_option_autocmds = function()
   })
 end
 
---todo: move to setup
-M.setup_option_autocmds()
-
 ---@type vim.bo
 local neo_tree_buffer_options = {
   buftype = "nofile",

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -3,7 +3,6 @@ local NuiTree = require("nui.tree")
 local NuiSplit = require("nui.split")
 local NuiPopup = require("nui.popup")
 local utils = require("neo-tree.utils")
-local compat = require("neo-tree.utils._compat")
 local highlights = require("neo-tree.ui.highlights")
 local popups = require("neo-tree.ui.popups")
 local events = require("neo-tree.events")
@@ -937,7 +936,7 @@ local get_tagged_selected_nodes = function(state)
 end
 
 ---@param func function command
----@param state neotree.StateWithTree
+---@param state neotree.State
 ---@param config table
 ---@param fallback string
 ---@param selected_nodes NuiTree.Node[]?
@@ -1094,10 +1093,10 @@ end
 local autocmd = vim.api.nvim_create_autocmd
 ---Tracks position for the neo-tree bufnr
 ---@param state neotree.State
----@param nt_bufnr integer
-local attach_position_autocmds = function(state, nt_bufnr)
+local attach_position_autocmds = function(state)
   local position_augroup = vim.api.nvim_create_augroup("NeoTreePosition", { clear = false })
   local wait_for_restore = true
+  local nt_bufnr = state.bufnr
 
   autocmd("BufDelete", {
 
@@ -1217,9 +1216,8 @@ M.setup_option_autocmds = function()
       if ft == "neo-tree" then
         set_neo_tree_options(win, args.buf)
       elseif ft == "neo-tree-popup" then
-        set_neo_tree_options(win, args.buf)
+        set_neo_tree_popup_options(win, args.buf)
       end
-      set_neo_tree_options(win, args.buf)
     end,
   })
 end
@@ -1239,35 +1237,33 @@ local neo_tree_buffer_options = {
 local state_bufname = function(state)
   return string.format("neo-tree %s [%s]", state.name, state.id)
 end
-local setup_buffer = function(state, bufnr)
+local setup_buffer = function(state)
+  local bufnr = assert(state.bufnr, "state needs a buffer")
   vim.api.nvim_buf_set_name(bufnr, state_bufname(state))
   local bo = vim.bo[bufnr]
   for k, v in pairs(neo_tree_buffer_options) do
     bo[k] = v
   end
-  attach_position_autocmds(state, bufnr)
+  set_buffer_mappings(state)
 end
 
 ---Tries to reuse a neo-tree buffer, or creates a new one.
 ---@param state neotree.State
----@return integer bufnr
----@nodiscard
-local get_buffer = function(state)
+local assign_buffer = function(state)
   local bufnr = vim.fn.bufnr(state_bufname(state))
   if bufnr > 0 then
-    if vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr) then
-      return bufnr
+    if vim.api.nvim_buf_is_loaded(bufnr) then
+      state.bufnr = bufnr
+      return
     else
       pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
       bufnr = 0
     end
   end
 
-  if bufnr < 1 then
-    bufnr = vim.api.nvim_create_buf(false, false)
-    setup_buffer(state, bufnr)
-  end
-  return bufnr
+  bufnr = vim.api.nvim_create_buf(false, false)
+  state.bufnr = bufnr
+  setup_buffer(state)
 end
 
 local pos_to_splitdir = {
@@ -1318,7 +1314,7 @@ M.acquire_window = function(state)
   if state.current_position == "float" then
     M.close_all_floating_windows()
     M.close(state)
-    state.bufnr = get_buffer(state)
+    assign_buffer(state)
     new_win = create_floating_window(state, nui_win_options)
     state.winid = new_win.winid
   elseif state.current_position == "current" then
@@ -1330,7 +1326,7 @@ M.acquire_window = function(state)
       return
     end
     state.winid = winid
-    state.bufnr = get_buffer(state)
+    assign_buffer(state)
     vim.api.nvim_win_set_buf(state.winid, state.bufnr)
   else
     local close_old_window = function(new_winid)
@@ -1343,15 +1339,15 @@ M.acquire_window = function(state)
     local location = windows.get_location(state.current_position)
     if location.winid > 0 then
       close_old_window(location.winid)
-      state.bufnr = get_buffer(state)
+      assign_buffer(state)
       state.winid = location.winid
       vim.api.nvim_win_set_buf(state.winid, state.bufnr)
     else
       close_old_window()
       new_win = NuiSplit(nui_win_options)
-      ---NuiSplit does not have a way to pass in a custom buffer. Take the one from nuisplit
-      setup_buffer(state, new_win.bufnr)
       state.bufnr = new_win.bufnr
+      ---NuiSplit does not have a way to pass in a custom buffer. Take the one from nuisplit
+      setup_buffer(state)
 
       if not enter and vim.fn.has("nvim-0.10") == 1 then
         -- hijack the window with a custom split method that doesn't emit winleave
@@ -1383,11 +1379,15 @@ M.acquire_window = function(state)
     vim.api.nvim_buf_set_var(state.bufnr, "neo_tree_winid", state.winid)
   end
 
-  if new_win and enter then
-    vim.api.nvim_set_current_win(state.winid)
+  if new_win then
+    if enter then
+      vim.api.nvim_set_current_win(state.winid)
+    end
+    ---Currently, this must be placed here because otherwise the nvim_set_current_win above will clear any queued up
+    ---positions that neo-tree may need to be set.
+    attach_position_autocmds(state)
   end
 
-  set_buffer_mappings(state)
   state._no_focus = nil
   return state.winid
 end

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1191,7 +1191,7 @@ local function set_neo_tree_popup_options(win, buf)
     assert(vim.api.nvim_get_current_buf() == buf)
   end
   -- vim.cmd([[
-  -- s", "etlocal winhighlight=Normal:NeoTreeFloatNormal,FloatBorder:NeoTreeFloatBorder
+  -- setlocal winhighlight=Normal:NeoTreeFloatNormal,FloatBorder:NeoTreeFloatBorder
   -- setlocal nolist nospell nonumber norelativenumber
   -- ]])
   local wo_nt_popup = _compat.wo[win][0]
@@ -1204,20 +1204,31 @@ local function set_neo_tree_popup_options(win, buf)
   local_options_set[win][buf] = local_options_set[win][buf] or true
 end
 
+---@param win integer
+local set_options_in_win = function(win)
+  local buf = vim.api.nvim_win_get_buf(win)
+  local ft = vim.bo[buf].filetype
+  if ft == "neo-tree" then
+    set_neo_tree_options(win, buf)
+  elseif ft == "neo-tree-popup" then
+    set_neo_tree_popup_options(win, buf)
+  end
+end
+
 ---Attaches autocmds that set options in any window containing a neo-tree buffer.
 M.setup_option_autocmds = function()
   local option_augroup = vim.api.nvim_create_augroup("NeoTreeOptions", { clear = false })
   autocmd({ "BufWinEnter", "BufEnter", "TabEnter", "WinEnter" }, {
     group = option_augroup,
-    callback = function(args)
+    callback = function()
       local win = vim.api.nvim_get_current_win()
-      local buf = vim.api.nvim_win_get_buf(win)
-      local ft = vim.bo[buf].filetype
-      if ft == "neo-tree" then
-        set_neo_tree_options(win, args.buf)
-      elseif ft == "neo-tree-popup" then
-        set_neo_tree_popup_options(win, args.buf)
-      end
+      set_options_in_win(win)
+    end,
+  })
+  events.subscribe({
+    event = events.NEO_TREE_WINDOW_AFTER_OPEN,
+    handler = function(args)
+      set_options_in_win(args.winid)
     end,
   })
 end

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1221,13 +1221,13 @@ M.setup_option_autocmds = function()
   autocmd({ "BufWinEnter", "BufEnter", "TabEnter", "WinEnter" }, {
     group = option_augroup,
     callback = function()
-      local win = vim.api.nvim_get_current_win()
-      set_options_in_win(win)
+      set_options_in_win(vim.api.nvim_get_current_win())
     end,
   })
   events.subscribe({
     event = events.NEO_TREE_WINDOW_AFTER_OPEN,
     handler = function(args)
+      -- guards against https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1674
       set_options_in_win(args.winid)
     end,
   })

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -10,6 +10,7 @@ local keymap = require("nui.utils.keymap")
 local log = require("neo-tree.log")
 local windows = require("neo-tree.ui.windows")
 local nt = require("neo-tree")
+local _compat = require("neo-tree.utils._compat")
 
 local M = { resize_timer_interval = 50 }
 local ESC_KEY = utils.keycode("<ESC>")
@@ -1017,7 +1018,7 @@ local set_buffer_mappings = function(state)
   state.resolved_mappings = resolved_mappings
 end
 
-local function create_floating_window(state, win_options, bufname)
+local function create_floating_window(state, win_options)
   state.force_float = nil
   -- First get the default options for floating windows.
   local title = utils.resolve_config_option(state, "window.popup.title", function(current_state)
@@ -1033,10 +1034,12 @@ local function create_floating_window(state, win_options, bufname)
   win_options.position = utils.resolve_config_option(state, "window.popup.position", "50%")
   win_options.border = utils.resolve_config_option(state, "window.popup.border", b)
 
-  ---@class NuiPopup
   local win = NuiPopup(win_options)
+  win.bufnr = buffer
   win:mount()
+  ---@diagnostic disable-next-line: inject-field
   win.source_name = state.name
+  ---@diagnostic disable-next-line: inject-field
   win.original_options = state.window
   table.insert(floating_windows, win)
 
@@ -1048,20 +1051,23 @@ local function create_floating_window(state, win_options, bufname)
   state.winid = win.winid
   state.bufnr = win.bufnr
   log.debug("Created floating window with winid:", win.winid, " and bufnr:", win.bufnr)
-  vim.api.nvim_buf_set_name(state.bufnr, bufname)
 
   -- why is this necessary?
   vim.api.nvim_set_current_win(win.winid)
   return win
 end
 
+local autocmd = vim.api.nvim_create_autocmd
 ---Tracks position for the neo-tree bufnr
 ---@param nt_bufnr integer
 ---@param state neotree.State
-local attach_position_autocmds = function(nt_bufnr, state)
-  local autocmd = vim.api.nvim_create_autocmd
+local attach_position_autocmds = function(state)
+  local position_augroup = vim.api.nvim_create_augroup("NeoTreePosition", { clear = false })
   local wait_for_restore = true
+  local nt_bufnr = state.bufnr
   autocmd("BufDelete", {
+
+    group = position_augroup,
     buffer = nt_bufnr,
     callback = function(args)
       if args.buf == nt_bufnr then
@@ -1072,6 +1078,7 @@ local attach_position_autocmds = function(nt_bufnr, state)
 
   autocmd({ "CursorMoved", "ModeChanged", "WinScrolled" }, {
     buffer = nt_bufnr,
+    group = position_augroup,
     callback = function(args)
       if state.bufnr ~= args.buf then
         return
@@ -1089,6 +1096,7 @@ local attach_position_autocmds = function(nt_bufnr, state)
 
   autocmd({ "WinEnter" }, {
     buffer = nt_bufnr,
+    group = position_augroup,
     callback = function(args)
       M.position.restore_selection(state)
       if state.bufnr ~= args.buf then
@@ -1101,6 +1109,108 @@ local attach_position_autocmds = function(nt_bufnr, state)
     end,
   })
 end
+
+local local_options_set = {}
+
+local neotree_winhl =
+  "Normal:NeoTreeNormal,NormalNC:NeoTreeNormalNC,SignColumn:NeoTreeSignColumn,CursorLine:NeoTreeCursorLine,FloatBorder:NeoTreeFloatBorder,StatusLine:NeoTreeStatusLine,StatusLineNC:NeoTreeStatusLineNC,VertSplit:NeoTreeVertSplit,EndOfBuffer:NeoTreeEndOfBuffer"
+if vim.version().minor >= 7 then
+  neotree_winhl = neotree_winhl .. ",WinSeparator:NeoTreeWinSeparator"
+end
+---@param win number
+---@param buf number
+local function set_neo_tree_options(win, buf)
+  vim.print({
+    "setting",
+    win,
+    buf,
+  })
+  if local_options_set[win] and local_options_set[win][buf] then
+    return
+  end
+  local wo_nt = _compat.wo[win][0]
+  -- vim.cmd([[
+  --   setlocal cursorline
+  --   setlocal cursorlineopt=line
+  --   setlocal nowrap
+  --   setlocal nolist nospell nonumber norelativenumber
+  --   ]])
+
+  wo_nt.cursorline = true
+  wo_nt.cursorlineopt = "line"
+  wo_nt.wrap = false
+  wo_nt.list = false
+  wo_nt.spell = false
+  wo_nt.number = false
+  wo_nt.relativenumber = false
+  wo_nt.colorcolumn = ""
+  wo_nt.signcolumn = "no"
+  wo_nt.winhighlight = neotree_winhl
+  local_options_set[win] = local_options_set[win] or {}
+  local_options_set[win][buf] = local_options_set[win][buf] or true
+end
+
+---@param win number
+---@param buf number
+local function set_neo_tree_popup_options(win, buf)
+  if local_options_set[win] and local_options_set[win][buf] then
+    return
+  end
+  if buf ~= 0 then
+    assert(vim.api.nvim_get_current_buf() == buf)
+  end
+  -- vim.cmd([[
+  -- s", "etlocal winhighlight=Normal:NeoTreeFloatNormal,FloatBorder:NeoTreeFloatBorder
+  -- setlocal nolist nospell nonumber norelativenumber
+  -- ]])
+  local wo_nt_popup = _compat.wo[win][0]
+  wo_nt_popup.winhighlight = "Normal:NeoTreeFloatNormal,FloatBorder:NeoTreeFloatBorder"
+  wo_nt_popup.list = false
+  wo_nt_popup.spell = false
+  wo_nt_popup.number = false
+  wo_nt_popup.relativenumber = false
+  local_options_set[win] = local_options_set[win] or {}
+  local_options_set[win][buf] = local_options_set[win][buf] or true
+end
+
+---Attaches autocmds that set options in any window containing a neo-tree buffer.
+M.setup_option_autocmds = function()
+  local option_augroup = vim.api.nvim_create_augroup("NeoTreeOptions", { clear = false })
+  autocmd({ "BufWinEnter", "BufEnter", "TabEnter", "WinEnter" }, {
+    group = option_augroup,
+    callback = function(args)
+      local win = vim.api.nvim_get_current_win()
+      local buf = vim.api.nvim_win_get_buf(win)
+      if vim.bo[buf].filetype ~= "neo-tree" then
+        return
+      end
+      set_neo_tree_options(win, args.buf)
+    end,
+  })
+  autocmd({ "BufWinEnter", "BufEnter", "TabEnter", "WinEnter" }, {
+    group = option_augroup,
+    callback = function()
+      local win = vim.api.nvim_get_current_win()
+      local buf = vim.api.nvim_win_get_buf(win)
+      if vim.bo[buf].filetype ~= "neo-tree-popup" then
+        return
+      end
+      set_neo_tree_popup_options(win, buf)
+    end,
+  })
+end
+
+--todo: move to setup
+M.setup_option_autocmds()
+
+---@type vim.bo
+local neo_tree_buffer_options = {
+  buftype = "nofile",
+  swapfile = false,
+  filetype = "neo-tree",
+  modifiable = false,
+  undolevels = -1,
+}
 
 ---Tries to reuse a neo-tree buffer, or creates a new one.
 ---@param bufname string
@@ -1115,19 +1225,25 @@ local get_buffer = function(bufname, state)
       bufnr = 0
     end
   end
+
   if bufnr < 1 then
     bufnr = vim.api.nvim_create_buf(false, false)
     vim.api.nvim_buf_set_name(bufnr, bufname)
-    vim.bo[bufnr].buftype = "nofile"
-    vim.bo[bufnr].swapfile = false
-    vim.bo[bufnr].filetype = "neo-tree"
-    vim.bo[bufnr].modifiable = false
-    vim.bo[bufnr].undolevels = -1
-    attach_position_autocmds(bufnr, state)
+    local bo = vim.bo[bufnr]
+    for k, v in pairs(neo_tree_buffer_options) do
+      bo[k] = v
+    end
+    attach_position_autocmds(state)
   end
   return bufnr
 end
 
+local pos_to_splitdir = {
+  top = "above",
+  bottom = "below",
+}
+
+---@param state neotree.State
 M.acquire_window = function(state)
   if M.window_exists(state) then
     return state.winid
@@ -1147,22 +1263,12 @@ M.acquire_window = function(state)
   else
     size_opt, default_size = "window.width", "40"
   end
-  local win_options = {
+  local nui_win_options = {
     ns_id = highlights.ns_id,
     size = utils.resolve_config_option(state, size_opt, default_size),
     position = state.current_position,
     relative = relative,
-    buf_options = {
-      buftype = "nofile",
-      modifiable = false,
-      swapfile = false,
-      filetype = "neo-tree",
-      undolevels = -1,
-    },
-    win_options = {
-      colorcolumn = "",
-      signcolumn = "no",
-    },
+    buf_options = vim.deepcopy(neo_tree_buffer_options),
   }
 
   local event_args = {
@@ -1173,11 +1279,16 @@ M.acquire_window = function(state)
   }
   events.fire_event(events.NEO_TREE_WINDOW_BEFORE_OPEN, event_args)
 
-  local win
+  local new_win
+  local buf = get_buffer(bufname, state)
+  nui_win_options.bufnr = buf
+
+  local enter = not state._no_focus
+  state._no_focus = nil
   if state.current_position == "float" then
     M.close_all_floating_windows()
     M.close(state)
-    win = create_floating_window(state, win_options, bufname)
+    new_win = create_floating_window(state, nui_win_options)
   elseif state.current_position == "current" then
     -- state.id is always the window id or tabnr that this state was created for
     -- in the case of a position = current state object, it will be the window id
@@ -1187,7 +1298,7 @@ M.acquire_window = function(state)
       return
     end
     state.winid = winid
-    state.bufnr = get_buffer(bufname, state)
+    state.bufnr = buf
     vim.api.nvim_win_set_buf(state.winid, state.bufnr)
   else
     local close_old_window = function(new_winid)
@@ -1200,15 +1311,27 @@ M.acquire_window = function(state)
     local location = windows.get_location(state.current_position)
     if location.winid > 0 then
       close_old_window(location.winid)
-      state.bufnr = get_buffer(bufname, state)
+      state.bufnr = buf
       state.winid = location.winid
       vim.api.nvim_win_set_buf(state.winid, state.bufnr)
     else
       close_old_window()
-      win = NuiSplit(win_options)
-      win:mount()
-      state.bufnr = win.bufnr
-      state.winid = win.winid
+      new_win = NuiSplit(nui_win_options)
+      if not enter and vim.fn.has("nvim-0.10") == 1 then
+        -- hijack the window with a custom split method that doesn't emit winleave
+        local vertical = nui_win_options.position == "left" or nui_win_options.position == "right"
+        new_win.winid = vim.api.nvim_open_win(buf, false, {
+          win = -1,
+          vertical = vertical,
+          width = vertical and nui_win_options.size or nil,
+          height = not vertical and nui_win_options.size or nil,
+          ---@diagnostic disable-next-line: assign-type-mismatch
+          split = pos_to_splitdir[nui_win_options.position] or nui_win_options.position,
+        })
+      end
+      new_win:mount()
+      state.bufnr = new_win.bufnr
+      state.winid = new_win.winid
       location.winid = state.winid
     end
     location.source = state.name
@@ -1224,11 +1347,10 @@ M.acquire_window = function(state)
     vim.api.nvim_buf_set_var(state.bufnr, "neo_tree_winid", state.winid)
   end
 
-  if win then
-    vim.api.nvim_buf_set_name(state.bufnr, bufname)
+  if new_win then
     vim.api.nvim_set_current_win(state.winid)
     -- Used to track the position of the cursor within the tree as it gains and loses focus
-    attach_position_autocmds(state.bufnr, state)
+    attach_position_autocmds(state)
   end
 
   set_buffer_mappings(state)

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1073,8 +1073,8 @@ local function create_floating_window(state, win_options)
   win_options.position = utils.resolve_config_option(state, "window.popup.position", "50%")
   win_options.border = utils.resolve_config_option(state, "window.popup.border", b)
 
+  win_options.bufnr = state.bufnr
   local win = NuiPopup(win_options)
-  win.bufnr = buffer
   win:mount()
   ---@diagnostic disable-next-line: inject-field
   win.source_name = state.name
@@ -1103,7 +1103,8 @@ local autocmd = vim.api.nvim_create_autocmd
 local attach_position_autocmds = function(state)
   local position_augroup = vim.api.nvim_create_augroup("NeoTreePosition", { clear = false })
   local wait_for_restore = true
-  local nt_bufnr = state.bufnr
+  local nt_bufnr = assert(state.bufnr)
+
   autocmd("BufDelete", {
 
     group = position_augroup,
@@ -1246,11 +1247,23 @@ local neo_tree_buffer_options = {
   undolevels = -1,
 }
 
+local state_bufname = function(state)
+  return string.format("neo-tree %s [%s]", state.name, state.id)
+end
+local setup_buffer = function(state, bufnr)
+  vim.api.nvim_buf_set_name(bufnr, state_bufname(state))
+  local bo = vim.bo[bufnr]
+  for k, v in pairs(neo_tree_buffer_options) do
+    bo[k] = v
+  end
+end
+
 ---Tries to reuse a neo-tree buffer, or creates a new one.
----@param bufname string
 ---@param state neotree.State
-local get_buffer = function(bufname, state)
-  local bufnr = vim.fn.bufnr(bufname)
+---@return integer bufnr
+---@nodiscard
+local get_buffer = function(state)
+  local bufnr = vim.fn.bufnr(state_bufname(state))
   if bufnr > 0 then
     if vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr) then
       return bufnr
@@ -1262,12 +1275,7 @@ local get_buffer = function(bufname, state)
 
   if bufnr < 1 then
     bufnr = vim.api.nvim_create_buf(false, false)
-    vim.api.nvim_buf_set_name(bufnr, bufname)
-    local bo = vim.bo[bufnr]
-    for k, v in pairs(neo_tree_buffer_options) do
-      bo[k] = v
-    end
-    attach_position_autocmds(state)
+    setup_buffer(state, bufnr)
   end
   return bufnr
 end
@@ -1286,14 +1294,10 @@ M.acquire_window = function(state)
   -- used by tests to determine if the tree is ready for testing
   state._ready = false
 
-  -- Check the no-focus flag set by command/init.lua action="show".
-  local no_focus = state._no_focus == true
-
   local default_position = utils.resolve_config_option(state, "window.position", "left")
   local relative = utils.resolve_config_option(state, "window.relative", "editor")
   state.current_position = state.current_position or default_position
 
-  local bufname = string.format("neo-tree %s [%s]", state.name, state.id)
   local size_opt, default_size
   if state.current_position == "top" or state.current_position == "bottom" then
     size_opt, default_size = "window.height", "15"
@@ -1317,14 +1321,14 @@ M.acquire_window = function(state)
   events.fire_event(events.NEO_TREE_WINDOW_BEFORE_OPEN, event_args)
 
   local new_win
-  local buf = get_buffer(bufname, state)
-  nui_win_options.bufnr = buf
 
+  -- Check the no-focus flag set by command/init.lua action="show".
   local enter = not state._no_focus
   state._no_focus = nil
   if state.current_position == "float" then
     M.close_all_floating_windows()
     M.close(state)
+    state.bufnr = get_buffer(state)
     new_win = create_floating_window(state, nui_win_options)
   elseif state.current_position == "current" then
     -- state.id is always the window id or tabnr that this state was created for
@@ -1335,7 +1339,7 @@ M.acquire_window = function(state)
       return
     end
     state.winid = winid
-    state.bufnr = buf
+    state.bufnr = get_buffer(state)
     vim.api.nvim_win_set_buf(state.winid, state.bufnr)
   else
     local close_old_window = function(new_winid)
@@ -1348,16 +1352,20 @@ M.acquire_window = function(state)
     local location = windows.get_location(state.current_position)
     if location.winid > 0 then
       close_old_window(location.winid)
-      state.bufnr = buf
+      state.bufnr = get_buffer(state)
       state.winid = location.winid
       vim.api.nvim_win_set_buf(state.winid, state.bufnr)
     else
       close_old_window()
       new_win = NuiSplit(nui_win_options)
+      ---NuiSplit does not have a way to pass in a custom buffer. Take the one from nuisplit
+      setup_buffer(state, new_win.bufnr)
+      state.bufnr = new_win.bufnr
+
       if not enter and vim.fn.has("nvim-0.10") == 1 then
         -- hijack the window with a custom split method that doesn't emit winleave
         local vertical = nui_win_options.position == "left" or nui_win_options.position == "right"
-        new_win.winid = vim.api.nvim_open_win(buf, false, {
+        new_win.winid = vim.api.nvim_open_win(state.bufnr, false, {
           win = -1,
           vertical = vertical,
           width = vertical and nui_win_options.size or nil,
@@ -1384,10 +1392,8 @@ M.acquire_window = function(state)
     vim.api.nvim_buf_set_var(state.bufnr, "neo_tree_winid", state.winid)
   end
 
-  if new_win then
+  if new_win and enter then
     vim.api.nvim_set_current_win(state.winid)
-    -- Used to track the position of the cursor within the tree as it gains and loses focus
-    attach_position_autocmds(state)
   end
 
   set_buffer_mappings(state)

--- a/lua/neo-tree/utils/_compat.lua
+++ b/lua/neo-tree/utils/_compat.lua
@@ -5,6 +5,11 @@ compat.noref = function()
   return vim.fn.has("nvim-0.10") == 1 and true or {} --[[@as boolean]]
 end
 
+---@return boolean
+compat.has_split_win = function()
+  return vim.fn.has("nvim-0.10") == 1
+end
+
 compat.gsplit_plain_arg = vim.fn.has("nvim-0.9") == 1 and { plain = true } or true
 
 ---source: https://github.com/Validark/Lua-table-functions/blob/master/table.lua

--- a/lua/neo-tree/utils/_compat.lua
+++ b/lua/neo-tree/utils/_compat.lua
@@ -1,4 +1,5 @@
 local compat = {}
+local api = vim.api
 local uv = vim.uv or vim.loop
 ---@return boolean
 compat.noref = function()
@@ -235,5 +236,40 @@ function compat.fs_normalize(path, opts)
 
   return path
 end
+
+---Backported since older vim.wo doesn't allow window-buffer-local options
+local function new_win_opt_accessor(winid, bufnr)
+  -- TODO(lewis6991): allow passing both buf and win to nvim_get_option_value
+  if bufnr ~= nil and bufnr ~= 0 then
+    error("only bufnr=0 is supported")
+  end
+
+  return setmetatable({}, {
+    __index = function(_, k)
+      if bufnr == nil and type(k) == "number" then
+        if winid == nil then
+          return new_win_opt_accessor(k)
+        else
+          return new_win_opt_accessor(winid, k)
+        end
+      end
+
+      return api.nvim_get_option_value(k, {
+        scope = bufnr and "local" or nil,
+        win = winid or 0,
+      })
+    end,
+
+    __newindex = function(_, k, v)
+      return api.nvim_set_option_value(k, v, {
+        scope = bufnr and "local" or nil,
+        win = winid or 0,
+      })
+    end,
+  })
+end
+
+---@type vim.wo
+compat.wo = new_win_opt_accessor()
 
 return compat

--- a/lua/neo-tree/utils/_compat.lua
+++ b/lua/neo-tree/utils/_compat.lua
@@ -6,11 +6,6 @@ compat.noref = function()
   return vim.fn.has("nvim-0.10") == 1 and true or {} --[[@as boolean]]
 end
 
----@return boolean
-compat.has_split_win = function()
-  return vim.fn.has("nvim-0.10") == 1
-end
-
 compat.gsplit_plain_arg = vim.fn.has("nvim-0.9") == 1 and { plain = true } or true
 
 ---source: https://github.com/Validark/Lua-table-functions/blob/master/table.lua

--- a/lua/neo-tree/utils/_compat.lua
+++ b/lua/neo-tree/utils/_compat.lua
@@ -6,6 +6,11 @@ compat.noref = function()
   return vim.fn.has("nvim-0.10") == 1 and true or {} --[[@as boolean]]
 end
 
+---@return boolean
+compat.has_split_win = function()
+  return vim.fn.has("nvim-0.10") == 1
+end
+
 compat.gsplit_plain_arg = vim.fn.has("nvim-0.9") == 1 and { plain = true } or true
 
 ---source: https://github.com/Validark/Lua-table-functions/blob/master/table.lua

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,9 @@
 [settings]
 windows_default_inline_shell_args = "powershell -NoProfile -NoLogo -Command"
+
 [env]
 NEOTREE_LUARC = ".luarc.json"
+MISE_BACKENDS_NEOVIM = "aqua:neovim/neovim"
 
 [tools]
 lua-language-server = "3"

--- a/tests/mininit.lua
+++ b/tests/mininit.lua
@@ -11,9 +11,12 @@ vim.opt.runtimepath = {
 local utils = require("neo-tree.utils")
 local deps_dir = utils.path_join(root_dir, ".dependencies")
 local deps = {}
+local version = vim.version()
 for basename, type in vim.fs.dir(deps_dir) do
   assert(type == "directory")
-  deps[#deps + 1] = utils.path_join(deps_dir, basename)
+  if version.minor >= 12 or basename ~= "nvim-treesitter" then
+    deps[#deps + 1] = utils.path_join(deps_dir, basename)
+  end
   -- add each dep
 end
 vim.opt.runtimepath:append(deps)

--- a/tests/neo-tree/command/command_spec.lua
+++ b/tests/neo-tree/command/command_spec.lua
@@ -205,6 +205,35 @@ describe("Command", function()
             run_show_command(cmd, expected_tree_node)
             return true
           end)
+      end)
+
+        it("`:Neotree show` should not trigger WinLeave on the current window", function()
+          local testfile = fs_tree.lookup["topfile1"].abspath
+          u.editfile(testfile)
+          local win_leave_fired = false
+          local augroup = vim.api.nvim_create_augroup("test_winleave", { clear = true })
+          vim.api.nvim_create_autocmd("WinLeave", {
+            group = augroup,
+            callback = function()
+              win_leave_fired = true
+            end,
+          })
+          run_show_command("Neotree show")
+          verify.after(500, function()
+            vim.api.nvim_del_augroup_by_id(augroup)
+            assert(not win_leave_fired, "WinLeave should not fire during action=show")
+            return true
+          end)
+        end)
+
+        it("`:Neotree show` should not prevent subsequent focus commands from working", function()
+          local testfile = fs_tree.lookup["topfile1"].abspath
+          u.editfile(testfile)
+          run_show_command("Neotree show")
+          verify.after(200, function()
+            run_focus_command("Neotree focus")
+            return true
+          end)
         end)
       end)
 

--- a/tests/neo-tree/command/command_spec.lua
+++ b/tests/neo-tree/command/command_spec.lua
@@ -207,24 +207,26 @@ describe("Command", function()
           end)
         end)
 
-        it("`:Neotree show` should not trigger WinLeave on the current window", function()
-          local testfile = fs_tree.lookup["topfile1"].abspath
-          u.editfile(testfile)
-          local win_leave_fired = false
-          local augroup = vim.api.nvim_create_augroup("test_winleave", { clear = true })
-          vim.api.nvim_create_autocmd("WinLeave", {
-            group = augroup,
-            callback = function()
-              win_leave_fired = true
-            end,
-          })
-          run_show_command("Neotree show")
-          verify.after(500, function()
-            vim.api.nvim_del_augroup_by_id(augroup)
-            assert(not win_leave_fired, "WinLeave should not fire during action=show")
-            return true
+        if vim.fn.has("nvim-0.10") == 1 then
+          it("`:Neotree show` should not trigger WinLeave on the current window", function()
+            local testfile = fs_tree.lookup["topfile1"].abspath
+            u.editfile(testfile)
+            local win_leave_fired = false
+            local augroup = vim.api.nvim_create_augroup("test_winleave", { clear = true })
+            vim.api.nvim_create_autocmd("WinLeave", {
+              group = augroup,
+              callback = function()
+                win_leave_fired = true
+              end,
+            })
+            run_show_command("Neotree show")
+            verify.after(500, function()
+              vim.api.nvim_del_augroup_by_id(augroup)
+              assert(not win_leave_fired, "WinLeave should not fire during action=show")
+              return true
+            end)
           end)
-        end)
+        end
 
         it("`:Neotree show` should not prevent subsequent focus commands from working", function()
           local testfile = fs_tree.lookup["topfile1"].abspath

--- a/tests/neo-tree/command/command_spec.lua
+++ b/tests/neo-tree/command/command_spec.lua
@@ -205,7 +205,7 @@ describe("Command", function()
             run_show_command(cmd, expected_tree_node)
             return true
           end)
-      end)
+        end)
 
         it("`:Neotree show` should not trigger WinLeave on the current window", function()
           local testfile = fs_tree.lookup["topfile1"].abspath


### PR DESCRIPTION
When action="show", use nvim_open_win(enter=false) instead of NuiSplit to avoid moving focus. This fixes two issues:
- WinLeave side effects (closes third-party floats like yazi.nvim)
- document_symbols async LSP leaving focus in symbol panel

Requires nvim 0.10+. Older versions fall back to NuiSplit as previous

for

- https://github.com/nvim-neo-tree/neo-tree.nvim/issues/1984