### PR TITLE
feat(commands): `select` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,8 @@ require("neo-tree").setup({
           jump_labels = "jfkdlsahgnuvrbytmiceoxwpqz",
         }
       },
+      ["<Tab>"] = "select",
+      ["<C-;>"] = "clear_selection",
       ["<space>"] = {
         "toggle_node",
         nowait = false, -- disable `nowait` if you have existing combos starting with this char that you want to use

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -277,6 +277,17 @@ w = open_with_window_picker: Uses the `window-picker` plugin to select a window
                              that is within the current working directory.
                              This will loop around if you are on the last one.
 
+<C-s>          = quick_jump: Enters a temporary "jump" mode where icons are
+                             replaced with jump labels. Inputting the labels
+                             will jump to the corresponding node, inputting
+                             otherwise will exit the mode.
+
+                             `config.jump_labels` sets what characters are used
+                             for jump labels (prioritized in the order listed),
+                             `config.on_jump` can either be "open_or_toggle"
+                             (default) or `fun(state, target_node)`, where
+                             `target_node` is the node that was jumped to.
+
 
 FILE ACTIONS                                            *neo-tree-file-actions*
 a    = add:                  Create a new file OR directory. Add a `/` to the
@@ -308,12 +319,14 @@ A    = add_directory:        Create a new directory, in this mode it does not
                              command. Also accepts `config.show_path` options
 
 d    = delete:               Delete the selected file or directory.
-                             Supports visual selection.
+
+                             Supports selection. ~
 
 T    = trash:                Trash the selected file or directory.
                              See |neo-tree-trash| to configure.
-                             Supports visual selection.
-                             Supports undo, depending on command used.
+
+                             Supports selection. ~
+                             Supports undo, depending on command used. ~
 
 u    = undo:                 Reverts the most recent undoable action.
 
@@ -344,10 +357,10 @@ b    = rename_basename:      Rename the selected file or directory without the
                              extension.
 
 y    = copy_to_clipboard:    Mark file to be copied.
-                             Supports visual selection.~
+                             Supports selection.~
 
 x    = cut_to_clipboard:     Mark file to be cut (moved).
-                             Supports visual selection.~
+                             Supports selection.~
 
 p    = paste_from_clipboard: Copy/move each marked file to the selected folder.
 
@@ -361,16 +374,14 @@ m    = move:                 Move the selected file or directory.
                              Also accepts the optional `config.show_path` option
                              like the add file action.
 
-<C-s> = quick_jump           Enters a temporary "jump" mode where icons are
-                             replaced with jump labels. Inputting the labels
-                             will jump to the corresponding node, inputting
-                             otherwise will exit the mode.
+<tab>         = select       Toggles whether a node is considered "selected" for
+                             the next selection-supporting command Neo-tree
+                             performs. (e.g. delete/trash)
 
-                             `config.jump_labels` sets what characters are used
-                             for jump labels (prioritized in the order listed),
-                             `config.on_jump` can either be "open_or_toggle"
-                             (default) or `fun(state, target_node)`, where
-                             `target_node` is the node that was jumped to.
+                             See |neo-tree-custom-mappings-selection| for
+                             details.
+
+                             Supports visual selection. ~
 
 
 VIEW CHANGES                                            *neo-tree-view-changes*
@@ -557,16 +568,18 @@ specific to that source and will not work for others.
 
 
 CUSTOM MAPPINGS WITH VISUAL MODE               *neo-tree-custom-mappings-visual*
+                                            *neo-tree-custom-mappings-selection*
 
-If you want to create a mapping that supports visual mode, the way to do that
-is to add a second command where the name is the same as the normal mode
-command, but with `_visual` added to the end. Any mapping for this command will
-then work in either normal or visual mode.
+In neo-tree, nodes can be selected in 2 ways: either by visual selection in
+visual mode, or by tagging the nodes as "selected" with the `select` command.
 
-The `_visual` version of the command will be called with a second argument
-which is a list of the nodes that were selected when the command was called.
+To create a mapping that can operate on a selection of nodes, add a second
+command where the name is the same as the normal mode command, but with
+`_visual` added to the end. When selected nodes exist, the `_visual` version of
+the command will be called with a second argument - a list of the nodes that
+were selected when the command was called.
 
-For example, this is how the built-in `delete` command is defined:
+For example, this is approximately how the built-in `delete` command is defined:
 
 >lua
     M.delete = function(state, callback)
@@ -583,6 +596,9 @@ For example, this is how the built-in `delete` command is defined:
       fs_actions.delete_nodes(paths_to_delete, callback)
     end
 <
+
+Nodes tagged as selected will be unselected if the command completes without
+error.
 
 CUSTOM MAPPINGS WITH ARGUMENTS               *neo-tree-custom-mappings-args*
 

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -367,16 +367,16 @@ y    = copy_to_clipboard:    Mark file to be copied.
 x    = cut_to_clipboard:     Mark file to be cut (moved).
                              Supports selection.~
 
-p    = paste_from_clipboard: Copy/move each marked file to the selected
+p    = paste_from_clipboard: Copy/move each marked file to the targeted
                              directory.
 
 <C-r> = clear_clipboard:     Clears the clipboard.
 
-c    = copy:                 Copy the selected file or directory.
+c    = copy:                 Copy the targeted file or directory.
                              Also accepts the optional `config.show_path` option
                              like the add file action.
 
-m    = move:                 Move the selected file or directory.
+m    = move:                 Move the targeted file or directory.
                              Also accepts the optional `config.show_path` option
                              like the add file action.
 

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -195,7 +195,7 @@ are defined by default. All built-in commands are listed here but some are not
 mapped by default. See |neo-tree-custom-commands| for details on how to use them
 in a custom mapping.
 
-Note: The "selected" item is the line the cursor is currently on.
+Note: The "targeted" item is the one on the line the cursor is currently on.
 
 <             = prev_source: Switches to the previous source.
 
@@ -203,16 +203,14 @@ Note: The "selected" item is the line the cursor is currently on.
 
 <bs>          = navigate_up: Moves the root directory up one level.
 
-.             = set_root:    Changes the root directory to the currently
-                             selected folder.
+.             = set_root:    Changes the root directory to the targeted
+                             directory.
 
 <space>       = toggle_node  Expand or collapse a node with children, which
                              may be a directory or a nested file.
 
-<2-LeftMouse> = open:        Expand or collapse a folder. If a file is selected,
-                             open it in the window closest to the tree.
-
-<cr>          = open:        Same as above.
+<2-LeftMouse> = open:        Expand or collapse a directory, or open a file
+<cr>                         in the window closest to the tree.
 
 C             = close_node:  Close node if it is open, else close it's parent.
 
@@ -259,15 +257,15 @@ t             = open_tabnew: Same as open, but opens in a new tab.
                              |:drop| command with the |:tab| modifier.
 
 w = open_with_window_picker: Uses the `window-picker` plugin to select a window
-                             to open the selected node in. Requires that
+                             to open the targeted node in. Requires that
                              https://github.com/s1n7ax/nvim-window-picker
                              be installed.
 
-   split_with_window_picker: Same as `open_with_window_picker` but opens split
-                             in selected node instead.
+   split_with_window_picker: Same as `open_with_window_picker` but opens a split
+                             with the targeted node instead.
 
-  vsplit_with_window_picker: Same as `open_with_window_picker` but opens
-                             vertical split in selected node instead.
+  vsplit_with_window_picker: Same as `split_with_window_picker` but with a
+                             vertical split.
 
 [g      = prev_git_modified: Jump to the previous file reported by `git status`
                              that is within the current working directory.
@@ -307,7 +305,7 @@ a    = add:                  Create a new file OR directory. Add a `/` to the
                              `"none"`:     which is the default.
                              `"relative"`: shows the portion which is relative
                                          to the current root of the tree.
-                             `"absolute"`: is the full path to the current
+                             `"absolute"`: is the full path to the targeted
                                          directory.
 
                              The file path also supports BASH style brace
@@ -326,19 +324,20 @@ A    = add_directory:        Create a new directory, in this mode it does not
                              BASH style brace expansion as explained in `add`
                              command. Also accepts `config.show_path` options
 
-d    = delete:               Delete the selected file or directory.
+d    = delete:               Delete the targeted file/directory.
                              Supports selection. ~
 
-T    = trash:                Trash the selected file or directory.
+T    = trash:                Trash the targeted file/directory.
                              See |neo-tree-trash| to configure.
                              Supports selection. ~
                              Supports undo, depending on command used. ~
 
 u    = undo:                 Reverts the most recent undoable action.
 
-U    = restore_from_trash:   Restores selected file or directories when used on
+U    = restore_from_trash:   Restores the targeted file or directory when used on
                              items inside the trash folder. See |neo-tree-trash|
                              for supported OSs.
+                             Supports selection. ~
 
 i    = show_file_details:    Show file details in a popup window, such as size
                              and last modified date.
@@ -357,9 +356,9 @@ i    = show_file_details:    Show file details in a popup window, such as size
                              If the options are not set, they default to the
                              format string "%Y-%m-%d %I:%M %p".
 
-r    = rename:               Rename the selected file or directory.
+r    = rename:               Rename the targeted file or directory.
 
-b    = rename_basename:      Rename the selected file or directory without the
+b    = rename_basename:      Rename the targeted file or directory without the
                              extension.
 
 y    = copy_to_clipboard:    Mark file to be copied.
@@ -368,7 +367,8 @@ y    = copy_to_clipboard:    Mark file to be copied.
 x    = cut_to_clipboard:     Mark file to be cut (moved).
                              Supports selection.~
 
-p    = paste_from_clipboard: Copy/move each marked file to the selected folder.
+p    = paste_from_clipboard: Copy/move each marked file to the selected
+                             directory.
 
 <C-r> = clear_clipboard:     Clears the clipboard.
 

--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -290,6 +290,14 @@ w = open_with_window_picker: Uses the `window-picker` plugin to select a window
 
 
 FILE ACTIONS                                            *neo-tree-file-actions*
+
+<tab>         = select       Toggles whether a node is considered "selected" for
+                             the next selection-supporting command Neo-tree
+                             performs. (e.g. delete/trash) See
+                             |neo-tree-custom-mappings-selection| for
+                             details.
+                             Supports visual selection. ~
+
 a    = add:                  Create a new file OR directory. Add a `/` to the
                              end of the name to make a directory. This command
                              supports an optional `config.show_path` option
@@ -319,12 +327,10 @@ A    = add_directory:        Create a new directory, in this mode it does not
                              command. Also accepts `config.show_path` options
 
 d    = delete:               Delete the selected file or directory.
-
                              Supports selection. ~
 
 T    = trash:                Trash the selected file or directory.
                              See |neo-tree-trash| to configure.
-
                              Supports selection. ~
                              Supports undo, depending on command used. ~
 
@@ -373,16 +379,6 @@ c    = copy:                 Copy the selected file or directory.
 m    = move:                 Move the selected file or directory.
                              Also accepts the optional `config.show_path` option
                              like the add file action.
-
-<tab>         = select       Toggles whether a node is considered "selected" for
-                             the next selection-supporting command Neo-tree
-                             performs. (e.g. delete/trash)
-
-                             See |neo-tree-custom-mappings-selection| for
-                             details.
-
-                             Supports visual selection. ~
-
 
 VIEW CHANGES                                            *neo-tree-view-changes*
 H  = toggle_hidden:  Toggle whether hidden (filtered items) are shown or not.

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -426,6 +426,7 @@ local config = {
         }
       },
       ["<Tab>"] = "select",
+      ["<C-;>"] = "clear_selection",
       ["<space>"] = {
           "toggle_node",
           nowait = false, -- disable `nowait` if you have existing combos starting with this char that you want to use

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -222,7 +222,7 @@ local config = {
       folder_open = "",
       folder_empty = "󰉖",
       folder_empty_open = "󰷏",
-      selected = "",
+      selected = "󰐾",
       use_filtered_colors = true, -- Whether to use a different highlight when the file is filtered (hidden, dotfile, etc.).
       -- The next two settings are only a fallback, if you use nvim-web-devicons and configure default icons there
       -- then these will never be used.

--- a/lua/neo-tree/defaults.lua
+++ b/lua/neo-tree/defaults.lua
@@ -222,6 +222,7 @@ local config = {
       folder_open = "",
       folder_empty = "󰉖",
       folder_empty_open = "󰷏",
+      selected = "",
       use_filtered_colors = true, -- Whether to use a different highlight when the file is filtered (hidden, dotfile, etc.).
       -- The next two settings are only a fallback, if you use nvim-web-devicons and configure default icons there
       -- then these will never be used.
@@ -424,6 +425,7 @@ local config = {
           jump_labels = "jfkdlsahgnuvrbytmiceoxwpqz",
         }
       },
+      ["<Tab>"] = "select",
       ["<space>"] = {
           "toggle_node",
           nowait = false, -- disable `nowait` if you have existing combos starting with this char that you want to use

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -632,14 +632,14 @@ end
 ---@param state neotree.StateWithTree
 M.select = function(state)
   local node = assert(state.tree:get_node())
-  state.selected[node.id] = not state.selected[node.id]
+  state.selected[node.id] = not state.selected[node.id] or nil
   renderer.redraw(state)
 end
 
 ---@type neotree.TreeCommandVisual
 M.select_visual = function(state, selected_nodes)
   for _, node in ipairs(selected_nodes) do
-    state.selected[node.id] = not state.selected[node.id]
+    state.selected[node.id] = not state.selected[node.id] or nil
   end
   renderer.redraw(state)
 end

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -642,6 +642,7 @@ M.select_visual = function(state, selected_nodes)
     state.selected[node.id] = not state.selected[node.id] or nil
   end
   renderer.redraw(state)
+  state._skip_consuming_selection = true
 end
 
 M.clear_selection = function(state)

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -629,6 +629,21 @@ M.show_file_details = function(state)
   popups.alert("File Details", lines)
 end
 
+---@param state neotree.StateWithTree
+M.select = function(state)
+  local node = assert(state.tree:get_node())
+  state.selected[node.id] = not state.selected[node.id]
+  renderer.redraw(state)
+end
+
+---@type neotree.TreeCommandVisual
+M.select_visual = function(state, selected_nodes)
+  for _, node in ipairs(selected_nodes) do
+    state.selected[node.id] = not state.selected[node.id]
+  end
+  renderer.redraw(state)
+end
+
 ---Pastes all items from the clipboard to the current directory.
 ---@param callback fun(node: NuiTree.Node?, destination: string) The callback to call when the command is done. Called with the parent node as the argument.
 M.paste_from_clipboard = function(state, callback)

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -644,6 +644,12 @@ M.select_visual = function(state, selected_nodes)
   renderer.redraw(state)
 end
 
+M.clear_selection = function(state)
+  state.selected = {}
+  log.info("Cleared selection")
+  renderer.redraw(state)
+end
+
 ---Pastes all items from the clipboard to the current directory.
 ---@param callback fun(node: NuiTree.Node?, destination: string) The callback to call when the command is done. Called with the parent node as the argument.
 M.paste_from_clipboard = function(state, callback)

--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -443,6 +443,7 @@ end
 ---@field folder_empty_open string The icon to display to represent an empty but open folder.
 ---@field folder_open string The icon to display for an open folder.
 ---@field folder_closed string The icon to display for a closed folder.
+---@field selected string The icon to display for a closed folder.
 ---@field use_filtered_colors boolean Whether to use the same highlight as filtered_by when the item is filtered.
 ---@field provider neotree.IconProvider?
 
@@ -472,6 +473,17 @@ M.icon = function(config, node, state)
   if config.use_filtered_colors then
     local filtered_by = M.filtered_by(config, node, state)
     icon.highlight = filtered_by.highlight or icon.highlight --  prioritize filtered highlighting
+  end
+
+  if state.selected[node.id] then
+    ---@type neotree.Render.Node[]
+    return {
+      {
+        text = config.selected or "[x]",
+        highlight = highlights.SELECTED,
+      },
+      icon,
+    }
   end
 
   return icon

--- a/lua/neo-tree/sources/document_symbols/commands.lua
+++ b/lua/neo-tree/sources/document_symbols/commands.lua
@@ -97,9 +97,6 @@ cc._add_common_commands(M, "help") -- help commands
 cc._add_common_commands(M, "with_window_picker$") -- open using window picker
 cc._add_common_commands(M, "^toggle_auto_expand_width$")
 cc._add_common_commands(M, "quick_jump")
-
-M.quick_jump = function(state)
-  cc.quick_jump(state)
-end
+cc._add_common_commands(M, "select")
 
 return M

--- a/lua/neo-tree/sources/document_symbols/components.lua
+++ b/lua/neo-tree/sources/document_symbols/components.lua
@@ -39,6 +39,17 @@ M.kind_icon = function(config, node, state)
     icon = config.provider(icon, node, state) or icon
   end
 
+  if state.selected[node.id] then
+    ---@type neotree.Render.Node[]
+    return {
+      {
+        text = require("neo-tree").config.default_component_configs.icon.selected or "[x]",
+        highlight = highlights.SELECTED,
+      },
+      icon,
+    }
+  end
+
   return icon
 end
 

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -84,6 +84,7 @@ local function create_state(tabid, sd, winid)
   ---private-ish
   ---@field orig_tree NuiTree?
   ---@field _ready boolean?
+  ---@field _skip_consuming_selection boolean?
   ---@field loading boolean?
   ---window
   ---@field window neotree.State.Window?

--- a/lua/neo-tree/sources/manager.lua
+++ b/lua/neo-tree/sources/manager.lua
@@ -130,6 +130,7 @@ local function create_state(tabid, sd, winid)
   state.position = {}
   state.sort = { label = "Name", direction = 1 }
   state.clipboard = {}
+  state.selected = {}
   state.undostack = {}
   events.fire_event(events.STATE_CREATED, state)
   table.insert(all_states, state)

--- a/lua/neo-tree/ui/highlights.lua
+++ b/lua/neo-tree/ui/highlights.lua
@@ -38,6 +38,7 @@ M.MESSAGE = "NeoTreeMessage"
 M.MODIFIED = "NeoTreeModified"
 M.NORMAL = "NeoTreeNormal"
 M.NORMALNC = "NeoTreeNormalNC"
+M.SELECTED = "NeoTreeSelected"
 M.SIGNCOLUMN = "NeoTreeSignColumn"
 M.STATUS_LINE = "NeoTreeStatusLine"
 M.STATUS_LINE_NC = "NeoTreeStatusLineNC"
@@ -321,6 +322,7 @@ M.setup = function()
 
   local faded_root = calculate_faded_highlight_group("NeoTreeRootName", 0.5)
   M.create_highlight_group(M.FILE_STATS_HEADER, {}, nil, faded_root.foreground, faded_root.gui)
+  M.create_highlight_group(M.SELECTED, { "Question" })
 end
 
 return M

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -944,7 +944,10 @@ local call_command = function(func, state, config, fallback, selected_nodes)
   state.fallback = fallback
   if selected_nodes then
     func(state, utils.unique(selected_nodes))
-    state.selected = {}
+    if not state._skip_consuming_selection then
+      state.selected = {}
+    end
+    state._skip_consuming_selection = false
   else
     func(state)
   end

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -902,8 +902,9 @@ create_tree = function(state)
 end
 
 ---@param state neotree.StateWithTree
+---@param skip_selection_tags boolean
 ---@return NuiTree.Node[]?
-local get_selected_nodes = function(state)
+local get_selected_nodes = function(state, skip_selection_tags)
   if state.winid ~= vim.api.nvim_get_current_win() then
     return nil
   end
@@ -917,10 +918,11 @@ local get_selected_nodes = function(state)
   while start_pos <= end_pos do
     local node = state.tree:get_node(start_pos)
     if node then
-      table.insert(selected_nodes, node)
+      selected_nodes[#selected_nodes + 1] = node
     end
     start_pos = start_pos + 1
   end
+
   return selected_nodes
 end
 
@@ -1003,7 +1005,11 @@ local set_buffer_mappings = function(state)
         keymap.set(state.bufnr, "v", cmd, function()
           vim.api.nvim_feedkeys(ESC_KEY, "i", true)
           vim.schedule(function()
-            local selected_nodes = get_selected_nodes(state)
+            local selected_nodes = get_selected_nodes(
+              state,
+              -- insane hack but not sure how to encode this as an attribute
+              vfunc == require("neo-tree.sources.common.commands").select_visual
+            )
             if utils.truthy(selected_nodes) then
               ---@cast selected_nodes -nil
               state.config = config

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -968,6 +968,7 @@ local set_buffer_mappings = function(state)
   }
   local mappings = state.window.mappings or {}
   local mapping_options = state.window.mapping_options or { noremap = true }
+  local selection_cmd = require("neo-tree.sources.common.commands").select
   for cmd, func in pairs(mappings) do
     ---@type neotree.TreeCommandVisual?
     local vfunc
@@ -1019,12 +1020,12 @@ local set_buffer_mappings = function(state)
         break
       end
       local fallback = utils.keycode(cmd)
-      local is_selection_bind = func == require("neo-tree.sources.common.commands").select
+      local is_selection_command = func == selection_cmd
       resolved_mappings[cmd] = {
         text = helptext,
         handler = function()
           local selected_nodes = get_tagged_selected_nodes(state)
-          if utils.truthy(selected_nodes) and vfunc and not is_selection_bind then
+          if utils.truthy(selected_nodes) and vfunc and not is_selection_command then
             -- Use the visual-mode function with selected nodes instead.
             selected_nodes[#selected_nodes + 1] = state.tree:get_node()
             call_command(vfunc, state, config, fallback, selected_nodes)
@@ -1039,7 +1040,7 @@ local set_buffer_mappings = function(state)
           vim.api.nvim_feedkeys(ESC_KEY, "i", true)
           vim.schedule(function()
             local selected_nodes = get_visually_selected_nodes(state) or {}
-            if not is_selection_bind then
+            if not is_selection_command then
               vim.list_extend(selected_nodes, get_tagged_selected_nodes(state))
             end
             if not utils.truthy(selected_nodes) then

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -902,9 +902,8 @@ create_tree = function(state)
 end
 
 ---@param state neotree.StateWithTree
----@param skip_selection_tags boolean
 ---@return NuiTree.Node[]?
-local get_selected_nodes = function(state, skip_selection_tags)
+local get_visually_selected_nodes = function(state)
   if state.winid ~= vim.api.nvim_get_current_win() then
     return nil
   end
@@ -923,13 +922,27 @@ local get_selected_nodes = function(state, skip_selection_tags)
     start_pos = start_pos + 1
   end
 
-  if not skip_selection_tags then
-    for id in pairs(state.selected) do
-      selected_nodes[#selected_nodes + 1] = state.tree:get_node(id)
-    end
-  end
-
   return utils.unique(selected_nodes)
+end
+
+---@param state neotree.StateWithTree
+local get_tagged_selected_nodes = function(state)
+  local selected_nodes = {}
+  for id in pairs(state.selected) do
+    selected_nodes[#selected_nodes + 1] = state.tree:get_node(id)
+  end
+  return selected_nodes
+end
+
+---@param func function command
+---@param state neotree.StateWithTree
+---@param config table
+---@param fallback string
+---@param selected_nodes NuiTree.Node[]?
+local call_command = function(func, state, config, fallback, selected_nodes)
+  state.config = config
+  state.fallback = fallback
+  return func(state, selected_nodes)
 end
 
 ---@class neotree.State.ResolvedMapping
@@ -998,12 +1011,18 @@ local set_buffer_mappings = function(state)
         break
       end
       local fallback = utils.keycode(cmd)
+      local is_selection_bind = func == require("neo-tree.sources.common.commands").select
       resolved_mappings[cmd] = {
         text = helptext,
         handler = function()
-          state.config = config
-          state.fallback = fallback
-          return func(state)
+          local selected_nodes = get_tagged_selected_nodes(state)
+          if utils.truthy(selected_nodes) and vfunc and not is_selection_bind then
+            -- Use the selected nodes in the vfunc instead.
+            selected_nodes[#selected_nodes + 1] = state.tree:get_node()
+            call_command(vfunc, state, config, fallback, utils.unique(selected_nodes))
+          else
+            call_command(func, state, config, fallback)
+          end
         end,
       }
       keymap.set(state.bufnr, "n", cmd, resolved_mappings[cmd].handler, map_options)
@@ -1011,16 +1030,15 @@ local set_buffer_mappings = function(state)
         keymap.set(state.bufnr, "v", cmd, function()
           vim.api.nvim_feedkeys(ESC_KEY, "i", true)
           vim.schedule(function()
-            local selected_nodes = get_selected_nodes(
-              state,
-              -- insane hack but not sure how to encode this as an attribute
-              vfunc == require("neo-tree.sources.common.commands").select_visual
-            )
-            if utils.truthy(selected_nodes) then
-              ---@cast selected_nodes -nil
-              state.config = config
-              vfunc(state, selected_nodes)
+            local selected_nodes = get_visually_selected_nodes(state) or {}
+            if not is_selection_bind then
+              vim.list_extend(selected_nodes, get_tagged_selected_nodes(state))
             end
+            selected_nodes = utils.unique(selected_nodes)
+            if not utils.truthy(selected_nodes) then
+              return
+            end
+            call_command(vfunc, state, config, fallback, selected_nodes)
           end)
         end, map_options)
       end
@@ -1028,7 +1046,6 @@ local set_buffer_mappings = function(state)
   end
   state.resolved_mappings = resolved_mappings
 end
-
 local function create_floating_window(state, win_options, bufname)
   state.force_float = nil
   -- First get the default options for floating windows.

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -923,7 +923,13 @@ local get_selected_nodes = function(state, skip_selection_tags)
     start_pos = start_pos + 1
   end
 
-  return selected_nodes
+  if not skip_selection_tags then
+    for id in pairs(state.selected) do
+      selected_nodes[#selected_nodes + 1] = state.tree:get_node(id)
+    end
+  end
+
+  return utils.unique(selected_nodes)
 end
 
 ---@class neotree.State.ResolvedMapping

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -942,7 +942,12 @@ end
 local call_command = function(func, state, config, fallback, selected_nodes)
   state.config = config
   state.fallback = fallback
-  return func(state, selected_nodes)
+  if selected_nodes then
+    func(state, utils.unique(selected_nodes))
+    state.selected = {}
+  else
+    func(state)
+  end
 end
 
 ---@class neotree.State.ResolvedMapping
@@ -1017,9 +1022,9 @@ local set_buffer_mappings = function(state)
         handler = function()
           local selected_nodes = get_tagged_selected_nodes(state)
           if utils.truthy(selected_nodes) and vfunc and not is_selection_bind then
-            -- Use the selected nodes in the vfunc instead.
+            -- Use the visual-mode function with selected nodes instead.
             selected_nodes[#selected_nodes + 1] = state.tree:get_node()
-            call_command(vfunc, state, config, fallback, utils.unique(selected_nodes))
+            call_command(vfunc, state, config, fallback, selected_nodes)
           else
             call_command(func, state, config, fallback)
           end
@@ -1034,7 +1039,6 @@ local set_buffer_mappings = function(state)
             if not is_selection_bind then
               vim.list_extend(selected_nodes, get_tagged_selected_nodes(state))
             end
-            selected_nodes = utils.unique(selected_nodes)
             if not utils.truthy(selected_nodes) then
               return
             end

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1361,6 +1361,10 @@ M.table_merge = function(base_table, override_table)
 end
 
 ---Evaluate the truthiness of a value, according to js/python rules.
+---Differences from Lua:
+---Strings are falsy if they are empty.
+---Numbers are falsy if 0 or below.
+---Tables are falsy if empty.
 ---@param value any
 ---@return boolean truthy
 M.truthy = function(value)


### PR DESCRIPTION
Closes #1829.

Adds a `select` command on `<tab>` that tags nodes as selected, which will be included in any commands that support selections (i.e. commands that have a  `_visual` variant). Also adds `clear_selection` on `<C-;>`.

Selected node ids can be iterated upon in the state.selected table.