### PR TITLE
chore: fix stylua link syntax in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ This is open for debate, but here is the current style choices being observed:
 
 ### StyLua
 
-We use (StyLua)[https://github.com/JohnnyMorganz/StyLua] to enforce consistency
+We use [StyLua](https://github.com/JohnnyMorganz/StyLua) to enforce consistency
 in code. You should install it on your local machine. PRs will be checked with
 this tool.
 


### PR DESCRIPTION
# Fix Stylua link syntax in `CONTRIBUTING.md`

## Description

Heya! I love this plugin and have been using it for ages, I believe I've found a bug (which I'll raise as an issue and link here in a second, https://github.com/nvim-neo-tree/neo-tree.nvim/issues/2058), but while looking through the source for the root cause I found this in the `CONTRIBUTING.md` and figured I'd raise a PR for it.

It's just the classic markdown link punctuation flip, where instead of

`[text](link)`, somebody wrote `(text)[link]`.

I wouldn't have thought there is anywhere else I would need to change anything, and apologies if I should have opened an issue prior to this PR, I figured as it was so small I wouldn't bother.

I did run 

```bash
rg '\(.+\)\[.+\]'
```

just to check if there were any other instances, but there doesn't appear to be any