### PR TITLE
fix(utils): fully flush job stdio streams before calling on_exit

### DIFF
--- a/lua/neo-tree/git/init.lua
+++ b/lua/neo-tree/git/init.lua
@@ -585,9 +585,9 @@ end
 
 ---Finds the worktree root and the corresponding git directory, already normalized.
 ---@param path string? Defaults to cwd.
----@param callback fun(worktree_root: string?, git_dir: string?, superproject_worktree_root: string?)? Async if provided.
----@return string? git_dir
+---@param callback fun(worktree_root: string?, git_dir_or_err: string?, superproject_worktree_root: string?)? Async if provided.
 ---@return string? worktree_root
+---@return string? git_dir_or_err
 ---@return string? superproject_worktree_root
 M.find_worktree_info = function(path, callback)
   path = path or log.assert(uv.cwd())
@@ -610,6 +610,7 @@ M.find_worktree_info = function(path, callback)
     log.assert(type(callback) == "function", "callback for find_worktree_info should be a function")
     utils.job(rev_parse_cmd, nil, function(code, stdout_chunks, stderr_chunks)
       if code ~= 0 then
+        callback(nil, table.concat(stderr_chunks, ""))
         return
       end
       local full_stdout = table.concat(stdout_chunks, "")
@@ -619,6 +620,10 @@ M.find_worktree_info = function(path, callback)
       end
       local info = process_output(path, stdout_lines)
       local git_dir, worktree_root, superproject_worktree_root = unpack(info)
+      if not git_dir and not worktree_root then
+        callback(nil, "unknown error? this only seems to happen in ci")
+        return
+      end
       callback(worktree_root, git_dir, superproject_worktree_root)
     end)
     return
@@ -626,7 +631,7 @@ M.find_worktree_info = function(path, callback)
 
   local ok, rev_parse_lines = utils.execute_command(rev_parse_cmd)
   if not ok then
-    return
+    return nil, table.concat(rev_parse_lines, "\n")
   end
   local info = process_output(path, rev_parse_lines)
   local git_dir, worktree_root, superproject_worktree_root = unpack(info)

--- a/lua/neo-tree/git/init.lua
+++ b/lua/neo-tree/git/init.lua
@@ -620,10 +620,6 @@ M.find_worktree_info = function(path, callback)
       end
       local info = process_output(path, stdout_lines)
       local git_dir, worktree_root, superproject_worktree_root = unpack(info)
-      if not git_dir and not worktree_root then
-        callback(nil, "unknown error? this only seems to happen in ci")
-        return
-      end
       callback(worktree_root, git_dir, superproject_worktree_root)
     end)
     return

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1804,7 +1804,6 @@ end
 M.prior_windows = {}
 
 ---Start an async command with uv.
----Placeholder before upgrading to vim.system
 ---@param cmd string[]
 ---@param opts uv.spawn.options? args, hide, and stdio are ignored
 ---@param on_exit fun(code: integer, stdout_chunks: string[], stderr_chunks: string[])?
@@ -1818,22 +1817,36 @@ M.job = function(cmd, opts, on_exit)
   local args = { unpack(cmd, 2) }
   local completed = false
   local exit_code
+
+  -- Track pipe reader states
+  local stdout_closed = false
+  local stderr_closed = false
+  local process_exited = false
+
   local stdout = log.assert(uv.new_pipe(false))
   local stderr = log.assert(uv.new_pipe(false))
+
+  local function try_finish()
+    if process_exited and stdout_closed and stderr_closed then
+      completed = true
+      if on_exit then
+        on_exit(exit_code, stdout_chunks, stderr_chunks)
+      end
+    end
+  end
+
   ---@type uv.spawn.options
   local spawnopts = opts or {}
   spawnopts.args = args
   spawnopts.hide = true
   spawnopts.stdio = { nil, stdout, stderr }
+
   local handle, pid_or_err = uv.spawn(path, spawnopts, function(code, _)
-    stdout:close()
-    stderr:close()
     exit_code = code
-    completed = true
-    if on_exit then
-      on_exit(code, stdout_chunks, stderr_chunks)
-    end
+    process_exited = true
+    try_finish()
   end)
+
   if not handle then
     stdout:close()
     stderr:close()
@@ -1841,17 +1854,27 @@ M.job = function(cmd, opts, on_exit)
   end
 
   stdout:read_start(function(err, data)
-    log.assert(not err, err)
     if type(data) == "string" then
       stdout_chunks[#stdout_chunks + 1] = data
+    else
+      log.error(err)
+      stdout:close()
+      stdout_closed = true
+      try_finish()
     end
   end)
+
   stderr:read_start(function(err, data)
-    log.assert(not err, err)
     if type(data) == "string" then
       stderr_chunks[#stderr_chunks + 1] = data
+    else
+      log.error(err)
+      stderr:close()
+      stderr_closed = true
+      try_finish()
     end
   end)
+
   ---@class neotree.utils.Job
   local job = {
     handle = handle,

--- a/lua/neo-tree/utils/init.lua
+++ b/lua/neo-tree/utils/init.lua
@@ -1854,10 +1854,12 @@ M.job = function(cmd, opts, on_exit)
   end
 
   stdout:read_start(function(err, data)
-    if type(data) == "string" then
-      stdout_chunks[#stdout_chunks + 1] = data
-    else
+    if err then
       log.error(err)
+    elseif type(data) == "string" then
+      stdout_chunks[#stdout_chunks + 1] = data
+      return
+    else
       stdout:close()
       stdout_closed = true
       try_finish()
@@ -1865,10 +1867,11 @@ M.job = function(cmd, opts, on_exit)
   end)
 
   stderr:read_start(function(err, data)
-    if type(data) == "string" then
+    if err then
+      log.error(err)
+    elseif type(data) == "string" then
       stderr_chunks[#stderr_chunks + 1] = data
     else
-      log.error(err)
       stderr:close()
       stderr_closed = true
       try_finish()

--- a/tests/neo-tree/sources/filesystem/git_nested_worktree_spec.lua
+++ b/tests/neo-tree/sources/filesystem/git_nested_worktree_spec.lua
@@ -7,7 +7,8 @@ local git = require("neo-tree.git")
 local utils = require("neo-tree.utils")
 
 -- Registration spawns `git rev-parse` and `git status`, which is slow on CI runners.
-local TIMEOUT = 45 * 1000
+-- Timeout determined by seeing how long successful runs take (usually 20 seconds or less)
+local TIMEOUT = 30 * 1000
 
 ---@param cwd string
 ---@param ... string
@@ -98,7 +99,7 @@ describe("Filesystem git status for nested repositories", function()
       verify.eventually(function()
         local status = git.find_existing_status_code(inner_file, {})
         return status ~= nil and status ~= "!"
-      end, "status code did not resolve properly", TIMEOUT)
+      end, "status code did not resolve properly for " .. inner_file, TIMEOUT)
     end)
   end
 end)

--- a/tests/utils/verify.lua
+++ b/tests/utils/verify.lua
@@ -1,6 +1,6 @@
 local utils = require("neo-tree.utils")
 local verify = {}
----@alias neotree.test.assertfunc fun(...):success: boolean, err: string?
+---@alias neotree.test.assertfunc fun(...):success: any, err: string?
 ---@alias neotree.test.failmsg (fun():string)|string
 
 local DEFAULT_TIMEOUT = 1000


### PR DESCRIPTION
fixes an issue discovered in ci where git repos would randomly not register