### PR TITLE
fix: set winfixheight/width on custom no-enter split

### DIFF
--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1368,6 +1368,8 @@ M.acquire_window = function(state)
           ---@diagnostic disable-next-line: assign-type-mismatch
           split = pos_to_splitdir[nui_win_options.position] or nui_win_options.position,
         })
+        vim.wo[new_win.winid].winfixheight = true
+        vim.wo[new_win.winid].winfixwidth = true
       end
       new_win:mount()
       state.bufnr = new_win.bufnr


### PR DESCRIPTION
Fixes https://github.com/nvim-neo-tree/neo-tree.nvim/pull/1985#issuecomment-4608782588

matches nuisplit behavior