### PR TITLE
fix: skip reveal if parent of reveal file doesn't exist

### DIFF
--- a/lua/neo-tree/command/init.lua
+++ b/lua/neo-tree/command/init.lua
@@ -70,7 +70,11 @@ local function handle_reveal(args, state)
     return
   end
 
-  local reveal_file_parent = assert(utils.split_path(args.reveal_file))
+  local reveal_file_parent = utils.split_path(args.reveal_file)
+  if not reveal_file_parent then
+    return
+  end
+
   if args.reveal_force_cwd then
     args.dir = reveal_file_parent
     do_show_or_focus(args, state, true)


### PR DESCRIPTION
health check file is health:// and neo-tree doesn't know how to parse the path so the best solution for now is just to ignore. maybe a more robust path handling solution should be adopted but throwing an error was the wrong fail behavior anyways so this fix should be ok

Closes #2058 