### PR TITLE
fix(filesystem): follow_current_file logic error

### DIFF
--- a/lua/neo-tree/sources/filesystem/init.lua
+++ b/lua/neo-tree/sources/filesystem/init.lua
@@ -160,8 +160,8 @@ M._navigate_internal = function(state, path, path_to_reveal, callback, async)
     local winpos = state.current_position
     local follow_file = state.follow_current_file.enabled
       and not is_search
-      and not winpos == "current"
-      and not winpos == "float"
+      and winpos ~= "current"
+      and winpos ~= "float"
       and manager.get_path_to_reveal()
     local handled = false
     if utils.truthy(follow_file) then


### PR DESCRIPTION
Neotree did not `follow_current_file` in my neovim setup anymore, same thing happening to a colleague using Neotree.

I let a LLM investigate and apparently the bug is that "not" is stronger binding than comparison, so the line

```
not winpos == "current"
--equals
(not winpos) == "current"
-- equals
false == "current"
```

The suggested fix solved the problem for me.