### PR TITLE
Fix missing bufnr

### DIFF
--- a/lua/neo-tree/setup/netrw.lua
+++ b/lua/neo-tree/setup/netrw.lua
@@ -39,6 +39,14 @@ M.hijack = function()
   utils.debounce("hijack_netrw_" .. dir_window, function()
     local manager = require("neo-tree.sources.manager")
     local log = require("neo-tree.log")
+    -- The hijack may have been triggered by a BufEnter that fired in a transient
+    -- window that no longer exists (this can happen during `:e <dir>` when the
+    -- startup buffer is a directory). Skip in that case so we don't create an
+    -- orphan state for a dead window.
+    if not vim.api.nvim_win_is_valid(dir_window) then
+      log.debug("hijack_netrw: dir_window", dir_window, "is no longer valid, skipping")
+      return
+    end
     -- We will want to replace the "directory" buffer with either the "alternate"
     -- buffer or a new blank one.
     local replacement_buffer = vim.fn.bufnr("#")

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1403,7 +1403,13 @@ draw = function(nodes, state, parent_id)
       return
     end
   else
-    M.acquire_window(state)
+    local winid = M.acquire_window(state)
+    if not winid or not state.bufnr then
+      -- acquire_window bailed out (e.g. the target window was closed before the
+      -- async scan finished). Don't try to build a tree without a buffer.
+      log.trace("Could not acquire window, aborting draw")
+      return
+    end
     create_tree(state)
   end
   ---@cast state neotree.StateWithTree


### PR DESCRIPTION
I am encountering the error `nui.nvim/lua/nui/tree/init.lua:188: missing bufnr` coming from `lua/neo-tree/ui/renderer.lua:891`.

The error is intermittent, and I can resume after hitting enter, but it's quite annoying.

The error is triggered when

* launching nvim with `.` as command line argument
* then switching to another directory, like `:e lib/`
* with `hijack_netrw_behavior = "open_current"` (unsure if this is needed to trigger the bug)

I tried to manually pinpoint the bug, but my knowledge of nvim and lua was not sufficient. With the help of a stochastic parrot, iterating with debug prints to pinpoint the issue, a plausible fix was produced.

I read the contrib guidelines, but `mise deps` failed compiling openssl, so I skipped all the linting etc.. It's only a small patch, so this should not be a big issue I hope.

The first commit is the real fix, the second is more a defensive measure.