### PR TITLE
feat(document_symbols): add ignore_symbols option to filter symbol tree

### DIFF
--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -699,6 +699,7 @@ local config = {
     follow_cursor = false,
     follow_tree_cursor = false, -- Automatically show symbol location when moving cursor in the tree
     client_filters = "first",
+    ignore_symbols = {}, -- LSP symbol kind names to hide, e.g. { "Variable", "Field" }
     renderers = {
       root = {
         {"indent"},

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -680,6 +680,7 @@ local config = {
     follow_cursor = false,
     follow_tree_cursor = false, -- Automatically show symbol location when moving cursor in the tree
     client_filters = "first",
+    ignore_symbols = {}, -- LSP symbol kind names to hide, e.g. { "Variable", "Field" }
     renderers = {
       root = {
         {"indent"},

--- a/lua/neo-tree/sources/document_symbols/lib/symbols_utils.lua
+++ b/lua/neo-tree/sources/document_symbols/lib/symbols_utils.lua
@@ -7,6 +7,9 @@ local M = {}
 
 local ignore_kinds = {}
 
+--- Filter out symbols whose kind matches an ignore set.
+--- @param symbols table[] list of symbol nodes
+--- @param ignore table<string,true>|nil lowercase kind name → true; nil or empty returns symbols as-is
 local function filter_symbols(symbols, ignore)
   if not ignore or vim.tbl_isempty(ignore) then
     return symbols

--- a/lua/neo-tree/sources/document_symbols/lib/symbols_utils.lua
+++ b/lua/neo-tree/sources/document_symbols/lib/symbols_utils.lua
@@ -5,6 +5,25 @@ local kinds = require("neo-tree.sources.document_symbols.lib.kinds")
 
 local M = {}
 
+local ignore_kinds = {}
+
+local function filter_symbols(symbols, ignore)
+  if not ignore or vim.tbl_isempty(ignore) then
+    return symbols
+  end
+  local out = {}
+  for _, s in ipairs(symbols) do
+    local label = s.extra and s.extra.kind and s.extra.kind.name
+    if not label or not ignore[label:lower()] then
+      if s.children then
+        s.children = filter_symbols(s.children, ignore) -- mutates in place
+      end
+      out[#out + 1] = s
+    end
+  end
+  return out
+end
+
 ---@alias Loc integer[] a location in a buffer {row, col}, 0-indexed
 ---@alias LocRange { start: Loc, ["end"]: Loc } a range consisting of two loc
 
@@ -146,6 +165,7 @@ local on_lsp_resp = function(lsp_resp, state)
     for i, resp_node in ipairs(client_result) do
       table.insert(symbol_list, parse_resp(resp_node, #items .. "." .. i, state, "/"))
     end
+    symbol_list = filter_symbols(symbol_list, ignore_kinds)
 
     -- add the parsed response to the tree
     local splits = vim.split(bufname, "/")
@@ -212,6 +232,14 @@ end
 M.setup = function(config)
   filters.setup(config.client_filters)
   kinds.setup(config.custom_kinds, config.kinds)
+  ignore_kinds = {}
+  for _, k in ipairs(config.ignore_symbols or {}) do
+    if type(k) == "string" and k ~= "" then
+      ignore_kinds[k:lower()] = true
+    end
+  end
 end
+
+M._filter_symbols = filter_symbols
 
 return M

--- a/tests/neo-tree/sources/document_symbols/filter_symbols_spec.lua
+++ b/tests/neo-tree/sources/document_symbols/filter_symbols_spec.lua
@@ -1,0 +1,102 @@
+pcall(require, "luacov")
+
+local symbols = require("neo-tree.sources.document_symbols.lib.symbols_utils")
+
+local function make_sym(name, kind_name, children)
+  children = children or {}
+  return {
+    id = name,
+    name = name,
+    type = "symbol",
+    path = "/test.lua",
+    children = children,
+    extra = {
+      kind = { name = kind_name, icon = "?", hl = "" },
+    },
+  }
+end
+
+describe("filter_symbols", function()
+  it("returns nil when ignore is nil", function()
+    local syms = { make_sym("foo", "Function") }
+    local got = symbols._filter_symbols(syms, nil)
+    assert.are.same(1, #got)
+  end)
+
+  it("returns all when ignore is empty", function()
+    local syms = { make_sym("foo", "Function") }
+    local got = symbols._filter_symbols(syms, {})
+    assert.are.same(1, #got)
+  end)
+
+  it("removes ignored kinds", function()
+    local syms = {
+      make_sym("foo", "Function"),
+      make_sym("bar", "Variable"),
+      make_sym("baz", "Function"),
+    }
+    local got = symbols._filter_symbols(syms, { variable = true })
+    assert.are.same(2, #got)
+    assert.are.same("foo", got[1].name)
+    assert.are.same("baz", got[2].name)
+  end)
+
+  it("removes multiple ignored kinds", function()
+    local syms = {
+      make_sym("f", "Function"),
+      make_sym("v", "Variable"),
+      make_sym("c", "Constant"),
+      make_sym("k", "Field"),
+    }
+    local got = symbols._filter_symbols(syms, { variable = true, field = true })
+    assert.are.same(2, #got)
+    assert.are.same("f", got[1].name)
+    assert.are.same("c", got[2].name)
+  end)
+
+  it("filters children recursively", function()
+    local syms = {
+      make_sym("top", "Function", {
+        make_sym("inner_var", "Variable"),
+        make_sym("inner_func", "Function", {
+          make_sym("deep_var", "Variable"),
+        }),
+      }),
+    }
+    local got = symbols._filter_symbols(syms, { variable = true })
+    assert.are.same(1, #got)
+    assert.are.same("top", got[1].name)
+    local children = got[1].children
+    assert.are.same(1, #children)
+    assert.are.same("inner_func", children[1].name)
+    local grandchildren = children[1].children
+    assert.are.same(0, #grandchildren)
+  end)
+
+  it("removes root symbol if its kind matches", function()
+    local syms = {
+      make_sym("only_var", "Variable"),
+    }
+    local got = symbols._filter_symbols(syms, { variable = true })
+    assert.are.same(0, #got)
+  end)
+
+  it("handles case-insensitive matching", function()
+    local syms = {
+      make_sym("f", "Function"),
+      make_sym("v", "Variable"),
+    }
+    local got = symbols._filter_symbols(syms, { VARIABLE = true })
+    assert.are.same(1, #got)
+    assert.are.same("f", got[1].name)
+  end)
+
+  it("passes through symbols without kind info", function()
+    local syms = {
+      make_sym("f", "Function"),
+      { id = "unknown", name = "unknown", type = "symbol", path = "/test.lua", children = {}, extra = {} },
+    }
+    local got = symbols._filter_symbols(syms, { variable = true })
+    assert.are.same(2, #got)
+  end)
+end)

--- a/tests/neo-tree/sources/document_symbols/filter_symbols_spec.lua
+++ b/tests/neo-tree/sources/document_symbols/filter_symbols_spec.lua
@@ -81,16 +81,6 @@ describe("filter_symbols", function()
     assert.are.same(0, #got)
   end)
 
-  it("handles case-insensitive matching", function()
-    local syms = {
-      make_sym("f", "Function"),
-      make_sym("v", "Variable"),
-    }
-    local got = symbols._filter_symbols(syms, { VARIABLE = true })
-    assert.are.same(1, #got)
-    assert.are.same("f", got[1].name)
-  end)
-
   it("passes through symbols without kind info", function()
     local syms = {
       make_sym("f", "Function"),


### PR DESCRIPTION
Allows hiding specific LSP symbol kinds (e.g. Variable, Field) from the document_symbols tree by matching against kinds.get_kind().name. Configured at source level:

    document_symbols = {
      ignore_symbols = { "Variable", "Field" },
    }

Matching is case-insensitive and recursive. Symbols without kind information are never filtered. Non-string config values are silently ignored to prevent runtime errors.

to close https://github.com/nvim-neo-tree/neo-tree.nvim/issues/2031