### PR TITLE
fix(clipboard): store only serializable node fields

### DIFF
--- a/doc/neo-tree.txt
+++ b/doc/neo-tree.txt
@@ -2161,6 +2161,21 @@ Neo-tree features a clipboard that you can copy, cut, and paste nodes with (by
 default, with y, x, and p respectively). You can also clear a clipboard with
 <C-R> by default.
 
+A clipboard maps node ids to entries shaped like the table below. Entries only
+hold the node fields the clipboard needs rather than whole |NuiTree| nodes, so
+that a clipboard is always serializable:
+>lua
+    {
+      action = "copy", -- or "cut"
+      node = {
+        id = "/path/to/file",
+        name = "file",
+        path = "/path/to/file",
+        type = "file",
+      },
+    }
+<
+
 CLIPBOARD SYNC                                         *neo-tree-clipboard-sync*
 
 Neo-tree's clipboard can be synced globally (across all Neo-trees within the

--- a/lua/neo-tree/clipboard/init.lua
+++ b/lua/neo-tree/clipboard/init.lua
@@ -5,9 +5,15 @@ local renderer = require("neo-tree.ui.renderer")
 
 local M = {}
 
----@class neotree.clipboard.Node
----@field action string
----@field node NuiTree.Node
+---@class (exact) neotree.clipboard.NodeInfo
+---@field id string
+---@field name string
+---@field path string?
+---@field type string?
+
+---@class (exact) neotree.clipboard.Node
+---@field action "copy"|"cut"
+---@field node neotree.clipboard.NodeInfo
 
 ---@alias neotree.clipboard.Contents table<string, neotree.clipboard.Node?>
 

--- a/lua/neo-tree/sources/common/commands.lua
+++ b/lua/neo-tree/sources/common/commands.lua
@@ -226,13 +226,24 @@ M.toggle_auto_expand_width = function(state)
   renderer.redraw(state)
 end
 
+---@param node NuiTree.Node
+---@return neotree.clipboard.NodeInfo
+local clipboard_node_info = function(node)
+  return {
+    id = node.id,
+    name = node.name,
+    path = node.path,
+    type = node.type,
+  }
+end
+
 ---@param state neotree.State
 local copy_node_to_clipboard = function(state, node)
   local existing = state.clipboard[node.id]
   if existing and existing.action == "copy" then
     state.clipboard[node.id] = nil
   else
