### PR TITLE
ci: continue on error for nightly typechecking

### DIFF
--- a/.github/workflows/luals-check.yml
+++ b/.github/workflows/luals-check.yml
@@ -30,6 +30,7 @@ jobs:
         install_args: "github:neovim/neovim@${{matrix.neovim}}"
 
     - name: Run lua-language-server check
+      continue-on-error: ${{ matrix.neovim == 'nightly' }}
       run: |
         mise use github:neovim/neovim@${{matrix.neovim}}
         mise run update-dependencies

--- a/.github/workflows/luals-check.yml
+++ b/.github/workflows/luals-check.yml
@@ -30,6 +30,8 @@ jobs:
         install_args: "github:neovim/neovim@${{matrix.neovim}}"
 
     - name: Run lua-language-server check
+      # nightly gets deprecated notices often so this prevents ci from looking like we're failing when we're just using
+      # a function that will only be deprecated on stable in months
       continue-on-error: ${{ matrix.neovim == 'nightly' }}
       run: |
         mise use github:neovim/neovim@${{matrix.neovim}}


### PR DESCRIPTION
largely because nightly tends to get deprecated notices