### PR TITLE
fix(git): discover nested repositories without the file watcher

### DIFF
--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -20,12 +20,10 @@ local M = {}
 --- how many entries to load per readdir
 local ENTRIES_BATCH_SIZE = 1000
 
----@type string[]
-local possible_worktree_roots = {}
-
 ---@param cwd string Filters what worktrees to view. Should be an ancestor of all the items.
 ---@param items neotree.FileItem[]
-local mark_gitignored = function(cwd, items)
+---@param possible_worktree_roots string[] Roots of newly-discovered nested repositories found while scanning.
+local mark_gitignored = function(cwd, items, possible_worktree_roots)
   if vim.in_fast_event() then
     log.warn("mark_gitignored cannot be called in a fast event", debug.traceback())
     return
@@ -63,7 +61,6 @@ local mark_gitignored = function(cwd, items)
       end
     end
   end
-  possible_worktree_roots = {}
 
   -- Sort by descending key length since we want to ensure that the most specific worktrees are matched first
   table.sort(roots_and_statuses, function(a, b)
@@ -155,7 +152,7 @@ local on_directory_loaded = function(context, dir_path)
         vim.endswith(child.path, utils.path_separator .. ".git")
         and not git.worktrees[target_path]
       then
-        possible_worktree_roots[#possible_worktree_roots + 1] = target_path
+        context.nested_worktree_roots[#context.nested_worktree_roots + 1] = target_path
         -- try running a status (and potentially start tracking)
         if nt.config.git_status_async then
           git.status_async(target_path, nil, nt.config.git_status_async_options)
@@ -253,7 +250,7 @@ local job_complete = function(context, skip_render_context)
   file_nesting.nest_items(context)
   ignored.mark_ignored(state, context.all_items)
   if should_check_gitignore(state) then
-    mark_gitignored(state.path, context.all_items)
+    mark_gitignored(state.path, context.all_items, context.nested_worktree_roots)
   end
   if not skip_render_context then
     vim.schedule(function()
@@ -678,6 +675,7 @@ end
 ---async
 ---@field paths_to_load string[]
 ---@field is_a_never_show_file fun(filename: string?):boolean
+---@field nested_worktree_roots string[] Roots of newly-discovered nested repositories found while scanning.
 
 ---@class neotree.sources.filesystem.State : neotree.State, neotree.Config.Filesystem
 ---@field path string
@@ -709,6 +707,7 @@ M.get_items = function(state, parent_id, path_to_reveal, callback, async_dir_sca
   context.path_to_reveal = path_to_reveal
   context.recursive = recursive
   context.callback = callback
+  context.nested_worktree_roots = {}
   -- Create root folder
   local root = file_items.create_item(context, parent_id or state.path, "directory") --[[@as neotree.FileItem.Directory]]
   root.name = vim.fn.fnamemodify(root.path, ":~")
@@ -738,6 +737,7 @@ M.get_dir_items_async = function(state, parent_id, recursive)
   context.recursive = recursive
   context.callback = nil
   context.paths_to_load = {}
+  context.nested_worktree_roots = {}
 
   -- Create root folder
   local root = file_items.create_item(context, parent_id or state.path, "directory") --[[@as neotree.FileItem.Directory]]

--- a/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
+++ b/lua/neo-tree/sources/filesystem/lib/fs_scan.lua
@@ -144,9 +144,32 @@ local on_directory_loaded = function(context, dir_path)
 
   folder.loaded = true
 
+  local target_path = folder.is_link and utils.path_join(folder.path, folder.link_to) or folder.path
+
+  -- A folder with a .git entry among its children is the root of its own worktree.
+  -- The tree root is already covered by the source, so only nested repositories are
+  -- left to register here.
+  if nt.config.enable_git_status and folder.path ~= state.path then
+    for _, child in ipairs(folder.children) do
+      if
+        vim.endswith(child.path, utils.path_separator .. ".git")
+        and not git.worktrees[target_path]
+      then
+        possible_worktree_roots[#possible_worktree_roots + 1] = target_path
+        -- try running a status (and potentially start tracking)
+        if nt.config.git_status_async then
+          git.status_async(target_path, nil, nt.config.git_status_async_options)
+        else
+          vim.schedule(function()
+            git.status(target_path, nil, false)
+          end)
+        end
+        break
+      end
+    end
+  end
+
   if state.use_libuv_file_watcher then
-    local target_path = folder.is_link and utils.path_join(folder.path, folder.link_to)
-      or folder.path
     -- git folders seem to throw off fs events constantly, ignore them this time.
     if target_path:find(".git", 1, true) then
       -- https://git-scm.com/docs/gitrepository-layout
@@ -165,23 +188,6 @@ local on_directory_loaded = function(context, dir_path)
         return
       end
     end
-    if nt.config.enable_git_status then
-      for i, child in ipairs(folder.children) do
-        if vim.endswith(child.path, ".git") and not git.worktrees[target_path] then
-          possible_worktree_roots[#possible_worktree_roots + 1] = target_path
-          -- try running a status (and potentially start tracking)
-          if nt.config.git_status_async then
-            git.status_async(target_path, nil, nt.config.git_status_async_options)
-          else
-            vim.schedule(function()
-              git.status(target_path, nil, false)
-            end)
-          end
-          break
-        end
-      end
-    end
-
     local fs_watch_callback = vim.schedule_wrap(function(err, fname)
       if err then
         log.error("file_event_callback: ", err)

--- a/tests/neo-tree/sources/filesystem/git_nested_worktree_spec.lua
+++ b/tests/neo-tree/sources/filesystem/git_nested_worktree_spec.lua
@@ -1,12 +1,13 @@
 pcall(require, "luacov")
 
 local u = require("tests.utils")
+local uv = vim.uv or vim.loop
 local verify = require("tests.utils.verify")
 local git = require("neo-tree.git")
 local utils = require("neo-tree.utils")
 
 -- Registration spawns `git rev-parse` and `git status`, which is slow on CI runners.
-local TIMEOUT = 5000
+local TIMEOUT = 30 * 1000
 
 ---@param cwd string
 ---@param ... string
@@ -33,7 +34,19 @@ local function create_nested_repos()
   u.fs.write_file(inner_file, { "hello" })
   git_cmd(inner, "add", "tracked.txt")
 
-  return outer, inner, utils.normalize_path(inner_file)
+  -- we must resolve all of these paths to realpaths because: (gemini-generated output below)
+  -- On Windows hosted virtual machines in GitHub Actions, "RUNNER~1" is the 8.3 short-form MS-DOS path representation
+  -- for the user profile directory C:\Users\RUNNER 1 (often belonging to the default user runneradmin). This path
+  -- frequently appears in environment variables, temporary folders, or test assertions on GitHub-hosted Windows
+  -- runners.  Node.js methods like os.tmpdir() can intermittently return either the short-form (RUNNER~1) or long-form
+  -- path, which sometimes breaks path-matching unit tests in CI pipelines.
+  local outputs = { outer, inner, inner_file }
+  for i, path in ipairs(outputs) do
+    outputs[i] = utils.normalize_path(assert(uv.fs_realpath(path)))
+  end
+
+  outer, inner, inner_file = unpack(outputs)
+  return outer, inner, inner_file
 end
 
 describe("Filesystem git status for nested repositories", function()
@@ -63,16 +76,17 @@ describe("Filesystem git status for nested repositories", function()
         dir = outer,
         reveal_file = inner_file,
       })
+      verify.filesystem_tree_node_is(inner_file)
       return inner, inner_file
     end
 
     it("resolves the nested repository to its own worktree" .. suffix, function()
       local inner, inner_file = open_tree_revealing_the_nested_repo()
-      local inner_root = git.find_worktree_info(inner)
 
       verify.eventually(function()
-        return git.find_existing_worktree(inner_file) == inner_root
-      end, "the nested file should resolve to the nested worktree, not the outer one", TIMEOUT)
+        local actual_worktree_root = git.find_existing_worktree(inner_file)
+        return actual_worktree_root and actual_worktree_root == inner
+      end, "worktree root never resolved to " .. inner, TIMEOUT)
     end)
 
     it("does not report files of the nested repository as ignored" .. suffix, function()
@@ -84,7 +98,7 @@ describe("Filesystem git status for nested repositories", function()
       verify.eventually(function()
         local status = git.find_existing_status_code(inner_file, {})
         return status ~= nil and status ~= "!"
-      end, "the nested file kept the outer repository's ignored status", TIMEOUT)
+      end, "status code did not resolve properly", TIMEOUT)
     end)
   end
 end)

--- a/tests/neo-tree/sources/filesystem/git_nested_worktree_spec.lua
+++ b/tests/neo-tree/sources/filesystem/git_nested_worktree_spec.lua
@@ -1,0 +1,90 @@
+pcall(require, "luacov")
+
+local u = require("tests.utils")
+local verify = require("tests.utils.verify")
+local git = require("neo-tree.git")
+local utils = require("neo-tree.utils")
+
+-- Registration spawns `git rev-parse` and `git status`, which is slow on CI runners.
+local TIMEOUT = 5000
+
+---@param cwd string
+---@param ... string
+local function git_cmd(cwd, ...)
+  vim.fn.system(vim.list_extend({ "git", "-C", cwd }, { ... }))
+  assert(vim.v.shell_error == 0, "git " .. table.concat({ ... }, " ") .. " failed in " .. cwd)
+end
+
+---An outer repository with an independent repository checked out inside of it, which
+---the outer .gitignore excludes. Nothing is committed on purpose: staging is enough
+---for `git status` to report the file, and it keeps the setup free of the user's
+---global commit hooks and signing config.
+---@return string outer, string inner, string inner_file
+local function create_nested_repos()
+  local outer = u.fs.create_temp_dir()
+  git_cmd(outer, "init", "--quiet")
+  u.fs.write_file(utils.path_join(outer, ".gitignore"), { "/inner/" })
+  git_cmd(outer, "add", ".gitignore")
+
+  local inner = utils.path_join(outer, "inner")
+  u.fs.create_dir(inner)
+  git_cmd(inner, "init", "--quiet")
+  local inner_file = utils.path_join(inner, "tracked.txt")
+  u.fs.write_file(inner_file, { "hello" })
+  git_cmd(inner, "add", "tracked.txt")
+
+  return outer, inner, utils.normalize_path(inner_file)
+end
+
+describe("Filesystem git status for nested repositories", function()
+  -- The temporary repositories are deliberately left on disk. Removing them while an
+  -- async `git status` is still in flight makes it fail against a missing directory,
+  -- and Neovim drops its own temp directory on exit anyway.
+  after_each(function()
+    u.clear_environment()
+  end)
+
+  for _, use_libuv_file_watcher in ipairs({ false, true }) do
+    local suffix = " (use_libuv_file_watcher=" .. tostring(use_libuv_file_watcher) .. ")"
+
+    ---@return string inner, string inner_file
+    local function open_tree_revealing_the_nested_repo()
+      local outer, inner, inner_file = create_nested_repos()
+      require("neo-tree").setup({
+        enable_git_status = true,
+        filesystem = {
+          use_libuv_file_watcher = use_libuv_file_watcher,
+          filtered_items = { hide_gitignored = false },
+        },
+      })
+      require("neo-tree.command").execute({
+        action = "show",
+        source = "filesystem",
+        dir = outer,
+        reveal_file = inner_file,
+      })
+      return inner, inner_file
+    end
+
+    it("resolves the nested repository to its own worktree" .. suffix, function()
+      local inner, inner_file = open_tree_revealing_the_nested_repo()
+      local inner_root = git.find_worktree_info(inner)
+
+      verify.eventually(function()
+        return git.find_existing_worktree(inner_file) == inner_root
+      end, "the nested file should resolve to the nested worktree, not the outer one", TIMEOUT)
+    end)
+
+    it("does not report files of the nested repository as ignored" .. suffix, function()
+      local _, inner_file = open_tree_revealing_the_nested_repo()
+
+      -- Waiting for a status code that is neither missing nor "!" covers both halves:
+      -- the outer .gitignore marks the nested file as ignored until the nested
+      -- repository is registered, and the nested repository reports it as staged.
+      verify.eventually(function()
+        local status = git.find_existing_status_code(inner_file, {})
+        return status ~= nil and status ~= "!"
+      end, "the nested file kept the outer repository's ignored status", TIMEOUT)
+    end)
+  end
+end)

--- a/tests/neo-tree/sources/filesystem/git_nested_worktree_spec.lua
+++ b/tests/neo-tree/sources/filesystem/git_nested_worktree_spec.lua
@@ -7,7 +7,7 @@ local git = require("neo-tree.git")
 local utils = require("neo-tree.utils")
 
 -- Registration spawns `git rev-parse` and `git status`, which is slow on CI runners.
-local TIMEOUT = 30 * 1000
+local TIMEOUT = 45 * 1000
 
 ---@param cwd string
 ---@param ... string

--- a/tests/utils/verify.lua
+++ b/tests/utils/verify.lua
@@ -1,21 +1,37 @@
 local utils = require("neo-tree.utils")
 local verify = {}
+---@alias neotree.test.assertfunc fun(...):success: boolean, err: string?
+---@alias neotree.test.failmsg (fun():string)|string
 
 local DEFAULT_TIMEOUT = 1000
----@param assertfunc function
----@param failmsg string|function
+---@param failmsg neotree.test.failmsg
+---@return string
+local resolve_failmsg = function(failmsg)
+  if type(failmsg) == "function" then
+    return failmsg()
+  end
+  return failmsg
+end
+---@param assertfunc neotree.test.assertfunc
+---@param failmsg neotree.test.failmsg
 ---@param timeout integer?
 verify.eventually = function(assertfunc, failmsg, timeout, ...)
-  local success, args = false, { ... }
-  vim.wait(timeout or DEFAULT_TIMEOUT, function()
-    success = assertfunc(unpack(args))
-    return success
+  local args = { ... }
+  local success, last_err
+  ---@type boolean, boolean|-1|-2|nil
+  local notimeout = vim.wait(timeout or DEFAULT_TIMEOUT, function()
+    success, last_err = assertfunc(unpack(args))
+    return success, last_err
   end)
-  assert(success, type(failmsg) == "function" and failmsg() or failmsg)
+  local err = resolve_failmsg(last_err or failmsg)
+  if not notimeout then
+    err = "timeout: " .. err
+  end
+  assert(notimeout and success, err)
 end
 
 ---Blocks until the assertfunc is run on the next vim.schedule. Will throw the error thrown by the scheduled function.
----@param assertfunc function
+---@param assertfunc neotree.test.assertfunc
 ---@param timeout integer?
 verify.schedule = function(assertfunc, timeout)
   local scheduled_func_ran = false


### PR DESCRIPTION
Nested repository discovery in `on_directory_loaded` sits inside the
`if state.use_libuv_file_watcher then` branch, so a folder holding a `.git`
entry is only registered as its own worktree when the file watcher is enabled.
`use_libuv_file_watcher` defaults to `false`, so under the default config a
nested repository is never discovered — every path below it resolves against
the outer worktree, and its files are reported as ignored whenever the outer
`.gitignore` excludes the directory. #2015 made resolution prefer the innermost
worktree, but with the watcher off the inner one never gets registered in the
first place.

To reproduce: an outer repo whose `.gitignore` contains `/inner/`, with an
independent repo checked out at `inner/`. On default settings every file under
`inner/` renders as gitignored; setting `use_libuv_file_watcher = true` fixes
it, which is what pointed at the coupling.

This moves the registration out of the watcher branch and gates it on
`enable_git_status`. Two details keep it from costing anything for people
without nested repositories:

- The tree root is skipped, since `filesystem.navigate` already runs a status
  for it. Without that it gets statused twice per fresh scan.
- The child has to be named exactly `.git` rather than merely end in `.git`, so
  a directory such as `mirror.git` no longer triggers a `git rev-parse` on
  every scan — it never becomes a registered worktree, so the existing lookup
  guard cannot suppress the repeat.

I counted git subprocesses on a plain repo with no nested repository (default
config, fresh open) and this branch matches `main` exactly: 2 `rev-parse`,
1 full `git status --ignored`, 1 `git status --untracked-files=no`, 1
`ls-files`. Same parity for a repo containing `sub/mirror.git/` and for a repo
opened through a symlink.

One thing worth flagging: `possible_worktree_roots` is drained only by
`mark_gitignored`, which `job_complete` skips when `hide_gitignored = false`,
so entries for nested repos can sit there unconsumed. That is pre-existing and
bounded — the `not git.worktrees[target_path]` guard stops appending once
registration completes — but this change makes it reachable on the default
config rather than only with the watcher on. Happy to address it here or
separately if you'd prefer.

Added `tests/neo-tree/sources/filesystem/git_nested_worktree_spec.lua`, which
runs both watcher settings. Against `main` the two `use_libuv_file_watcher =
false` cases fail and the two `= true` cases pass; with this change all four
pass. Full suite goes from 91 to 95 passing, no failures or errors.
