### PR TITLE
fix(document_symbols): correct diagnostic text sign shift

### DIFF
--- a/lua/neo-tree/sources/common/components.lua
+++ b/lua/neo-tree/sources/common/components.lua
@@ -221,7 +221,7 @@ M.diagnostics = function(config, node, state)
     }
   else
     return {
-      text = severity:sub(1, 1),
+      text = to2char(severity:sub(1, 1)),
       highlight = "Diagnostic" .. severity,
     }
   end


### PR DESCRIPTION
closes #1554

When diagnostic rendering would fallback to char rendering it would only print a single char, but it needs padding same as 5 lines above.

**Before/After:**
<img width="311" height="484" alt="{2D733B94-309B-411C-8D06-EBF279567370}" src="https://github.com/user-attachments/assets/a5d3f2f8-1abc-4e2c-bcfd-a26e48356479" /><img width="309" height="484" alt="{D4B32EB2-B972-4048-92B4-BE5F30FA5FC2}" src="https://github.com/user-attachments/assets/a40a44c7-630f-48a6-a05b-dd982919e601" />