-    state.clipboard[node.id] = { action = "copy", node = node }
+    state.clipboard[node.id] = { action = "copy", node = clipboard_node_info(node) }
     log.info("Copied " .. node.name .. " to clipboard")
   end
   events.fire_event(events.NEO_TREE_CLIPBOARD_CHANGED, {
@@ -272,7 +283,7 @@ local cut_node_to_clipboard = function(state, node)
   if existing and existing.action == "cut" then
     state.clipboard[node.id] = nil
   else
-    state.clipboard[node.id] = { action = "cut", node = node }
+    state.clipboard[node.id] = { action = "cut", node = clipboard_node_info(node) }
     log.info("Cut " .. node.name .. " to clipboard")
   end
   events.fire_event(events.NEO_TREE_CLIPBOARD_CHANGED, {

--- a/tests/neo-tree/clipboard/universal_spec.lua
+++ b/tests/neo-tree/clipboard/universal_spec.lua
@@ -1,0 +1,77 @@
+local u = require("tests.utils")
+local verify = require("tests.utils.verify")
+local renderer = require("neo-tree.ui.renderer")
+local UniversalBackend = require("neo-tree.clipboard.sync.universal")
+
+describe("Universal clipboard", function()
+  local test = u.fs.init_test({
+    items = {
+      { name = "topfile1.txt", type = "file", id = "topfile1" },
+    },
+  })
+
+  test.setup()
+
+  ---Closes the fs_event handles the backend opens while loading, so that they
+  ---do not outlive the test.
+  local close_handles = function()
+    for filename, handle in pairs(UniversalBackend.handles or {}) do
+      if not handle:is_closing() then
+        handle:close()
+      end
+      UniversalBackend.handles[filename] = nil
+    end
+  end
+
+  after_each(function()
+    close_handles()
+    u.clear_environment()
+  end)
+
+  it("should save a clipboard that survives a round-trip through json", function()
+    require("neo-tree").setup({})
+
+    vim.cmd("Neotree")
+    u.wait_for_neo_tree()
+    local state = assert(verify.get_state())
+
+    local topfile = assert(test.fs_tree.lookup["topfile1"])
+    renderer.focus_node(state, topfile.abspath)
+    verify.filesystem_tree_node_is(topfile.abspath)
+
+    local wait = u.changedtick_waiter()
+    u.feedkeys("y")
+    wait()
+
+    -- Only the fields that paste_from_clipboard and the clipboard component
+    -- read are kept, so that the clipboard stays serializable no matter what
+    -- nui puts on its nodes.
+    local node = assert(state.tree:get_node())
+    u.eq(vim.tbl_count(state.clipboard), 1)
+    u.eq(state.clipboard[node:get_id()], {
+      action = "copy",
+      node = {
+        id = node:get_id(),
+        name = "topfile1.txt",
+        path = node:get_id(),
+        type = "file",
+      },
+    })
+
+    local dir = u.fs.create_temp_dir()
+    local writer = assert(UniversalBackend:new({ dir = dir }))
+    local saved, save_err = writer:save(state)
+    assert(saved, save_err)
+
+    -- A separate backend has no cached clipboard, so this reads the file back.
+    local reader = assert(UniversalBackend:new({ dir = dir }))
+    local loaded, load_err = reader:load(state)
+    assert(loaded, load_err)
+    u.eq(loaded, state.clipboard)
+
+    close_handles()
+    u.fs.remove_dir(dir, true)
+  end)
+
+  test.teardown()
+end)


### PR DESCRIPTION
nui.nvim 3d425a7 (`perf(tree): optimize redraw for large amount of nodes`) sets `node._tree = tree` on every node during `initialize_nodes`. neo-tree stores whole nodes on the clipboard, so the universal backend's `vim.json.encode` now walks `node._tree` into the NuiTree and fails. With `clipboard.sync = "universal"` every yank reports `Couldn't encode clipboard into json` and the clipboard is never written.

That commit is only on nui's `main` so far, which is why pinning to 0.4.0 works around it — but 0.5.0 is open (MunifTanjim/nui.nvim#410), so the workaround has a shelf life.

Only four fields are read downstream: `paste_from_clipboard` uses `node.path`, `node.name` and `node.id`, and the clipboard component uses `action`. Nothing else touches `state.clipboard[*].node`. So this keeps just `id`, `name`, `path` and `type` rather than the whole node.

`load()` already returned plain tables from `vim.json.decode` rather than real `NuiTree.Node`s, and that path has always worked — this makes both paths agree, and makes the clipboard immune to whatever nui puts on its nodes next. It also stops the `global` backend from holding a whole tree in memory.

**Behaviour change:** `state.clipboard[id].node` is a plain table rather than a `NuiTree.Node`, so a custom command calling `node:get_id()` on it would break. Given the load path already produced plain tables, I would expect this to be unobserved in practice.

Verified locally on macOS with nui at `10fc361` (which includes 3d425a7): yank, cut and paste all work, cross-instance sync works, and the reported error is gone.

Added `tests/neo-tree/clipboard/universal_spec.lua`. Against `main` it fails because the whole node lands on the clipboard; with this change it passes. Full suite goes from 99 to 100 passing, no failures or errors.

One thing worth flagging separately: the test lives in its own file because `manager._clear_state()` empties `source_data` without clearing `all_states`, so a second test in `sync_spec.lua` hits a nil index in `dispose_state` once the existing `Global` test has opened a tab. That is pre-existing and unrelated to this fix — happy to open a separate issue if that is useful.

Fixes #2080
