### PR TITLE
fix(commands): adjust `invert_selection` normal-mode behavior

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -189,20 +189,28 @@ HELP                                                            *neo-tree-help*
 
 SELECTION                                                  *neo-tree-selection*
 
-In neo-tree, nodes can either be selected by |visual-mode|, or be tagged as
-selected with the following commands:
+In Neo-tree, nodes are considered selected if they are:
+- targeted by |visual-mode| selection
+- tagged as `selected`.
+
+(Additionally, if there are any nodes tagged as `selected`, then the node under
+the cursor counts too, even in Normal mode.)
+
+Nodes can be tagged as `selected` using the following commands:
 
 <tab>              = select  Toggles whether a node is tagged as selected. In
                              Visual mode, tags all targeted nodes unless they
                              were all already tagged, in which case they will
-                             all be untagged as selected.
+                             all be untagged.
                              Supports visual selection. ~
 
 <C-S-i>  = invert_selection  Inverts the selection tags on targeted node(s).
+                             In Normal mode, targets all visible nodes.
                              Supports visual selection. ~
 
 See |neo-tree-custom-mappings-selection| for how to write commands that use
-selected nodes.
+selected nodes. Due to limitations of the current keymap system, there is
+currently no way to write your own commands that do selection.
 
 NAVIGATION                                                *neo-tree-navigation*
 

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -707,7 +707,15 @@ M.clear_selection = function(state)
   renderer.redraw(state)
 end
 
-M.invert_selection = M.select
+---@type neotree.TreeCommandVisual
+M.invert_selection = function(state)
+  save_previous_selection_to_undo(state)
+
+  for _, node in ipairs(renderer.get_all_visible_nodes(state.tree)) do
+    state.selected[node.id] = not state.selected[node.id] or nil
+  end
+  renderer.redraw(state)
+end
 
 ---@type neotree.TreeCommandVisual
 M.invert_selection_visual = function(state, selected_nodes)


### PR DESCRIPTION
having invert_selection not actually invert the selection in normal mode may be surprising.

not breaking because invert_selection is unreleased.