### PR TITLE
fix(fs_actions): clear buffers when trashing

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_actions.lua
@@ -801,6 +801,7 @@ M.trash_node = function(path, callback, state)
     if state and restorefunc then
       table.insert(state.undostack, restorefunc)
     end
+    clear_buffer(path)
     internal_hooks.on_file_deleted(path, callback)
   end)
 end
@@ -822,6 +823,12 @@ M.trash_nodes = function(paths, callback, state)
 
     if state and restorefunc then
       table.insert(state.undostack, restorefunc)
+    end
+
+    for _, path in ipairs(paths) do
+      if not uv.fs_lstat(path) then
+        clear_buffer(path)
+      end
     end
 
     internal_hooks.on_files_trashed(paths, callback)


### PR DESCRIPTION
delete does this so i thought trash should do too?

not super sure about `stat`ing files in a loop for the `trash_nodes` variant but my thoughts were if some individual files failed to be trashed (there doesn't seem to be any communication of partial-failures i believe)?