### PR TITLE
fix(components): render conflict icon for files with git conflicts

### DIFF
--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -299,6 +299,7 @@ M.git_status = function(config, node, state)
     stage_sb = symbols.unstaged
     stage_hl = highlights.GIT_UNSTAGED
   elseif git_parser.status_code_is_conflict(x, y) then
+    is_conflict = true
     stage_sb = symbols.conflict
     stage_hl = highlights.GIT_CONFLICT
   end
@@ -343,7 +344,7 @@ M.git_status = function(config, node, state)
     end
   end
 
-  if #y > 0 and y ~= "." then
+  if not is_conflict and #y > 0 and y ~= "." then
     if y == "M" or y == "U" then
       worktree_change_sb = symbols.modified
       worktree_change_hl = highlights.GIT_MODIFIED

--- a/tests/neo-tree/sources/common/components_spec.lua
+++ b/tests/neo-tree/sources/common/components_spec.lua
@@ -1,0 +1,46 @@
+pcall(require, "luacov")
+
+local components = require("neo-tree.sources.common.components")
+local git = require("neo-tree.git")
+local highlights = require("neo-tree.ui.highlights")
+
+describe("sources/common/components git_status", function()
+  local original_find_existing_status_code
+
+  before_each(function()
+    original_find_existing_status_code = git.find_existing_status_code
+  end)
+
+  after_each(function()
+    git.find_existing_status_code = original_find_existing_status_code
+  end)
+
+  it("shows one change marker and one conflict marker for conflicted file nodes", function()
+    git.find_existing_status_code = function()
+      return "UU"
+    end
+
+    local rendered = components.git_status({
+      symbols = {
+        modified = "M",
+        conflict = "C",
+      },
+    }, {
+      type = "file",
+      path = "/tmp/conflicted.rs",
+    }, {
+      git_base_by_worktree = {},
+    })
+
+    assert.are.same({
+      {
+        text = "M ",
+        highlight = highlights.GIT_MODIFIED,
+      },
+      {
+        text = "C ",
+        highlight = highlights.GIT_CONFLICT,
+      },
+    }, rendered)
+  end)
+end)


### PR DESCRIPTION
Currently, when there is a git merge or rebase conflict in a file, neo-tree renders two `modified` symbols instead of one `modified` and one `conflict` symbol. This happens because the renderer detects the conflict, but does not carry that information forward into the later rendering logic. As a result, the normal worktree-side component is still rendered, which produces the duplicate `modified` symbol. The first commit in this PR adds a regression test to expose this issue. The fix in the second commit is to set `is_conflict` to `true` and only render the normal `y` component when there is no conflict.