### PR TITLE
fix(auto_expand_width): stop width ratchet, reset stale longest_node

### DIFF
--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -221,6 +221,12 @@ M.toggle_auto_expand_width = function(state)
     compat.nvim_win_set_width(0, state.window.last_user_width)
     state.win_width = state.window.last_user_width
     state.longest_width_exact = 0
+    -- longest_node is a high-water mark that only otherwise resets on a full
+    -- tree rebuild (show_nodes). Without resetting it here too, a stale,
+    -- inflated value from a previous expand cycle (e.g. picked up from a
+    -- transient width blip while a floating popup was open) keeps padding
+    -- future auto-expand widths even after collapsing.
+    state.longest_node = 0
     log.trace("Collapse auto_expand_width.")
   end
   renderer.redraw(state)

--- a/lua/neo-tree/ui/renderer.lua
+++ b/lua/neo-tree/ui/renderer.lua
@@ -1534,7 +1534,16 @@ render_tree = function(state)
     state._in_pre_render = false
     local textoffset = vim.fn.getwininfo(state.winid)[1].textoff or 0
     local desired_width = state.longest_node + textoffset
-    state.window.last_user_width = vim.api.nvim_win_get_width(state.winid)
+    -- Only capture the baseline width once. Overwriting it on every render
+    -- pass means that after auto-expand has already grown the window, the
+    -- next render treats the *expanded* width as the new baseline, which
+    -- lets newly-eligible columns (e.g. type/last_modified, gated by
+    -- required_width) keep pushing the window wider on each subsequent
+    -- render, and leaves nothing to restore to when auto-expand is toggled
+    -- back off.
+    if not state.window.last_user_width then
+      state.window.last_user_width = vim.api.nvim_win_get_width(state.winid)
+    end
     if should_auto_expand and desired_width > state.window.last_user_width then
       log.at.trace.format("auto_expand_width: on. Expanding width to %s.", state.longest_node)
       _compat.nvim_win_set_width(state.winid, desired_width)


### PR DESCRIPTION
## Problem

With `auto_expand_width` on, toggling it and interacting with the tree (e.g. opening a `show_file_details` popup) can cause the window to keep growing wider on its own, revealing `type`/`last_modified` columns that shouldn't be visible yet, and the window doesn't fully shrink back down when auto-expand is toggled off again — only a full close/reopen of the tree resets it.

## Cause

1. `render_tree` (`ui/renderer.lua`) overwrote `state.window.last_user_width` with the *current* window width on every render pass, instead of capturing it once. Since column visibility (`file_size`/`type`/`last_modified`) is gated by the live window width (`sources/common/container.lua`), each successive render could treat an already-expanded width as the new baseline, letting the window ratchet wider as more columns crossed their `required_width` thresholds — and leaving nothing to restore to when auto-expand was disabled.
2. `toggle_auto_expand_width` (`sources/common/commands.lua`) already reset `state.longest_width_exact = 0` on collapse, but not `state.longest_node` — the monotonic high-water mark actually used to compute the auto-expand target width. A stale, inflated value from a prior expand cycle (e.g. picked up from a transient width read while a floating popup was open) kept padding future auto-expand widths even after collapsing, since it only resets on a full tree rebuild.

## Fix

- Only set `last_user_width` when it isn't already set, so it reflects the genuine pre-expand baseline.
- Reset `state.longest_node` alongside `state.longest_width_exact` when collapsing.

## Testing

Manually verified in a live Neovim config: toggling `auto_expand_width` (`e`) now expands only to fit currently-eligible content, collapses back to the exact original width, and repeated toggle/expand cycles (including opening/closing the file-details popup in between) no longer accumulate extra width or reveal columns that shouldn't be visible yet. Manually widening the window still correctly reveals `type`/`last_modified` once it crosses their `required_width`, confirming the column-gating logic itself is untouched.