### PR TITLE
fix(ignore): skip .ignore-like directories and other special filekinds

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/ignored.lua
+++ b/lua/neo-tree/sources/filesystem/lib/ignored.lua
@@ -60,12 +60,12 @@ local find_ignorers_in_dir = function(relpaths, dir)
   local found = {}
   for _, relpath in ipairs(relpaths) do
     local fullpath = utils.path_join(dir, relpath)
-    local lstat = uv.fs_lstat(fullpath)
-    if lstat then
+    local stat = uv.fs_stat(fullpath)
+    if stat and stat.type == "file" then
       ---@class neotree.sources.filesystem.Ignorer
       local ignorer = {
         fullpath,
-        file_to_glob(fullpath, dir, lstat),
+        file_to_glob(fullpath, dir, stat),
         dir,
       }
       found[#found + 1] = ignorer


### PR DESCRIPTION
Fell for "assuming that every ignore-like name is a file" again award